### PR TITLE
TRS-friendly

### DIFF
--- a/pipes/WDL/workflows/align_and_plot.wdl
+++ b/pipes/WDL/workflows/align_and_plot.wdl
@@ -1,4 +1,4 @@
-import "tasks_reports.wdl" as reports
+import "../tasks/tasks_reports.wdl" as reports
 
 workflow align_and_plot {
     call reports.plot_coverage {

--- a/pipes/WDL/workflows/assemble_denovo.wdl
+++ b/pipes/WDL/workflows/assemble_denovo.wdl
@@ -1,5 +1,5 @@
-import "tasks_taxon_filter.wdl" as taxon_filter
-import "tasks_assembly.wdl" as assembly
+import "../tasks/tasks_taxon_filter.wdl" as taxon_filter
+import "../tasks/tasks_assembly.wdl" as assembly
 
 workflow assemble_denovo {
   

--- a/pipes/WDL/workflows/assemble_denovo_with_deplete.wdl
+++ b/pipes/WDL/workflows/assemble_denovo_with_deplete.wdl
@@ -1,5 +1,5 @@
-import "tasks_taxon_filter.wdl" as taxon_filter
-import "tasks_assembly.wdl" as assembly
+import "../tasks/tasks_taxon_filter.wdl" as taxon_filter
+import "../tasks/tasks_assembly.wdl" as assembly
 
 workflow assemble_denovo_with_deplete {
   

--- a/pipes/WDL/workflows/assemble_denovo_with_deplete_and_isnv_calling.wdl
+++ b/pipes/WDL/workflows/assemble_denovo_with_deplete_and_isnv_calling.wdl
@@ -1,6 +1,6 @@
-import "tasks_taxon_filter.wdl" as taxon_filter
-import "tasks_assembly.wdl" as assembly
-import "tasks_intrahost.wdl" as intrahost
+import "../tasks/tasks_taxon_filter.wdl" as taxon_filter
+import "../tasks/tasks_assembly.wdl" as assembly
+import "../tasks/tasks_intrahost.wdl" as intrahost
 
 workflow assemble_denovo_with_deplete_and_isnv_calling {
   

--- a/pipes/WDL/workflows/assemble_denovo_with_isnv_calling.wdl
+++ b/pipes/WDL/workflows/assemble_denovo_with_isnv_calling.wdl
@@ -1,6 +1,6 @@
-import "tasks_taxon_filter.wdl" as taxon_filter
-import "tasks_assembly.wdl" as assembly
-import "tasks_intrahost.wdl" as intrahost
+import "../tasks/tasks_taxon_filter.wdl" as taxon_filter
+import "../tasks/tasks_assembly.wdl" as assembly
+import "../tasks/tasks_intrahost.wdl" as intrahost
 
 workflow assemble_denovo_with_isnv_calling {
     File reads_unmapped_bam

--- a/pipes/WDL/workflows/assemble_refbased.wdl
+++ b/pipes/WDL/workflows/assemble_refbased.wdl
@@ -1,4 +1,4 @@
-import "tasks_assembly.wdl" as assembly
+import "../tasks/tasks_assembly.wdl" as assembly
 
 workflow assemble_refbased {
   call assembly.refine_2x_and_plot

--- a/pipes/WDL/workflows/classify_kaiju.wdl
+++ b/pipes/WDL/workflows/classify_kaiju.wdl
@@ -1,4 +1,4 @@
-import "tasks_metagenomics.wdl" as metagenomics
+import "../tasks/tasks_metagenomics.wdl" as metagenomics
 
 workflow classify_kaiju {
     call metagenomics.kaiju

--- a/pipes/WDL/workflows/classify_kraken.wdl
+++ b/pipes/WDL/workflows/classify_kraken.wdl
@@ -1,5 +1,5 @@
-import "tasks_metagenomics.wdl" as metagenomics
-import "tasks_reports.wdl" as reports
+import "../tasks/tasks_metagenomics.wdl" as metagenomics
+import "../tasks/tasks_reports.wdl" as reports
 
 workflow classify_kraken {
     call metagenomics.kraken

--- a/pipes/WDL/workflows/classify_krakenuniq.wdl
+++ b/pipes/WDL/workflows/classify_krakenuniq.wdl
@@ -1,5 +1,5 @@
-import "tasks_metagenomics.wdl" as metagenomics
-import "tasks_reports.wdl" as reports
+import "../tasks/tasks_metagenomics.wdl" as metagenomics
+import "../tasks/tasks_reports.wdl" as reports
 
 workflow classify_krakenuniq {
     call metagenomics.krakenuniq

--- a/pipes/WDL/workflows/contigs.wdl
+++ b/pipes/WDL/workflows/contigs.wdl
@@ -1,6 +1,6 @@
-import "tasks_metagenomics.wdl" as metagenomics
-import "tasks_taxon_filter.wdl" as taxon_filter
-import "tasks_assembly.wdl" as assembly
+import "../tasks/tasks_metagenomics.wdl" as metagenomics
+import "../tasks/tasks_taxon_filter.wdl" as taxon_filter
+import "../tasks/tasks_assembly.wdl" as assembly
 
 workflow contigs {
 

--- a/pipes/WDL/workflows/coverage_table.wdl
+++ b/pipes/WDL/workflows/coverage_table.wdl
@@ -1,4 +1,4 @@
-import "tasks_reports.wdl" as reports
+import "../tasks/tasks_reports.wdl" as reports
 
 workflow coverage_table {
     call reports.coverage_report

--- a/pipes/WDL/workflows/demux_metag.wdl
+++ b/pipes/WDL/workflows/demux_metag.wdl
@@ -1,10 +1,10 @@
 #DX_SKIP_WORKFLOW
 
-import "tasks_demux.wdl" as demux
-import "tasks_metagenomics.wdl" as metagenomics
-import "tasks_taxon_filter.wdl" as taxon_filter
-import "tasks_assembly.wdl" as assembly
-import "tasks_reports.wdl" as reports
+import "../tasks/tasks_demux.wdl" as demux
+import "../tasks/tasks_metagenomics.wdl" as metagenomics
+import "../tasks/tasks_taxon_filter.wdl" as taxon_filter
+import "../tasks/tasks_assembly.wdl" as assembly
+import "../tasks/tasks_reports.wdl" as reports
 
 workflow demux_metag {
   call demux.illumina_demux as illumina_demux

--- a/pipes/WDL/workflows/demux_only.wdl
+++ b/pipes/WDL/workflows/demux_only.wdl
@@ -1,4 +1,4 @@
-import "tasks_demux.wdl" as tasks_demux
+import "../tasks/tasks_demux.wdl" as tasks_demux
 
 workflow demux_only {
     call tasks_demux.illumina_demux

--- a/pipes/WDL/workflows/demux_plus.wdl
+++ b/pipes/WDL/workflows/demux_plus.wdl
@@ -1,8 +1,8 @@
-import "tasks_demux.wdl" as demux
-import "tasks_metagenomics.wdl" as metagenomics
-import "tasks_taxon_filter.wdl" as taxon_filter
-import "tasks_assembly.wdl" as assembly
-import "tasks_reports.wdl" as reports
+import "../tasks/tasks_demux.wdl" as demux
+import "../tasks/tasks_metagenomics.wdl" as metagenomics
+import "../tasks/tasks_taxon_filter.wdl" as taxon_filter
+import "../tasks/tasks_assembly.wdl" as assembly
+import "../tasks/tasks_reports.wdl" as reports
 
 workflow demux_plus {
 

--- a/pipes/WDL/workflows/deplete_only.wdl
+++ b/pipes/WDL/workflows/deplete_only.wdl
@@ -1,4 +1,4 @@
-import "tasks_taxon_filter.wdl" as taxon_filter
+import "../tasks/tasks_taxon_filter.wdl" as taxon_filter
 
 workflow deplete_only {
     call taxon_filter.deplete_taxa

--- a/pipes/WDL/workflows/downsample.wdl
+++ b/pipes/WDL/workflows/downsample.wdl
@@ -1,4 +1,4 @@
-import "tasks_read_utils.wdl" as reads
+import "../tasks/tasks_read_utils.wdl" as reads
 
 workflow downsample {
     call reads.downsample_bams

--- a/pipes/WDL/workflows/fetch_annotations.wdl
+++ b/pipes/WDL/workflows/fetch_annotations.wdl
@@ -1,4 +1,4 @@
-import "tasks_ncbi.wdl" as ncbi
+import "../tasks/tasks_ncbi.wdl" as ncbi
 
 workflow fetch_annotations {
     call ncbi.download_annotations

--- a/pipes/WDL/workflows/fetch_sra_to_bam.wdl
+++ b/pipes/WDL/workflows/fetch_sra_to_bam.wdl
@@ -1,6 +1,6 @@
 version 1.0
 
-import "tasks_ncbi_tools.wdl" as ncbi_tools
+import "../tasks/tasks_ncbi_tools.wdl" as ncbi_tools
 
 workflow multi_Fetch_SRA_to_BAM {
     input {

--- a/pipes/WDL/workflows/filter_classified_bam_to_taxa.wdl
+++ b/pipes/WDL/workflows/filter_classified_bam_to_taxa.wdl
@@ -1,4 +1,4 @@
-import "tasks_metagenomics.wdl" as metagenomics
+import "../tasks/tasks_metagenomics.wdl" as metagenomics
 
 workflow filter_classified_bam_to_taxa {
     call metagenomics.filter_bam_to_taxa

--- a/pipes/WDL/workflows/genbank.wdl
+++ b/pipes/WDL/workflows/genbank.wdl
@@ -1,5 +1,5 @@
-import "tasks_interhost.wdl" as interhost
-import "tasks_ncbi.wdl" as ncbi
+import "../tasks/tasks_interhost.wdl" as interhost
+import "../tasks/tasks_ncbi.wdl" as ncbi
 
 workflow genbank {
 

--- a/pipes/WDL/workflows/isnvs_merge_to_vcf.wdl
+++ b/pipes/WDL/workflows/isnvs_merge_to_vcf.wdl
@@ -1,5 +1,5 @@
-import "tasks_interhost.wdl" as interhost
-import "tasks_intrahost.wdl" as tasks_intrahost
+import "../tasks/tasks_interhost.wdl" as interhost
+import "../tasks/tasks_intrahost.wdl" as tasks_intrahost
 
 workflow isnvs_merge_to_vcf {
     File          reference_fasta

--- a/pipes/WDL/workflows/isnvs_one_sample.wdl
+++ b/pipes/WDL/workflows/isnvs_one_sample.wdl
@@ -1,4 +1,4 @@
-import "tasks_intrahost.wdl" as intrahost
+import "../tasks/tasks_intrahost.wdl" as intrahost
 
 workflow isnvs_one_sample {
     call intrahost.isnvs_per_sample

--- a/pipes/WDL/workflows/mafft.wdl
+++ b/pipes/WDL/workflows/mafft.wdl
@@ -1,4 +1,4 @@
-import "tasks_interhost.wdl" as interhost
+import "../tasks/tasks_interhost.wdl" as interhost
 
 workflow mafft {
     call interhost.multi_align_mafft

--- a/pipes/WDL/workflows/merge_bams.wdl
+++ b/pipes/WDL/workflows/merge_bams.wdl
@@ -1,4 +1,4 @@
-import "tasks_demux.wdl" as demux
+import "../tasks/tasks_demux.wdl" as demux
 
 workflow merge_bams {
     call demux.merge_and_reheader_bams

--- a/pipes/WDL/workflows/merge_tar_chunks.wdl
+++ b/pipes/WDL/workflows/merge_tar_chunks.wdl
@@ -1,4 +1,4 @@
-import "tasks_demux.wdl" as demux
+import "../tasks/tasks_demux.wdl" as demux
 
 workflow merge_tar_chunks {
     call demux.merge_tarballs

--- a/pipes/WDL/workflows/multi_sample_assemble_kraken.wdl
+++ b/pipes/WDL/workflows/multi_sample_assemble_kraken.wdl
@@ -1,8 +1,8 @@
-import "tasks_demux.wdl" as demux
-import "tasks_metagenomics.wdl" as metagenomics
-import "tasks_taxon_filter.wdl" as taxon_filter
-import "tasks_assembly.wdl" as assembly
-import "tasks_reports.wdl" as reports
+import "../tasks/tasks_demux.wdl" as demux
+import "../tasks/tasks_metagenomics.wdl" as metagenomics
+import "../tasks/tasks_taxon_filter.wdl" as taxon_filter
+import "../tasks/tasks_assembly.wdl" as assembly
+import "../tasks/tasks_reports.wdl" as reports
 
 workflow multi_sample_assemble_kraken {
 

--- a/pipes/WDL/workflows/scaffold_and_refine.wdl
+++ b/pipes/WDL/workflows/scaffold_and_refine.wdl
@@ -1,4 +1,4 @@
-import "tasks_assembly.wdl" as assembly
+import "../tasks/tasks_assembly.wdl" as assembly
 
 workflow scaffold_and_refine {
     File reads_unmapped_bam

--- a/pipes/WDL/workflows/spikein.wdl
+++ b/pipes/WDL/workflows/spikein.wdl
@@ -1,4 +1,4 @@
-import "tasks_reports.wdl" as reports
+import "../tasks/tasks_reports.wdl" as reports
 
 workflow spikein {
     call reports.spikein_report

--- a/travis/version-wdl-runtimes.sh
+++ b/travis/version-wdl-runtimes.sh
@@ -8,4 +8,6 @@ while IFS='=' read module version; do
 	NEW_TAG="$module:$STRIP_VERSION"
 	echo Replacing $OLD_TAG with $NEW_TAG in all task WDL files
 	sed -i -- "s|$OLD_TAG|$NEW_TAG|g" pipes/WDL/tasks/*.wdl
+	echo Replacing relative paths to same directory
+	sed -i -- 's|import \"../tasks/|import \"|g' pipes/WDL/workflows/*.wdl
 done < $MODULE_VERSIONS


### PR DESCRIPTION
Make the WDL file imports relative to the git repo's directory structure, but then flatten the directory structure for dx build and local cromwell tests on Travis. This is intended to make dockstore's auto import of workflows from this github repo a bit more straightforward.