### PR TITLE
pass novocraft_license file in tasks

### DIFF
--- a/pipes/WDL/tasks/tasks_assembly.wdl
+++ b/pipes/WDL/tasks/tasks_assembly.wdl
@@ -215,6 +215,7 @@ task refine {
           --major_cutoff ${major_cutoff} \
           --novo_params="${novoalign_options}" \
           --JVMmemory "$mem_in_mb"m \
+          ${"--NOVOALIGN_LICENSE_PATH" + novocraft_license} \
           --loglevel=DEBUG
     }
 
@@ -284,6 +285,7 @@ task refine_2x_and_plot {
           --major_cutoff ${refine1_major_cutoff} \
           --novo_params="${refine1_novoalign_options}" \
           --JVMmemory "$mem_in_mb"m \
+          ${"--NOVOALIGN_LICENSE_PATH" + novocraft_license} \
           --loglevel=DEBUG
 
         # refine 2
@@ -295,6 +297,7 @@ task refine_2x_and_plot {
           --min_coverage ${refine2_min_coverage} \
           --major_cutoff ${refine2_major_cutoff} \
           --novo_params="${refine2_novoalign_options}" \
+          ${"--NOVOALIGN_LICENSE_PATH" + novocraft_license} \
           --JVMmemory "$mem_in_mb"m \
           --loglevel=DEBUG
 

--- a/pipes/WDL/tasks/tasks_assembly.wdl
+++ b/pipes/WDL/tasks/tasks_assembly.wdl
@@ -206,7 +206,7 @@ task refine {
         ln -s ${assembly_fasta} assembly.fasta
         read_utils.py novoindex \
         assembly.fasta \
-        ${"--NOVOALIGN_LICENSE_PATH" + novocraft_license} \
+        ${"--NOVOALIGN_LICENSE_PATH=" + novocraft_license} \
         --loglevel=DEBUG
 
         assembly.py refine_assembly \
@@ -218,7 +218,7 @@ task refine {
           --major_cutoff ${major_cutoff} \
           --novo_params="${novoalign_options}" \
           --JVMmemory "$mem_in_mb"m \
-          ${"--NOVOALIGN_LICENSE_PATH" + novocraft_license} \
+          ${"--NOVOALIGN_LICENSE_PATH=" + novocraft_license} \
           --loglevel=DEBUG
     }
 
@@ -278,7 +278,7 @@ task refine_2x_and_plot {
         ln -s ${assembly_fasta} assembly.fasta
         read_utils.py novoindex \
         assembly.fasta \
-        ${"--NOVOALIGN_LICENSE_PATH" + novocraft_license} \
+        ${"--NOVOALIGN_LICENSE_PATH=" + novocraft_license} \
         --loglevel=DEBUG
 
         # refine 1
@@ -291,7 +291,7 @@ task refine_2x_and_plot {
           --major_cutoff ${refine1_major_cutoff} \
           --novo_params="${refine1_novoalign_options}" \
           --JVMmemory "$mem_in_mb"m \
-          ${"--NOVOALIGN_LICENSE_PATH" + novocraft_license} \
+          ${"--NOVOALIGN_LICENSE_PATH=" + novocraft_license} \
           --loglevel=DEBUG
 
         # refine 2
@@ -303,7 +303,7 @@ task refine_2x_and_plot {
           --min_coverage ${refine2_min_coverage} \
           --major_cutoff ${refine2_major_cutoff} \
           --novo_params="${refine2_novoalign_options}" \
-          ${"--NOVOALIGN_LICENSE_PATH" + novocraft_license} \
+          ${"--NOVOALIGN_LICENSE_PATH=" + novocraft_license} \
           --JVMmemory "$mem_in_mb"m \
           --loglevel=DEBUG
 
@@ -315,7 +315,7 @@ task refine_2x_and_plot {
           --outBamFiltered ${sample_name}.mapped.bam \
           --aligner_options "${plot_coverage_novoalign_options}" \
           --JVMmemory "$mem_in_mb"m \
-          ${"--NOVOALIGN_LICENSE_PATH" + novocraft_license} \
+          ${"--NOVOALIGN_LICENSE_PATH=" + novocraft_license} \
           --loglevel=DEBUG
 
         # collect figures of merit

--- a/pipes/WDL/tasks/tasks_assembly.wdl
+++ b/pipes/WDL/tasks/tasks_assembly.wdl
@@ -309,6 +309,7 @@ task refine_2x_and_plot {
           --outBamFiltered ${sample_name}.mapped.bam \
           --aligner_options "${plot_coverage_novoalign_options}" \
           --JVMmemory "$mem_in_mb"m \
+          ${"--NOVOALIGN_LICENSE_PATH" + novocraft_license} \
           --loglevel=DEBUG
 
         # collect figures of merit

--- a/pipes/WDL/tasks/tasks_assembly.wdl
+++ b/pipes/WDL/tasks/tasks_assembly.wdl
@@ -204,7 +204,10 @@ task refine {
         assembly.py --version | tee VERSION
 
         ln -s ${assembly_fasta} assembly.fasta
-        read_utils.py novoindex assembly.fasta --loglevel=DEBUG
+        read_utils.py novoindex \
+        assembly.fasta \
+        ${"--NOVOALIGN_LICENSE_PATH" + novocraft_license} \
+        --loglevel=DEBUG
 
         assembly.py refine_assembly \
           assembly.fasta \
@@ -273,7 +276,10 @@ task refine_2x_and_plot {
         assembly.py --version | tee VERSION
 
         ln -s ${assembly_fasta} assembly.fasta
-        read_utils.py novoindex assembly.fasta --loglevel=DEBUG
+        read_utils.py novoindex \
+        assembly.fasta \
+        ${"--NOVOALIGN_LICENSE_PATH" + novocraft_license} \
+        --loglevel=DEBUG
 
         # refine 1
         assembly.py refine_assembly \

--- a/pipes/WDL/tasks/tasks_interhost.wdl
+++ b/pipes/WDL/tasks/tasks_interhost.wdl
@@ -13,9 +13,9 @@ task multi_align_mafft_ref {
     interhost.py multichr_mafft \
       ${reference_fasta} ${sep=' ' assemblies_fasta} \
       . \
-      ${'--ep' + mafft_ep} \
-      ${'--gapOpeningPenalty' + mafft_gapOpeningPenalty} \
-      ${'--maxiters' + mafft_maxIters} \
+      ${'--ep=' + mafft_ep} \
+      ${'--gapOpeningPenalty=' + mafft_gapOpeningPenalty} \
+      ${'--maxiters=' + mafft_maxIters} \
       --outFilePrefix align_mafft-${fasta_basename} \
       --preservecase \
       --localpair \
@@ -50,9 +50,9 @@ task multi_align_mafft {
     interhost.py multichr_mafft \
       ${sep=' ' assemblies_fasta} \
       . \
-      ${'--ep' + mafft_ep} \
-      ${'--gapOpeningPenalty' + mafft_gapOpeningPenalty} \
-      ${'--maxiters' + mafft_maxIters} \
+      ${'--ep=' + mafft_ep} \
+      ${'--gapOpeningPenalty=' + mafft_gapOpeningPenalty} \
+      ${'--maxiters=' + mafft_maxIters} \
       --outFilePrefix ${out_prefix} \
       --preservecase \
       --localpair \
@@ -83,7 +83,7 @@ task index_ref {
     read_utils.py --version | tee VERSION
     read_utils.py novoindex \
     "${referenceGenome}" \
-    ${"--NOVOALIGN_LICENSE_PATH" + novocraft_license}
+    ${"--NOVOALIGN_LICENSE_PATH=" + novocraft_license}
     
     read_utils.py index_fasta_samtools "${referenceGenome}"
     read_utils.py index_fasta_picard "${referenceGenome}"

--- a/pipes/WDL/tasks/tasks_interhost.wdl
+++ b/pipes/WDL/tasks/tasks_interhost.wdl
@@ -76,11 +76,15 @@ task multi_align_mafft {
 
 task index_ref {
   File     referenceGenome
+  File?    novocraft_license
   String?  docker="quay.io/broadinstitute/viral-core"
 
   command {
     read_utils.py --version | tee VERSION
-    read_utils.py novoindex "${referenceGenome}"
+    read_utils.py novoindex \
+    "${referenceGenome}" \
+    ${"--NOVOALIGN_LICENSE_PATH" + novocraft_license}
+    
     read_utils.py index_fasta_samtools "${referenceGenome}"
     read_utils.py index_fasta_picard "${referenceGenome}"
   }

--- a/pipes/WDL/tasks/tasks_reports.wdl
+++ b/pipes/WDL/tasks/tasks_reports.wdl
@@ -25,7 +25,11 @@ task plot_coverage {
     read_utils.py --version | tee VERSION
 
     cp ${assembly_fasta} assembly.fasta
-    read_utils.py novoindex assembly.fasta --loglevel=DEBUG
+    read_utils.py novoindex \
+    assembly.fasta \
+    ${"--NOVOALIGN_LICENSE_PATH" + novocraft_license} \
+    --loglevel=DEBUG
+    
     read_utils.py index_fasta_picard assembly.fasta --loglevel=DEBUG
     read_utils.py index_fasta_samtools assembly.fasta --loglevel=DEBUG
 

--- a/pipes/WDL/tasks/tasks_reports.wdl
+++ b/pipes/WDL/tasks/tasks_reports.wdl
@@ -38,6 +38,7 @@ task plot_coverage {
       --aligner_options "${aligner_options}" \
       ${true='--skipMarkDupes' false="" skip_mark_dupes} \
       --JVMmemory=3g \
+      ${"--NOVOALIGN_LICENSE_PATH" + novocraft_license} \
       --loglevel=DEBUG
 
     samtools index ${sample_name}.mapped.bam

--- a/pipes/WDL/tasks/tasks_reports.wdl
+++ b/pipes/WDL/tasks/tasks_reports.wdl
@@ -27,7 +27,7 @@ task plot_coverage {
     cp ${assembly_fasta} assembly.fasta
     read_utils.py novoindex \
     assembly.fasta \
-    ${"--NOVOALIGN_LICENSE_PATH" + novocraft_license} \
+    ${"--NOVOALIGN_LICENSE_PATH=" + novocraft_license} \
     --loglevel=DEBUG
     
     read_utils.py index_fasta_picard assembly.fasta --loglevel=DEBUG
@@ -42,7 +42,7 @@ task plot_coverage {
       --aligner_options "${aligner_options}" \
       ${true='--skipMarkDupes' false="" skip_mark_dupes} \
       --JVMmemory=3g \
-      ${"--NOVOALIGN_LICENSE_PATH" + novocraft_license} \
+      ${"--NOVOALIGN_LICENSE_PATH=" + novocraft_license} \
       --loglevel=DEBUG
 
     samtools index ${sample_name}.mapped.bam


### PR DESCRIPTION
pass novocraft_license file through to `refine_assembly`, `align_and_fix`, and `novoindex` calls in WDL tasks so the license file will be copied alongside Novoalign during tool instantiation and allow multithreaded operation