### PR TITLE
post-ivar samtools sort reduce ram

### DIFF
--- a/pipes/WDL/tasks/tasks_assembly.wdl
+++ b/pipes/WDL/tasks/tasks_assembly.wdl
@@ -195,7 +195,7 @@ task ivar_trim {
         ivar version | tee VERSION
         if [ -n "${trim_coords_bed}" ]; then
           ivar trim -e -i ${aligned_bam} -b ${trim_coords_bed} -p trim ${'-m ' + min_keep_length}
-          samtools sort -@ `nproc` -m 1500M -o ${bam_basename}.trimmed.bam trim.bam
+          samtools sort -@ `nproc` -m 1000M -o ${bam_basename}.trimmed.bam trim.bam
         else
           cp ${aligned_bam} ${bam_basename}.trimmed.bam
         fi


### PR DESCRIPTION
the ivar WDL task sometimes fails because I think we're using almost exactly as much ram as the VM has -- ask for a little less so that it more reliably succeeds