### PR TITLE
refbased assembly improvements

### DIFF
--- a/pipes/WDL/tasks/tasks_assembly.wdl
+++ b/pipes/WDL/tasks/tasks_assembly.wdl
@@ -185,6 +185,8 @@ task ivar_trim {
     File    aligned_bam
     File?   trim_coords_bed
     Int?    min_keep_length
+    Int?    sliding_window
+    Int?    min_quality
 
     String? docker="andersenlabapps/ivar"
 
@@ -193,8 +195,14 @@ task ivar_trim {
     command {
         set -ex -o pipefail
         ivar version | tee VERSION
+
         if [ -n "${trim_coords_bed}" ]; then
-          ivar trim -e -i ${aligned_bam} -b ${trim_coords_bed} -p trim ${'-m ' + min_keep_length}
+          ivar trim -e \
+            ${'-b ' + trim_coords_bed} \
+            ${'-m ' + min_keep_length} \
+            ${'-s ' + sliding_window} \
+            ${'-q ' + min_quality} \
+            -i ${aligned_bam} -p trim
           samtools sort -@ `nproc` -m 1000M -o ${bam_basename}.trimmed.bam trim.bam
         else
           cp ${aligned_bam} ${bam_basename}.trimmed.bam

--- a/pipes/WDL/tasks/tasks_assembly.wdl
+++ b/pipes/WDL/tasks/tasks_assembly.wdl
@@ -194,7 +194,7 @@ task ivar_trim {
 
     command {
         set -ex -o pipefail
-        ivar version | tee VERSION
+        ivar version | head -1 | tee VERSION
 
         if [ -n "${trim_coords_bed}" ]; then
           ivar trim -e \

--- a/pipes/WDL/tasks/tasks_assembly.wdl
+++ b/pipes/WDL/tasks/tasks_assembly.wdl
@@ -259,27 +259,8 @@ task refine_assembly_with_aligned_reads {
           --JVMmemory "$mem_in_mb"m \
           --loglevel=DEBUG
 
-        # hacky rename fasta headers
-        python - <<SCRIPT
-import util.file
-samplename = "${sample_name}"
-with open('refined.fasta', 'rt') as inf:
-          with open('final.fasta', 'wt') as outf:
-            if util.file.fasta_length('refined.fasta') == 1:
-              # case with just one sequence
-              inf.readline()
-              outf.write('>' + samplename + '\n')
-              for line in inf:
-                outf.write(line)
-            else:
-              # case with multiple sequences
-              i = 1
-              for line in inf:
-                if line.startswith('>'):
-                  line = samplename + '-' + str(i) + '\n'
-                outf.write(line)
-SCRIPT
-        mv final.fasta ${sample_name}.fasta
+        file_utils.py rename_fasta_sequences \
+          refined.fasta "${sample_name}.fasta" "${sample_name}"
     }
 
     output {

--- a/pipes/WDL/tasks/tasks_reports.wdl
+++ b/pipes/WDL/tasks/tasks_reports.wdl
@@ -2,6 +2,7 @@
 task plot_coverage {
   File     assembly_fasta
   File     reads_unmapped_bam
+  String   sample_name
 
   File?    novocraft_license
 
@@ -15,8 +16,6 @@ task plot_coverage {
 
   String?  docker="quay.io/broadinstitute/viral-core"
   
-  String   sample_name = basename(basename(basename(reads_unmapped_bam, ".bam"), ".taxfilt"), ".clean")
-
   command {
     set -ex -o pipefail
 

--- a/pipes/WDL/tasks/tasks_reports.wdl
+++ b/pipes/WDL/tasks/tasks_reports.wdl
@@ -22,32 +22,41 @@ task plot_coverage {
     read_utils.py --version | tee VERSION
 
     cp ${assembly_fasta} assembly.fasta
-    if [ "${aligner}" == "novoalign" ]; then
-      read_utils.py novoindex \
+    grep -v '^>' assembly.fasta | tr -d '\n' | wc -c | tee assembly_length
+
+    if [ `cat assembly_length` != "0" ]; then
+
+      # only perform the following if the reference is non-empty
+
+      if [ "${aligner}" == "novoalign" ]; then
+        read_utils.py novoindex \
+          assembly.fasta \
+          ${"--NOVOALIGN_LICENSE_PATH=" + novocraft_license} \
+          --loglevel=DEBUG
+      fi
+      read_utils.py index_fasta_picard assembly.fasta --loglevel=DEBUG
+      read_utils.py index_fasta_samtools assembly.fasta --loglevel=DEBUG
+
+      read_utils.py align_and_fix \
+        ${reads_unmapped_bam} \
         assembly.fasta \
+        --outBamAll "${sample_name}.all.bam" \
+        --outBamFiltered "${sample_name}.mapped.bam" \
+        --aligner ${aligner} \
+        ${'--aligner_options "' + aligner_options + '"'} \
+        ${true='--skipMarkDupes' false="" skip_mark_dupes} \
+        --JVMmemory=3g \
         ${"--NOVOALIGN_LICENSE_PATH=" + novocraft_license} \
         --loglevel=DEBUG
+
+    else
+      touch "${sample_name}.all.bam" "${sample_name}.mapped.bam"
+
     fi
-    read_utils.py index_fasta_picard assembly.fasta --loglevel=DEBUG
-    read_utils.py index_fasta_samtools assembly.fasta --loglevel=DEBUG
-
-    read_utils.py align_and_fix \
-      ${reads_unmapped_bam} \
-      assembly.fasta \
-      --outBamAll ${sample_name}.all.bam \
-      --outBamFiltered ${sample_name}.mapped.bam \
-      --aligner ${aligner} \
-      ${'--aligner_options "' + aligner_options + '"'} \
-      ${true='--skipMarkDupes' false="" skip_mark_dupes} \
-      --JVMmemory=3g \
-      ${"--NOVOALIGN_LICENSE_PATH=" + novocraft_license} \
-      --loglevel=DEBUG
-
-    samtools index ${sample_name}.mapped.bam
 
     # collect figures of merit
-    grep -v '^>' assembly.fasta | tr -d '\n' | wc -c | tee assembly_length
     grep -v '^>' assembly.fasta | tr -d '\nNn' | wc -c | tee assembly_length_unambiguous
+    samtools view -c ${reads_unmapped_bam} | tee reads_provided
     samtools view -c ${sample_name}.mapped.bam | tee reads_aligned
     # report only primary alignments 260=exclude unaligned reads and secondary mappings
     samtools view -h -F 260 ${sample_name}.all.bam | samtools flagstat - | tee ${sample_name}.all.bam.flagstat.txt
@@ -55,6 +64,11 @@ task plot_coverage {
     samtools view ${sample_name}.mapped.bam | cut -f10 | tr -d '\n' | wc -c | tee bases_aligned
     #echo $(( $(cat bases_aligned) / $(cat assembly_length) )) | tee mean_coverage
     python -c "print (float("`cat bases_aligned`")/"`cat assembly_length`") if "`cat assembly_length`">0 else 0" > mean_coverage
+
+    # index mapped bam if non-empty
+    if [ `cat reads_aligned` != "0" ]; then
+      samtools index ${sample_name}.mapped.bam
+    fi
 
     # fastqc mapped bam
     reports.py fastqc ${sample_name}.mapped.bam ${sample_name}.mapped_fastqc.html --out_zip ${sample_name}.mapped_fastqc.zip
@@ -96,6 +110,7 @@ task plot_coverage {
     File   coverage_plot                 = "${sample_name}.coverage_plot.pdf"
     Int    assembly_length               = read_int("assembly_length")
     Int    assembly_length_unambiguous   = read_int("assembly_length_unambiguous")
+    Int    reads_provided                = read_int("reads_provided")
     Int    reads_aligned                 = read_int("reads_aligned")
     Int    read_pairs_aligned            = read_int("read_pairs_aligned")
     Int    bases_aligned                 = read_int("bases_aligned")

--- a/pipes/WDL/workflows/align_and_plot.wdl
+++ b/pipes/WDL/workflows/align_and_plot.wdl
@@ -1,8 +1,11 @@
 import "../tasks/tasks_reports.wdl" as reports
 
 workflow align_and_plot {
+    String  reads_unmapped_bam
     call reports.plot_coverage {
         input:
-            aligner_options = "-r Random -l 30 -g 40 -x 20 -t 502"
+            reads_unmapped_bam = reads_unmapped_bam,
+            aligner_options = "-r Random -l 30 -g 40 -x 20 -t 502",
+            sample_name = basename(basename(basename(reads_unmapped_bam, ".bam"), ".taxfilt"), ".clean")
     }
 }

--- a/pipes/WDL/workflows/assemble_refbased.wdl
+++ b/pipes/WDL/workflows/assemble_refbased.wdl
@@ -8,7 +8,7 @@ workflow assemble_refbased {
   File?    novocraft_license
   Boolean? skip_mark_dupes=false
 
-  String?  sample_name = basename(basename(basename(reads_unmapped_bam, ".bam"), ".taxfilt"), ".clean")
+  String   sample_name = basename(basename(basename(reads_unmapped_bam, ".bam"), ".taxfilt"), ".clean")
 
   call reports.plot_coverage as align_to_ref {
     input:

--- a/pipes/WDL/workflows/assemble_refbased.wdl
+++ b/pipes/WDL/workflows/assemble_refbased.wdl
@@ -8,12 +8,15 @@ workflow assemble_refbased {
   File?    novocraft_license
   Boolean? skip_mark_dupes=false
 
+  String?  sample_name = basename(basename(basename(reads_unmapped_bam, ".bam"), ".taxfilt"), ".clean")
+
   call reports.plot_coverage as align_to_ref {
     input:
         assembly_fasta     = reference_fasta,
         reads_unmapped_bam = reads_unmapped_bam,
         novocraft_license  = novocraft_license,
         skip_mark_dupes    = skip_mark_dupes,
+        sample_name        = "${sample_name}.align_to_ref",
         aligner_options    = "-r Random -l 40 -g 40 -x 20 -t 501 -k"
         ## (for bwa) -- aligner_options = "-k 12 -B 1"
         ## (for novoalign) -- aligner_options = "-r Random -l 40 -g 40 -x 20 -t 501 -k"
@@ -28,7 +31,8 @@ workflow assemble_refbased {
     input:
         reference_fasta   = reference_fasta,
         reads_aligned_bam = ivar_trim.aligned_trimmed_bam,
-        novocraft_license  = novocraft_license
+        sample_name       = sample_name,
+        novocraft_license = novocraft_license
   }
 
   call reports.plot_coverage as align_to_self {
@@ -37,6 +41,7 @@ workflow assemble_refbased {
         reads_unmapped_bam = reads_unmapped_bam,
         novocraft_license  = novocraft_license,
         skip_mark_dupes    = skip_mark_dupes,
+        sample_name        = "${sample_name}.align_to_self",
         aligner_options    = "-r Random -l 40 -g 40 -x 20 -t 100"
   }
 

--- a/pipes/dnax/dx-defaults-assemble_denovo_with_deplete.json
+++ b/pipes/dnax/dx-defaults-assemble_denovo_with_deplete.json
@@ -4,9 +4,7 @@
   ],
   "assemble_denovo_with_deplete.deplete_taxa.blastDbs": [
     "dx://file-Fg2p9Zj0xf5VyJ380GxkBg0k",
-    "dx://file-F8BjgXj09y3gkfZGPPQZbZkK",
-    "dx://file-Fg2p9b80xf5y05Vg0GJb12vY",
-    "dx://file-Fg2p9bQ0xf5zx8VB8BYyJj0k"
+    "dx://file-F8BjgXj09y3gkfZGPPQZbZkK"
   ],
 
   "assemble_denovo_with_deplete.assemble.trim_clip_db":

--- a/pipes/dnax/dx-defaults-assemble_denovo_with_deplete_and_isnv_calling.json
+++ b/pipes/dnax/dx-defaults-assemble_denovo_with_deplete_and_isnv_calling.json
@@ -4,9 +4,7 @@
   ],
   "assemble_denovo_with_deplete_and_isnv_calling.deplete_taxa.blastDbs": [
     "dx://file-Fg2p9Zj0xf5VyJ380GxkBg0k",
-    "dx://file-F8BjgXj09y3gkfZGPPQZbZkK",
-    "dx://file-Fg2p9b80xf5y05Vg0GJb12vY",
-    "dx://file-Fg2p9bQ0xf5zx8VB8BYyJj0k"
+    "dx://file-F8BjgXj09y3gkfZGPPQZbZkK"
   ],
 
   "assemble_denovo_with_deplete_and_isnv_calling.assemble.trim_clip_db":

--- a/pipes/dnax/dx-defaults-contigs.json
+++ b/pipes/dnax/dx-defaults-contigs.json
@@ -4,9 +4,7 @@
   ],
   "contigs.deplete.blastDbs": [
     "dx://file-Fg2p9Zj0xf5VyJ380GxkBg0k",
-    "dx://file-F8BjgXj09y3gkfZGPPQZbZkK",
-    "dx://file-Fg2p9b80xf5y05Vg0GJb12vY",
-    "dx://file-Fg2p9bQ0xf5zx8VB8BYyJj0k"
+    "dx://file-F8BjgXj09y3gkfZGPPQZbZkK"
   ],
 
   "contigs.spades.trim_clip_db":

--- a/pipes/dnax/dx-defaults-demux_plus.json
+++ b/pipes/dnax/dx-defaults-demux_plus.json
@@ -7,9 +7,7 @@
   ],
   "demux_plus.blastDbs": [
     "dx://file-Fg2p9Zj0xf5VyJ380GxkBg0k",
-    "dx://file-F8BjgXj09y3gkfZGPPQZbZkK",
-    "dx://file-Fg2p9b80xf5y05Vg0GJb12vY",
-    "dx://file-Fg2p9bQ0xf5zx8VB8BYyJj0k"
+    "dx://file-F8BjgXj09y3gkfZGPPQZbZkK"
   ],
 
   "demux_plus.trim_clip_db":

--- a/pipes/dnax/dx-defaults-deplete_only.json
+++ b/pipes/dnax/dx-defaults-deplete_only.json
@@ -4,8 +4,6 @@
   ],
   "deplete_only.deplete_taxa.blastDbs": [
     "dx://file-Fg2p9Zj0xf5VyJ380GxkBg0k",
-    "dx://file-F8BjgXj09y3gkfZGPPQZbZkK",
-    "dx://file-Fg2p9b80xf5y05Vg0GJb12vY",
-    "dx://file-Fg2p9bQ0xf5zx8VB8BYyJj0k"
+    "dx://file-F8BjgXj09y3gkfZGPPQZbZkK"
   ]
 }

--- a/requirements-modules.txt
+++ b/requirements-modules.txt
@@ -1,4 +1,4 @@
-broadinstitute/viral-core=v2.0.16
-broadinstitute/viral-assemble=v2.0.16.0
+broadinstitute/viral-core=v2.0.17
+broadinstitute/viral-assemble=v2.0.17.0
 broadinstitute/viral-classify=v2.0.16.0
 broadinstitute/viral-phylo=v2.0.16.0


### PR DESCRIPTION
Some improvements mostly around usability / cleanliness / user options. This addresses much in #28 but not quite all of it.

Here we:
- expose additional ivar options
- move fasta header renaming into viral-core method
- keep both invocations of reports.plot_coverage outputting to separate filenames when run in an environment (e.g. DNAnexus) where all tasks output into the same directory
- add another Int output to the tasks that reports on the number of starting reads in the bam
- defensive code around empty fastas and empty bams
- bump viral-assemble to 2.0.17

Also (kind of unrelated, sorry):
- drop metagenomics contaminants from default depletion inputs on dnanexus