### PR TITLE
add run size detection based on tile count for NovaSeq SP

### DIFF
--- a/pipes/WDL/tasks/tasks_demux.wdl
+++ b/pipes/WDL/tasks/tasks_demux.wdl
@@ -144,8 +144,8 @@ task illumina_demux {
     elif [ "$total_tile_count" -le 1408 ]; then
         demux_threads=32 # with NovaSeq-size output, OOM errors can sporadically occur with higher thread counts
         mem_in_mb=$(/opt/viral-ngs/source/docker/calc_mem.py mb 80)
-        max_reads_in_ram_per_tile=1200000 # reduce the number of reads per tile since the NovaSeq has so many
-        max_records_in_ram=3000000
+        max_reads_in_ram_per_tile=600000 # reduce the number of reads per tile since the NovaSeq has so many
+        max_records_in_ram=2000000
         echo "Detected $total_tile_count tiles, interpreting as NovaSeq run."
         echo "  **Note: Q20 threshold used since NovaSeq with RTA3 writes only four Q-score values: 2, 12, 23, and 37.**"
         echo "    See: https://www.illumina.com/content/dam/illumina-marketing/documents/products/appnotes/novaseq-hiseq-q30-app-note-770-2017-010.pdf"

--- a/pipes/WDL/tasks/tasks_demux.wdl
+++ b/pipes/WDL/tasks/tasks_demux.wdl
@@ -134,6 +134,10 @@ task illumina_demux {
         max_records_in_ram=2500000
         echo "Detected $total_tile_count tiles, interpreting as NextSeq (high-output) run."
     elif [ "$total_tile_count" -le 624 ]; then
+        demux_threads=32 # with NovaSeq-size output, OOM errors can sporadically occur with higher thread counts
+        mem_in_mb=$(/opt/viral-ngs/source/docker/calc_mem.py mb 80)
+        max_reads_in_ram_per_tile=1200000 # reduce the number of reads per tile since the NovaSeq has so many
+        max_records_in_ram=3000000
         echo "Detected $total_tile_count tiles, interpreting as NovaSeq SP run."
     elif [ "$total_tile_count" -le 896 ]; then
         echo "Detected $total_tile_count tiles, interpreting as HiSeq4k run."

--- a/pipes/WDL/tasks/tasks_demux.wdl
+++ b/pipes/WDL/tasks/tasks_demux.wdl
@@ -150,9 +150,10 @@ task illumina_demux {
         echo "  **Note: Q20 threshold used since NovaSeq with RTA3 writes only four Q-score values: 2, 12, 23, and 37.**"
         echo "    See: https://www.illumina.com/content/dam/illumina-marketing/documents/products/appnotes/novaseq-hiseq-q30-app-note-770-2017-010.pdf"
     elif [ "$total_tile_count" -gt 1408 ]; then
-        demux_threads=32 # with NovaSeq-size output, OOM errors can sporadically occur with higher thread counts
-        max_reads_in_ram_per_tile=1200000 # reduce the number of reads per tile since the NovaSeq has so many
-        max_records_in_ram=3000000
+        demux_threads=30 # with NovaSeq-size output, OOM errors can sporadically occur with higher thread counts
+        mem_in_mb=$(/opt/viral-ngs/source/docker/calc_mem.py mb 80)
+        max_reads_in_ram_per_tile=600000 # reduce the number of reads per tile since the NovaSeq has so many
+        max_records_in_ram=2000000
         echo "Tile count: $total_tile_count tiles (unknown instrument type)."
     fi
 

--- a/pipes/WDL/tasks/tasks_demux.wdl
+++ b/pipes/WDL/tasks/tasks_demux.wdl
@@ -133,6 +133,8 @@ task illumina_demux {
         max_reads_in_ram_per_tile=1500000 # reduce the number of reads per tile since the NovaSeq has so many
         max_records_in_ram=2500000
         echo "Detected $total_tile_count tiles, interpreting as NextSeq (high-output) run."
+    elif [ "$total_tile_count" -le 624 ]; then
+        echo "Detected $total_tile_count tiles, interpreting as NovaSeq SP run."
     elif [ "$total_tile_count" -le 896 ]; then
         echo "Detected $total_tile_count tiles, interpreting as HiSeq4k run."
     elif [ "$total_tile_count" -le 1408 ]; then

--- a/pipes/WDL/tasks/tasks_demux.wdl
+++ b/pipes/WDL/tasks/tasks_demux.wdl
@@ -126,6 +126,12 @@ task illumina_demux {
         max_reads_in_ram_per_tile=1500000
         max_records_in_ram=2000000
         echo "Detected $total_tile_count tiles, interpreting as NextSeq (mid-output) run."
+    elif [ "$total_tile_count" -le 624 ]; then
+        demux_threads=32 # with NovaSeq-size output, OOM errors can sporadically occur with higher thread counts
+        mem_in_mb=$(/opt/viral-ngs/source/docker/calc_mem.py mb 80)
+        max_reads_in_ram_per_tile=600000 # reduce the number of reads per tile since the NovaSeq has so many
+        max_records_in_ram=2000000
+        echo "Detected $total_tile_count tiles, interpreting as NovaSeq SP run."
     elif [ "$total_tile_count" -le 864 ]; then
         # increase the number of reads in ram per-tile for NextSeq, since the tiles are larger
         # without this setting, reads will spill to disk and may read the limit
@@ -133,12 +139,6 @@ task illumina_demux {
         max_reads_in_ram_per_tile=1500000 # reduce the number of reads per tile since the NovaSeq has so many
         max_records_in_ram=2500000
         echo "Detected $total_tile_count tiles, interpreting as NextSeq (high-output) run."
-    elif [ "$total_tile_count" -le 624 ]; then
-        demux_threads=32 # with NovaSeq-size output, OOM errors can sporadically occur with higher thread counts
-        mem_in_mb=$(/opt/viral-ngs/source/docker/calc_mem.py mb 80)
-        max_reads_in_ram_per_tile=1200000 # reduce the number of reads per tile since the NovaSeq has so many
-        max_records_in_ram=3000000
-        echo "Detected $total_tile_count tiles, interpreting as NovaSeq SP run."
     elif [ "$total_tile_count" -le 896 ]; then
         echo "Detected $total_tile_count tiles, interpreting as HiSeq4k run."
     elif [ "$total_tile_count" -le 1408 ]; then

--- a/pipes/dnax/dx-launcher/demux_launcher.yml
+++ b/pipes/dnax/dx-launcher/demux_launcher.yml
@@ -116,9 +116,13 @@ runSpec:
           tar_consolidation_instance_size="mem1_ssd2_x16"
           demux_instance_type="mem1_ssd1_x32"
           echo "Detected $total_tile_count tiles, interpreting as NextSeq (high-output) run."
+      elif [ "$total_tile_count" -le 624 ]; then
+          tar_consolidation_instance_size="mem1_ssd1_x32"
+          demux_instance_type="mem3_ssd1_x32"
+          echo "Detected $total_tile_count tiles, interpreting as NovaSeq SP run, executing on a $demux_instance_type machine."
       elif [ "$total_tile_count" -le 896 ]; then
           tar_consolidation_instance_size="mem1_ssd1_x32"
-          demux_instance_type="mem1_ssd1_x32"
+          demux_instance_type="mem3_ssd1_x32"
           echo "Detected $total_tile_count tiles, interpreting as HiSeq4k run, executing on a $demux_instance_type machine."
       elif [ "$total_tile_count" -le 1408 ]; then
           tar_consolidation_instance_size="mem1_ssd2_x36"

--- a/pipes/dnax/dx-launcher/demux_launcher.yml
+++ b/pipes/dnax/dx-launcher/demux_launcher.yml
@@ -112,14 +112,14 @@ runSpec:
           tar_consolidation_instance_size="mem1_ssd2_x4"
           demux_instance_type="mem1_ssd1_x32"
           echo "Detected $total_tile_count tiles, interpreting as NextSeq (mid-output) run."
-      elif [ "$total_tile_count" -le 864 ]; then
-          tar_consolidation_instance_size="mem1_ssd2_x16"
-          demux_instance_type="mem1_ssd1_x32"
-          echo "Detected $total_tile_count tiles, interpreting as NextSeq (high-output) run."
       elif [ "$total_tile_count" -le 624 ]; then
           tar_consolidation_instance_size="mem1_ssd1_x32"
           demux_instance_type="mem3_ssd1_x32"
           echo "Detected $total_tile_count tiles, interpreting as NovaSeq SP run, executing on a $demux_instance_type machine."
+      elif [ "$total_tile_count" -le 864 ]; then
+          tar_consolidation_instance_size="mem1_ssd2_x16"
+          demux_instance_type="mem1_ssd1_x32"
+          echo "Detected $total_tile_count tiles, interpreting as NextSeq (high-output) run."
       elif [ "$total_tile_count" -le 896 ]; then
           tar_consolidation_instance_size="mem1_ssd1_x32"
           demux_instance_type="mem3_ssd1_x32"


### PR DESCRIPTION
add run size detection based on tile count for NovaSeq SP, which has 624 tiles and requires a rather large instance