### PR TITLE
reference based assembly pipeline updates

### DIFF
--- a/pipes/WDL/tasks/tasks_assembly.wdl
+++ b/pipes/WDL/tasks/tasks_assembly.wdl
@@ -220,6 +220,7 @@ task refine_assembly_with_aligned_reads {
     File     reads_aligned_bam
     String   sample_name
 
+    File?    novocraft_license
     Boolean? mark_duplicates=false
     Float?   major_cutoff=0.5
     Int?     min_coverage=2
@@ -254,6 +255,7 @@ task refine_assembly_with_aligned_reads {
           --outVcf ${sample_name}.sites.vcf.gz \
           --min_coverage ${min_coverage} \
           --major_cutoff ${major_cutoff} \
+          ${"--NOVOALIGN_LICENSE_PATH=" + novocraft_license} \
           --JVMmemory "$mem_in_mb"m \
           --loglevel=DEBUG
 

--- a/pipes/WDL/tasks/tasks_assembly.wdl
+++ b/pipes/WDL/tasks/tasks_assembly.wdl
@@ -195,10 +195,9 @@ task ivar_trim {
         ivar version | tee VERSION
         if [ -n "${trim_coords_bed}" ]; then
           ivar trim -e -i ${aligned_bam} -b ${trim_coords_bed} -p trim ${'-m ' + min_keep_length}
-
           samtools sort -@ `nproc` -m 1500M -o ${bam_basename}.trimmed.bam trim.bam
         else
-          ln -s ${aligned_bam} ${bam_basename}.trimmed.bam
+          cp ${aligned_bam} ${bam_basename}.trimmed.bam
         fi
     }
 

--- a/pipes/WDL/tasks/tasks_assembly.wdl
+++ b/pipes/WDL/tasks/tasks_assembly.wdl
@@ -243,6 +243,7 @@ task refine_assembly_with_aligned_reads {
         else
           ln -s ${reads_aligned_bam} temp_markdup.bam
         fi
+        samtools index -@ `nproc` temp_markdup.bam temp_markdup.bai
 
         ln -s ${reference_fasta} assembly.fasta
         assembly.py refine_assembly \

--- a/pipes/WDL/tasks/tasks_assembly.wdl
+++ b/pipes/WDL/tasks/tasks_assembly.wdl
@@ -244,6 +244,7 @@ task refine_assembly_with_aligned_reads {
           ln -s ${reads_aligned_bam} temp_markdup.bam
         fi
 
+        ln -s ${reference_fasta} assembly.fasta
         assembly.py refine_assembly \
           assembly.fasta \
           temp_markdup.bam \

--- a/pipes/WDL/tasks/tasks_assembly.wdl
+++ b/pipes/WDL/tasks/tasks_assembly.wdl
@@ -259,10 +259,10 @@ task refine_assembly_with_aligned_reads {
 
         # hacky rename fasta headers
         python - <<SCRIPT
-          import util.file
-          samplename = ${sample_name}
-          with open('refined.fasta', 'rt') as inf:
-            with open('final.fasta', 'wt') as outf:
+import util.file
+samplename = "${sample_name}"
+with open('refined.fasta', 'rt') as inf:
+          with open('final.fasta', 'wt') as outf:
             if util.file.fasta_length('refined.fasta') == 1:
               # case with just one sequence
               inf.readline()
@@ -276,7 +276,7 @@ task refine_assembly_with_aligned_reads {
                 if line.startswith('>'):
                   line = samplename + '-' + str(i) + '\n'
                 outf.write(line)
-        SCRIPT
+SCRIPT
         mv final.fasta ${sample_name}.fasta
     }
 

--- a/pipes/WDL/tasks/tasks_assembly.wdl
+++ b/pipes/WDL/tasks/tasks_assembly.wdl
@@ -184,6 +184,7 @@ task scaffold {
 task ivar_trim {
     File    aligned_bam
     File?   trim_coords_bed
+    Int?    min_keep_length
 
     String? docker="andersenlabapps/ivar"
 
@@ -191,10 +192,11 @@ task ivar_trim {
 
     command {
         set -ex -o pipefail
-        ivar --version | tee VERSION
+        ivar version | tee VERSION
         if [ -n ${trim_coords_bed} ]; then
-          ivar trim -e -i ${aligned_bam} -b ${trim_coords_bed} tmp.bam
-          samtools sort -@ `nproc` -m 1500M -o ${bam_basename}.trimmed.bam tmp.bam
+          ivar trim -e -i ${aligned_bam} -b ${trim_coords_bed} -p trim ${'-m ' + min_keep_length}
+
+          samtools sort -@ `nproc` -m 1500M -o ${bam_basename}.trimmed.bam trim.bam
         else
           ln -s ${aligned_bam} ${bam_basename}.trimmed.bam
         fi
@@ -219,7 +221,7 @@ task refine_assembly_with_aligned_reads {
     File     reads_aligned_bam
     String   sample_name
 
-    Boolean? mark_duplicates=true
+    Boolean? mark_duplicates=false
     Float?   major_cutoff=0.5
     Int?     min_coverage=2
 

--- a/pipes/WDL/tasks/tasks_assembly.wdl
+++ b/pipes/WDL/tasks/tasks_assembly.wdl
@@ -193,7 +193,7 @@ task ivar_trim {
     command {
         set -ex -o pipefail
         ivar version | tee VERSION
-        if [ -n ${trim_coords_bed} ]; then
+        if [ -n "${trim_coords_bed}" ]; then
           ivar trim -e -i ${aligned_bam} -b ${trim_coords_bed} -p trim ${'-m ' + min_keep_length}
 
           samtools sort -@ `nproc` -m 1500M -o ${bam_basename}.trimmed.bam trim.bam

--- a/pipes/WDL/tasks/tasks_assembly.wdl
+++ b/pipes/WDL/tasks/tasks_assembly.wdl
@@ -195,7 +195,7 @@ task ivar_trim {
         if [ -n ${trim_coords_bed} ]; then
           ivar trim -e -i ${aligned_bam} -b ${trim_coords_bed} tmp.bam
           samtools sort -@ `nproc` -m 1500M -o ${bam_basename}.trimmed.bam tmp.bam
-        elif
+        else
           ln -s ${aligned_bam} ${bam_basename}.trimmed.bam
         fi
     }

--- a/pipes/WDL/workflows/assemble_refbased.wdl
+++ b/pipes/WDL/workflows/assemble_refbased.wdl
@@ -5,11 +5,13 @@ workflow assemble_refbased {
 
   File     reference_fasta
   File     reads_unmapped_bam
+  File?    novocraft_license
 
   call reports.plot_coverage as plot_initial {
     input:
         assembly_fasta     = reference_fasta,
-        reads_unmapped_bam = reads_unmapped_bam
+        reads_unmapped_bam = reads_unmapped_bam,
+        novocraft_license  = novocraft_license
   }
 
   call assembly.ivar_trim {
@@ -20,13 +22,15 @@ workflow assemble_refbased {
   call assembly.refine_assembly_with_aligned_reads as polish {
     input:
         reference_fasta   = reference_fasta,
-        reads_aligned_bam = ivar_trim.aligned_trimmed_bam
+        reads_aligned_bam = ivar_trim.aligned_trimmed_bam,
+        novocraft_license  = novocraft_license
   }
 
   call reports.plot_coverage as plot_final {
     input:
         assembly_fasta     = polish.refined_assembly_fasta,
-        reads_unmapped_bam = reads_unmapped_bam
+        reads_unmapped_bam = reads_unmapped_bam,
+        novocraft_license  = novocraft_license
   }
 
 }

--- a/pipes/WDL/workflows/assemble_refbased.wdl
+++ b/pipes/WDL/workflows/assemble_refbased.wdl
@@ -5,7 +5,7 @@ workflow assemble_refbased {
 
   File     assembly_fasta
   File     reads_unmapped_bam
-  
+
   call reports.plot_coverage as plot_initial {
     input:
         assembly_fasta = assembly_fasta,
@@ -20,7 +20,7 @@ workflow assemble_refbased {
   call assembly.refine_assembly_with_aligned_reads {
     input:
         reads_aligned_bam   = plot_initial.aligned_only_reads_bam,
-        aligned_trimmed_bam = assembly.ivar_trim,aligned_trimmed_bam
+        aligned_trimmed_bam = assembly.ivar_trim.aligned_trimmed_bam
   }
 
   call reports.plot_coverage as plot_final {

--- a/pipes/WDL/workflows/assemble_refbased.wdl
+++ b/pipes/WDL/workflows/assemble_refbased.wdl
@@ -17,15 +17,14 @@ workflow assemble_refbased {
         aligned_bam = plot_initial.aligned_only_reads_bam
   }
 
-  call assembly.refine_assembly_with_aligned_reads {
+  call assembly.refine_assembly_with_aligned_reads as polish {
     input:
-        reads_aligned_bam   = plot_initial.aligned_only_reads_bam,
-        aligned_trimmed_bam = assembly.ivar_trim.aligned_trimmed_bam
+        reads_aligned_bam = assembly.ivar_trim.aligned_trimmed_bam
   }
 
   call reports.plot_coverage as plot_final {
     input:
-        assembly_fasta = assembly.refine_assembly_with_aligned_reads.refined_assembly_fasta,
+        assembly_fasta = polish.refined_assembly_fasta,
         reads_unmapped_bam = reads_unmapped_bam
   }
 

--- a/pipes/WDL/workflows/assemble_refbased.wdl
+++ b/pipes/WDL/workflows/assemble_refbased.wdl
@@ -3,12 +3,12 @@ import "../tasks/tasks_reports.wdl" as reports
 
 workflow assemble_refbased {
 
-  File     assembly_fasta
+  File     reference_fasta
   File     reads_unmapped_bam
 
   call reports.plot_coverage as plot_initial {
     input:
-        assembly_fasta     = assembly_fasta,
+        assembly_fasta     = reference_fasta,
         reads_unmapped_bam = reads_unmapped_bam
   }
 
@@ -19,7 +19,7 @@ workflow assemble_refbased {
 
   call assembly.refine_assembly_with_aligned_reads as polish {
     input:
-        reference_fasta   = assembly_fasta,
+        reference_fasta   = reference_fasta,
         reads_aligned_bam = ivar_trim.aligned_trimmed_bam
   }
 

--- a/pipes/WDL/workflows/assemble_refbased.wdl
+++ b/pipes/WDL/workflows/assemble_refbased.wdl
@@ -8,7 +8,7 @@ workflow assemble_refbased {
 
   call reports.plot_coverage as plot_initial {
     input:
-        assembly_fasta = assembly_fasta,
+        assembly_fasta     = assembly_fasta,
         reads_unmapped_bam = reads_unmapped_bam
   }
 
@@ -19,12 +19,13 @@ workflow assemble_refbased {
 
   call assembly.refine_assembly_with_aligned_reads as polish {
     input:
+        reference_fasta   = assembly_fasta,
         reads_aligned_bam = ivar_trim.aligned_trimmed_bam
   }
 
   call reports.plot_coverage as plot_final {
     input:
-        assembly_fasta = polish.refined_assembly_fasta,
+        assembly_fasta     = polish.refined_assembly_fasta,
         reads_unmapped_bam = reads_unmapped_bam
   }
 

--- a/pipes/WDL/workflows/assemble_refbased.wdl
+++ b/pipes/WDL/workflows/assemble_refbased.wdl
@@ -19,7 +19,7 @@ workflow assemble_refbased {
 
   call assembly.refine_assembly_with_aligned_reads as polish {
     input:
-        reads_aligned_bam = assembly.ivar_trim.aligned_trimmed_bam
+        reads_aligned_bam = ivar_trim.aligned_trimmed_bam
   }
 
   call reports.plot_coverage as plot_final {

--- a/pipes/WDL/workflows/assemble_refbased_old.wdl
+++ b/pipes/WDL/workflows/assemble_refbased_old.wdl
@@ -1,5 +1,5 @@
 import "../tasks/tasks_assembly.wdl" as assembly
 
-workflow assemble_refbased {
+workflow assemble_refbased_old {
   call assembly.refine_2x_and_plot
 }

--- a/pipes/WDL/workflows/assemble_refbased_old.wdl
+++ b/pipes/WDL/workflows/assemble_refbased_old.wdl
@@ -1,0 +1,5 @@
+import "../tasks/tasks_assembly.wdl" as assembly
+
+workflow assemble_refbased {
+  call assembly.refine_2x_and_plot
+}

--- a/test/input/WDL/test_inputs-assemble_refbased-local.json
+++ b/test/input/WDL/test_inputs-assemble_refbased-local.json
@@ -1,0 +1,5 @@
+{
+  "assemble_refbased.assembly_fasta": "test/input/ebov-makona.fasta",
+  "assemble_refbased.polish.sample_name": "G5012.3",
+  "assemble_refbased.reads_unmapped_bam": "test/input/G5012.3.testreads.bam"
+}

--- a/test/input/WDL/test_inputs-assemble_refbased-local.json
+++ b/test/input/WDL/test_inputs-assemble_refbased-local.json
@@ -1,5 +1,5 @@
 {
-  "assemble_refbased.assembly_fasta": "test/input/ebov-makona.fasta",
+  "assemble_refbased.reference_fasta": "test/input/ebov-makona.fasta",
   "assemble_refbased.polish.sample_name": "G5012.3",
   "assemble_refbased.reads_unmapped_bam": "test/input/G5012.3.testreads.bam"
 }


### PR DESCRIPTION
We haven't had much development on the reference-based assembly approach since early 2015, but here's a little dusting it off.
1. it's broken out a bit more modularly in WDL, and we only do one round of polish/refine instead of two.
2. we add an [iVar](https://github.com/andersen-lab/ivar) trim WDL step to handle amplicon sequencing primer trimming
3. output assembly sequences are now properly named based on the sample name (instead of the reference scaffold name).
4. travis unit test (on Cromwell with local backend) added for this workflow.

Merging of this PR should await successful demonstration on real data (see [this job](https://platform.dnanexus.com/projects/Fk2gKXQ0GY2Z20FQ6x0p98JV/monitor/analysis/Fp773VQ0GY2q9fKG34Zz2K1Q)).