### PR TITLE
add bams_multiqc workflow

### DIFF
--- a/pipes/WDL/workflows/bams_multiqc.wdl
+++ b/pipes/WDL/workflows/bams_multiqc.wdl
@@ -1,0 +1,18 @@
+import "../tasks/tasks_reports.wdl" as reports
+
+workflow bams_multiqc {
+    Array[File]+  read_bams
+
+    scatter(reads_bam in read_bams) {
+        call reports.fastqc as fastqc {
+            input:
+                reads_bam = reads_bam
+        }
+    }
+
+    call reports.MultiQC {
+        input:
+            input_files = fastqc.fastqc_zip
+    }
+
+}


### PR DESCRIPTION
add `bams_multiqc` workflow to create a multiqc report from multiple input bam files (creating fastqc reports during an intermediate step)