### PR TITLE
refbased novoalign params

### DIFF
--- a/pipes/WDL/workflows/assemble_refbased.wdl
+++ b/pipes/WDL/workflows/assemble_refbased.wdl
@@ -36,7 +36,8 @@ workflow assemble_refbased {
         assembly_fasta     = call_consensus.refined_assembly_fasta,
         reads_unmapped_bam = reads_unmapped_bam,
         novocraft_license  = novocraft_license,
-        skip_mark_dupes    = skip_mark_dupes
+        skip_mark_dupes    = skip_mark_dupes,
+        aligner_options    = "-r Random -l 40 -g 40 -x 20 -t 100"
   }
 
 }


### PR DESCRIPTION
This PR restores novoalign options/parameters we used to have for the second pass (align to self), taken from the 2nd refine_assembly alignment params. Historically, we've never run novoalign without parameters like this before, perhaps this will address some cryptic crashes we've seen without it.