### PR TITLE
add more disk specs to the runtimes for Terra

### DIFF
--- a/pipes/WDL/tasks/tasks_assembly.wdl
+++ b/pipes/WDL/tasks/tasks_assembly.wdl
@@ -87,6 +87,7 @@ task assemble {
         docker: "${docker}"
         memory: "15 GB"
         cpu: 4
+        disks: "local-disk 375 LOCAL"
         dx_instance_type: "mem1_ssd1_v2_x8"
     }
 
@@ -175,6 +176,7 @@ task scaffold {
         docker: "${docker}"
         memory: "15 GB"
         cpu: 4
+        disks: "local-disk 375 LOCAL"
         dx_instance_type: "mem1_ssd1_v2_x8"
     }
 }
@@ -226,6 +228,7 @@ task refine {
         docker: "${docker}"
         memory: "7 GB"
         cpu: 8
+        disks: "local-disk 375 LOCAL"
         dx_instance_type: "mem1_ssd1_v2_x8"
     }
 }
@@ -360,6 +363,7 @@ task refine_2x_and_plot {
         docker: "${docker}"
         memory: "7 GB"
         cpu: 8
+        disks: "local-disk 375 LOCAL"
         dx_instance_type: "mem1_ssd1_v2_x8"
     }
 }

--- a/pipes/WDL/tasks/tasks_demux.wdl
+++ b/pipes/WDL/tasks/tasks_demux.wdl
@@ -31,7 +31,7 @@ task merge_tarballs {
     docker: "${docker}"
     memory: "7 GB"
     cpu: 16
-    disks: "900 GB"
+    disks: "local-disk 1125 LOCAL"
     dx_instance_type: "mem1_ssd2_v2_x16"
     preemptible: 0
   }
@@ -217,7 +217,7 @@ task illumina_demux {
     docker: "${docker}"
     memory: "30 GB"
     cpu: 16
-    disks: "900 GB"
+    disks: "local-disk 1125 LOCAL"
     dx_instance_type: "mem1_ssd2_v2_x16"
     preemptible: 0  # this is the very first operation before scatter, so let's get it done quickly & reliably
   }
@@ -256,8 +256,9 @@ task merge_and_reheader_bams {
 
   runtime {
     docker: "${docker}"
-    memory: "2000 MB"
+    memory: "2 GB"
     cpu: 2
+    disks: "local-disk 750 LOCAL"
     dx_instance_type: "mem1_ssd2_v2_x4"
   }
 }

--- a/pipes/WDL/tasks/tasks_metagenomics.wdl
+++ b/pipes/WDL/tasks/tasks_metagenomics.wdl
@@ -69,8 +69,9 @@ task krakenuniq {
 
   runtime {
     docker: "${docker}"
-    memory: "200 GB"
+    memory: "240 GB"
     cpu: 32
+    disks: "local-disk 375 LOCAL"
     dx_instance_type: "mem3_ssd1_v2_x32"
     preemptible: 0
   }
@@ -129,8 +130,8 @@ task build_krakenuniq_db {
 
   runtime {
     docker: "${docker}"
-    memory: "200 GB"
-    disks: "local-disk 350 HDD"
+    memory: "240 GB"
+    disks: "local-disk 375 LOCAL"
     cpu: 32
     dx_instance_type: "mem3_ssd1_v2_x32"
     preemptible: 0
@@ -208,8 +209,9 @@ task kraken {
 
   runtime {
     docker: "${docker}"
-    memory: "200 GB"
+    memory: "240 GB"
     cpu: 32
+    disks: "local-disk 375 HDD"
     dx_instance_type: "mem3_ssd1_v2_x32"
     preemptible: 0
   }
@@ -268,8 +270,8 @@ task build_kraken_db {
 
   runtime {
     docker: "${docker}"
-    memory: "200 GB"
-    disks: "local-disk 350 HDD"
+    memory: "240 GB"
+    disks: "local-disk 375 HDD"
     cpu: 32
     dx_instance_type: "mem3_ssd1_v2_x32"
     preemptible: 0
@@ -325,6 +327,7 @@ task krona {
     docker: "${docker}"
     memory: "4 GB"
     cpu: 1
+    disks: "local-disk 50 SSD"
     dx_instance_type: "mem1_ssd2_v2_x2"
   }
 }
@@ -386,6 +389,7 @@ task filter_bam_to_taxa {
   runtime {
     docker: "${docker}"
     memory: "4 GB"
+    disks: "local-disk 375 LOCAL"
     cpu: 1
     dx_instance_type: "mem1_ssd2_v2_x2"
   }
@@ -458,6 +462,7 @@ task kaiju {
     docker: "${docker}"
     memory: "100 GB"
     cpu: 16
+    disks: "local-disk 375 LOCAL"
     dx_instance_type: "mem3_ssd1_v2_x16"
   }
 }

--- a/pipes/WDL/tasks/tasks_reports.wdl
+++ b/pipes/WDL/tasks/tasks_reports.wdl
@@ -103,6 +103,7 @@ task plot_coverage {
     docker: "${docker}"
     memory: "3500 MB"
     cpu: 4
+    disks: "local-disk 375 LOCAL"
     dx_instance_type: "mem1_ssd1_v2_x8"
   }
 }
@@ -131,6 +132,7 @@ task coverage_report {
     docker: "${docker}"
     memory: "2000 MB"
     cpu: 2
+    disks: "local-disk 375 LOCAL"
     dx_instance_type: "mem1_ssd2_v2_x4"
   }
 }
@@ -156,6 +158,7 @@ task fastqc {
     memory: "2 GB"
     cpu: 1
     docker: "${docker}"
+    disks: "local-disk 375 LOCAL"
     dx_instance_type: "mem1_ssd1_v2_x4"
   }
 }
@@ -198,6 +201,7 @@ task spikein_report {
     memory: "3 GB"
     cpu: 2
     docker: "${docker}"
+    disks: "local-disk 375 LOCAL"
     dx_instance_type: "mem1_ssd1_v2_x4"
   }
 }
@@ -226,6 +230,7 @@ task spikein_summary {
     memory: "3 GB"
     cpu: 2
     docker: "${docker}"
+    disks: "local-disk 50 SSD"
     dx_instance_type: "mem1_ssd1_v2_x4"
   }
 }
@@ -263,6 +268,7 @@ task aggregate_metagenomics_reports {
     docker: "${docker}"
     memory: "4 GB"
     cpu: 1
+    disks: "local-disk 50 SSD"
     dx_instance_type: "mem1_ssd2_v2_x2"
     preemptible: 0
   }

--- a/pipes/WDL/tasks/tasks_taxon_filter.wdl
+++ b/pipes/WDL/tasks/tasks_taxon_filter.wdl
@@ -74,6 +74,7 @@ task deplete_taxa {
     docker: "${docker}"
     memory: "15 GB"
     cpu: 8
+    disks: "local-disk 375 LOCAL"
     dx_instance_type: "mem1_ssd1_v2_x8"
     preemptible: 0
   }
@@ -136,6 +137,7 @@ task filter_to_taxon {
     docker: "${docker}"
     memory: "14 GB"
     cpu: 16
+    disks: "local-disk 375 LOCAL"
     dx_instance_type: "mem1_ssd1_v2_x8"
   }
 }
@@ -161,6 +163,7 @@ task build_lastal_db {
     docker: "${docker}"
     memory: "7 GB"
     cpu: 2
+    disks: "local-disk 375 LOCAL"
     dx_instance_type: "mem1_ssd1_v2_x4"
   }
 }
@@ -205,6 +208,7 @@ task merge_one_per_sample {
     memory: "7 GB"
     cpu: 4
     docker: "${docker}"
+    disks: "local-disk 750 LOCAL"
     dx_instance_type: "mem1_ssd2_v2_x4"
   }
 }


### PR DESCRIPTION
Adding a bunch more `disks` specifics to the runtime specs for WDL tasks. This benefits execution on Terra, where it's running in a Cromwell we don't configure ourselves (our usual Cromwell executions on GCP use a config file that defaults some of this so we don't normally notice these out-of-disk errors). Probably best to make sure the Tasks always ask for what they need anyway. This appears to validate fine on womtool and compile and execute properly on dnanexus.