### PR TITLE
refbased assembly updates

### DIFF
--- a/pipes/WDL/tasks/tasks_assembly.wdl
+++ b/pipes/WDL/tasks/tasks_assembly.wdl
@@ -242,7 +242,7 @@ task align_reads {
 
     read_utils.py --version | tee VERSION
 
-    cp ${assembly_fasta} assembly.fasta
+    cp ${reference_fasta} assembly.fasta
     grep -v '^>' assembly.fasta | tr -d '\n' | wc -c | tee assembly_length
 
     if [ `cat assembly_length` != "0" ]; then

--- a/pipes/WDL/tasks/tasks_assembly.wdl
+++ b/pipes/WDL/tasks/tasks_assembly.wdl
@@ -326,7 +326,6 @@ task refine_assembly_with_aligned_reads {
     File     reads_aligned_bam
     String   sample_name
 
-    File?    novocraft_license
     Boolean? mark_duplicates=false
     Float?   major_cutoff=0.5
     Int?     min_coverage=2
@@ -361,7 +360,6 @@ task refine_assembly_with_aligned_reads {
           --outVcf ${sample_name}.sites.vcf.gz \
           --min_coverage ${min_coverage} \
           --major_cutoff ${major_cutoff} \
-          ${"--NOVOALIGN_LICENSE_PATH=" + novocraft_license} \
           --JVMmemory "$mem_in_mb"m \
           --loglevel=DEBUG
 

--- a/pipes/WDL/tasks/tasks_assembly.wdl
+++ b/pipes/WDL/tasks/tasks_assembly.wdl
@@ -314,10 +314,11 @@ task align_reads {
 
   runtime {
     docker: "${docker}"
-    memory: "3500 MB"
-    cpu: 4
+    memory: "7000 MB"
+    cpu: 8
     disks: "local-disk 375 LOCAL"
     dx_instance_type: "mem1_ssd1_v2_x8"
+    preemptible: 1
   }
 }
 
@@ -545,6 +546,7 @@ task refine_2x_and_plot {
           reports.py plot_coverage \
             ${sample_name}.mapped.bam \
             ${sample_name}.coverage_plot.pdf \
+            --outSummary "${sample_name}.coverage_plot.txt" \
             --plotFormat pdf \
             --plotWidth 1100 \
             --plotHeight 850 \
@@ -552,7 +554,7 @@ task refine_2x_and_plot {
             --plotTitle "${sample_name} coverage plot" \
             --loglevel=DEBUG
         else
-          touch ${sample_name}.coverage_plot.pdf
+          touch ${sample_name}.coverage_plot.pdf ${sample_name}.coverage_plot.txt
         fi
     }
 
@@ -569,6 +571,7 @@ task refine_2x_and_plot {
         File aligned_only_reads_fastqc     = "${sample_name}.mapped_fastqc.html"
         File aligned_only_reads_fastqc_zip = "${sample_name}.mapped_fastqc.zip"
         File coverage_plot                 = "${sample_name}.coverage_plot.pdf"
+        File coverage_tsv                  = "${sample_name}.coverage_plot.txt"
         Int  assembly_length               = read_int("assembly_length")
         Int  assembly_length_unambiguous   = read_int("assembly_length_unambiguous")
         Int  reads_aligned                 = read_int("reads_aligned")

--- a/pipes/WDL/tasks/tasks_assembly.wdl
+++ b/pipes/WDL/tasks/tasks_assembly.wdl
@@ -223,6 +223,104 @@ task ivar_trim {
     }
 }
 
+task align_reads {
+  File     reference_fasta
+  File     reads_unmapped_bam
+
+  File?    novocraft_license
+
+  String?  aligner="novoalign" # novoalign or bwa
+  String?  aligner_options
+  Boolean? skip_mark_dupes=false
+
+  String?  docker="quay.io/broadinstitute/viral-core"
+
+  String   sample_name = basename(basename(basename(reads_unmapped_bam, ".bam"), ".taxfilt"), ".clean")
+  
+  command {
+    set -ex -o pipefail
+
+    read_utils.py --version | tee VERSION
+
+    cp ${assembly_fasta} assembly.fasta
+    grep -v '^>' assembly.fasta | tr -d '\n' | wc -c | tee assembly_length
+
+    if [ `cat assembly_length` != "0" ]; then
+
+      # only perform the following if the reference is non-empty
+
+      if [ "${aligner}" == "novoalign" ]; then
+        read_utils.py novoindex \
+          assembly.fasta \
+          ${"--NOVOALIGN_LICENSE_PATH=" + novocraft_license} \
+          --loglevel=DEBUG
+      fi
+      read_utils.py index_fasta_picard assembly.fasta --loglevel=DEBUG
+      read_utils.py index_fasta_samtools assembly.fasta --loglevel=DEBUG
+
+      read_utils.py align_and_fix \
+        ${reads_unmapped_bam} \
+        assembly.fasta \
+        --outBamAll "${sample_name}.all.bam" \
+        --outBamFiltered "${sample_name}.mapped.bam" \
+        --aligner ${aligner} \
+        ${'--aligner_options "' + aligner_options + '"'} \
+        ${true='--skipMarkDupes' false="" skip_mark_dupes} \
+        --JVMmemory=3g \
+        ${"--NOVOALIGN_LICENSE_PATH=" + novocraft_license} \
+        --loglevel=DEBUG
+
+    else
+      touch "${sample_name}.all.bam" "${sample_name}.mapped.bam"
+
+    fi
+
+    # collect figures of merit
+    grep -v '^>' assembly.fasta | tr -d '\nNn' | wc -c | tee assembly_length_unambiguous
+    samtools view -c ${reads_unmapped_bam} | tee reads_provided
+    samtools view -c ${sample_name}.mapped.bam | tee reads_aligned
+    # report only primary alignments 260=exclude unaligned reads and secondary mappings
+    samtools view -h -F 260 ${sample_name}.all.bam | samtools flagstat - | tee ${sample_name}.all.bam.flagstat.txt
+    grep properly ${sample_name}.all.bam.flagstat.txt | cut -f 1 -d ' ' | tee read_pairs_aligned
+    samtools view ${sample_name}.mapped.bam | cut -f10 | tr -d '\n' | wc -c | tee bases_aligned
+    python -c "print (float("`cat bases_aligned`")/"`cat assembly_length_unambiguous`") if "`cat assembly_length_unambiguous`">0 else 0" > mean_coverage
+
+    # index mapped bam if non-empty
+    if [ `cat reads_aligned` != "0" ]; then
+      samtools index ${sample_name}.mapped.bam
+    else
+      touch ${sample_name}.mapped.bai
+    fi
+
+    # fastqc mapped bam
+    reports.py fastqc ${sample_name}.mapped.bam ${sample_name}.mapped_fastqc.html --out_zip ${sample_name}.mapped_fastqc.zip
+  }
+
+  output {
+    File   aligned_bam                   = "${sample_name}.all.bam"
+    File   aligned_bam_idx               = "${sample_name}.all.bai"
+    File   aligned_bam_flagstat          = "${sample_name}.all.bam.flagstat.txt"
+    File   aligned_only_reads_bam        = "${sample_name}.mapped.bam"
+    File   aligned_only_reads_bam_idx    = "${sample_name}.mapped.bai"
+    File   aligned_only_reads_fastqc     = "${sample_name}.mapped_fastqc.html"
+    File   aligned_only_reads_fastqc_zip = "${sample_name}.mapped_fastqc.zip"
+    Int    reads_provided                = read_int("reads_provided")
+    Int    reads_aligned                 = read_int("reads_aligned")
+    Int    read_pairs_aligned            = read_int("read_pairs_aligned")
+    Int    bases_aligned                 = read_int("bases_aligned")
+    Float  mean_coverage                 = read_float("mean_coverage")
+    String viralngs_version              = read_string("VERSION")
+  }
+
+  runtime {
+    docker: "${docker}"
+    memory: "3500 MB"
+    cpu: 4
+    disks: "local-disk 375 LOCAL"
+    dx_instance_type: "mem1_ssd1_v2_x8"
+  }
+}
+
 task refine_assembly_with_aligned_reads {
     File     reference_fasta
     File     reads_aligned_bam
@@ -269,12 +367,18 @@ task refine_assembly_with_aligned_reads {
 
         file_utils.py rename_fasta_sequences \
           refined.fasta "${sample_name}.fasta" "${sample_name}"
+
+      # collect figures of merit
+      grep -v '^>' refined.fasta | tr -d '\n' | wc -c | tee assembly_length
+      grep -v '^>' refined.fasta | tr -d '\nNn' | wc -c | tee assembly_length_unambiguous
     }
 
     output {
-        File   refined_assembly_fasta  = "${sample_name}.fasta"
-        File   sites_vcf_gz            = "${sample_name}.sites.vcf.gz"
-        String viralngs_version        = read_string("VERSION")
+        File   refined_assembly_fasta       = "${sample_name}.fasta"
+        File   sites_vcf_gz                 = "${sample_name}.sites.vcf.gz"
+        Int    assembly_length              = read_int("assembly_length")
+        Int    assembly_length_unambiguous  = read_int("assembly_length_unambiguous")
+        String viralngs_version             = read_string("VERSION")
     }
 
     runtime {

--- a/pipes/WDL/tasks/tasks_demux.wdl
+++ b/pipes/WDL/tasks/tasks_demux.wdl
@@ -273,9 +273,10 @@ task merge_and_reheader_bams {
     set -ex -o pipefail
 
     read_utils.py --version | tee VERSION
+    mem_in_mb=`/opt/viral-ngs/source/docker/calc_mem.py mb 90`
 
     if [ ${length(in_bams)} -gt 1 ]; then
-      read_utils.py merge_bams ${sep=' ' in_bams} merged.bam --loglevel DEBUG
+      read_utils.py merge_bams ${sep=' ' in_bams} merged.bam --JVMmemory="$mem_in_mb"m --loglevel DEBUG
     else
       echo "Skipping merge, only one input file"
       ln -s ${select_first(in_bams)} merged.bam

--- a/pipes/WDL/tasks/tasks_demux.wdl
+++ b/pipes/WDL/tasks/tasks_demux.wdl
@@ -4,10 +4,6 @@ task merge_tarballs {
   String        out_filename
   String?       docker="quay.io/broadinstitute/viral-core"
 
-#  parameter_meta {
-#    tar_chunks: "stream"
-#  }
-
   command {
     set -ex -o pipefail
 
@@ -31,7 +27,7 @@ task merge_tarballs {
     docker: "${docker}"
     memory: "7 GB"
     cpu: 16
-    disks: "local-disk 1125 LOCAL"
+    disks: "local-disk 2625 LOCAL"
     dx_instance_type: "mem1_ssd2_v2_x16"
     preemptible: 0
   }
@@ -59,11 +55,6 @@ task illumina_demux {
   Boolean? forceGC=true
 
   String? docker="quay.io/broadinstitute/viral-core"
-
-
-#  parameter_meta {
-#    flowcell_tgz: "stream"
-#  }
 
   command {
     set -ex -o pipefail
@@ -262,46 +253,3 @@ task illumina_demux {
     preemptible: 0  # this is the very first operation before scatter, so let's get it done quickly & reliably
   }
 }
-
-task merge_and_reheader_bams {
-  Array[File]+  in_bams
-  File?         reheader_table # tsv with 3 cols: field, old value, new value
-  String        out_basename
-  String?       docker="quay.io/broadinstitute/viral-core"
-
-  command {
-    set -ex -o pipefail
-
-    read_utils.py --version | tee VERSION
-    mem_in_mb=`/opt/viral-ngs/source/docker/calc_mem.py mb 90`
-
-    if [ ${length(in_bams)} -gt 1 ]; then
-      read_utils.py merge_bams ${sep=' ' in_bams} merged.bam --JVMmemory="$mem_in_mb"m --loglevel DEBUG
-    else
-      echo "Skipping merge, only one input file"
-      ln -s ${select_first(in_bams)} merged.bam
-    fi    
-
-    if [[ -f "${reheader_table}" ]]; then
-      read_utils.py reheader_bam merged.bam ${reheader_table} ${out_basename}.bam --loglevel DEBUG
-    else
-      echo "Skipping reheader, no mapping table specified"
-      ln -s merged.bam ${out_basename}.bam
-    fi
-  }
-
-  output {
-    File   out_bam          = "${out_basename}.bam"
-    String viralngs_version = read_string("VERSION")
-  }
-
-  runtime {
-    docker: "${docker}"
-    memory: "2 GB"
-    cpu: 2
-    disks: "local-disk 750 LOCAL"
-    dx_instance_type: "mem1_ssd2_v2_x4"
-  }
-}
-
-

--- a/pipes/WDL/tasks/tasks_read_utils.wdl
+++ b/pipes/WDL/tasks/tasks_read_utils.wdl
@@ -37,12 +37,12 @@ task merge_bams {
             if [ -s reheader_table.txt ]; then
               read_utils.py reheader_bam merged.bam reheader_table.txt "${out_basename}.bam" --loglevel DEBUG
             else
-              mv merged.bam "${out_basename}.bam}"
+              mv merged.bam "${out_basename}.bam"
             fi
+
         else
             # input was empty, so output should be empty (samtools doesn't like empty files)
             touch "${out_basename}.bam"
-
         fi
     }
 

--- a/pipes/WDL/tasks/tasks_read_utils.wdl
+++ b/pipes/WDL/tasks/tasks_read_utils.wdl
@@ -23,7 +23,7 @@ task merge_bams_one_sample {
             # create sample name remapping table based on existing sample names
             samtools view -H merged.bam | perl -n -e'/SM:(\S+)/ && print "SM\t$1\t'${sample_name}'\n"' | sort | uniq > sample_remap_table.txt
             # rename samples BAM headers
-            read_utils.py reheader_bam merged.bam ${reheader_table} "${out_basename}.bam" --loglevel DEBUG
+            read_utils.py reheader_bam merged.bam sample_remap_table.txt "${out_basename}.bam" --loglevel DEBUG
         else
             # input was empty, so output should be empty (samtools doesn't like empty files)
             touch "${out_basename}.bam" "${out_basename}.bai"

--- a/pipes/WDL/tasks/tasks_read_utils.wdl
+++ b/pipes/WDL/tasks/tasks_read_utils.wdl
@@ -98,7 +98,8 @@ task downsample_bams {
   runtime {
     docker: "${docker}"
     memory: "3 GB"
-    cpu: 2
+    cpu:    4
+    disks:  "local-disk 750 LOCAL"
     dx_instance_type: "mem1_ssd1_v2_x4"
   }
 }

--- a/pipes/WDL/tasks/tasks_read_utils.wdl
+++ b/pipes/WDL/tasks/tasks_read_utils.wdl
@@ -1,5 +1,5 @@
 
-task merge_bams {
+task merge_and_reheader_bams {
     Array[File]+    in_bams
     String?         sample_name
     File?           reheader_table # tsv with 3 cols: field, old value, new value

--- a/pipes/WDL/tasks/tasks_read_utils.wdl
+++ b/pipes/WDL/tasks/tasks_read_utils.wdl
@@ -1,4 +1,50 @@
 
+task merge_bams_one_sample {
+    Array[File]+    in_bams
+    Array[File]     optional_reads_bais
+    String          sample_name
+    String          out_basename
+    String?         docker="quay.io/broadinstitute/viral-core"
+
+    command {
+        set -ex -o pipefail
+
+        read_utils.py --version | tee VERSION
+        mem_in_mb=`/opt/viral-ngs/source/docker/calc_mem.py mb 90`
+
+        if [ ${length(in_bams)} -gt 1 ]; then
+            read_utils.py merge_bams ${sep=' ' in_bams} merged.bam --JVMmemory="$mem_in_mb"m --loglevel DEBUG
+        else
+            echo "Skipping merge, only one input file"
+            cp ${select_first(in_bams)} merged.bam
+        fi    
+
+        if [ -s merged.bam ]; then
+            # create sample name remapping table based on existing sample names
+            samtools view -H merged.bam | perl -n -e'/SM:(\S+)/ && print "SM\t$1\t'${sample_name}'\n"' | sort | uniq > sample_remap_table.txt
+            # rename samples BAM headers
+            read_utils.py reheader_bam merged.bam ${reheader_table} "${out_basename}.bam" --loglevel DEBUG
+        else
+            # input was empty, so output should be empty (samtools doesn't like empty files)
+            touch "${out_basename}.bam" "${out_basename}.bai"
+
+        fi
+    }
+
+    output {
+        File   out_bam          = "${out_basename}.bam"
+        String viralngs_version = read_string("VERSION")
+    }
+
+    runtime {
+        docker: "${docker}"
+        memory: "2 GB"
+        cpu: 2
+        disks: "local-disk 750 LOCAL"
+        dx_instance_type: "mem1_ssd2_v2_x4"
+    }
+}
+
 task downsample_bams {
   Array[File]  reads_bam
   Int?         readCount

--- a/pipes/WDL/tasks/tasks_read_utils.wdl
+++ b/pipes/WDL/tasks/tasks_read_utils.wdl
@@ -37,10 +37,11 @@ task merge_bams_one_sample {
 
     runtime {
         docker: "${docker}"
-        memory: "2 GB"
-        cpu: 2
+        memory: "3 GB"
+        cpu: 4
         disks: "local-disk 750 LOCAL"
         dx_instance_type: "mem1_ssd2_v2_x4"
+        preemptible: 0
     }
 }
 

--- a/pipes/WDL/tasks/tasks_read_utils.wdl
+++ b/pipes/WDL/tasks/tasks_read_utils.wdl
@@ -1,7 +1,6 @@
 
 task merge_bams_one_sample {
     Array[File]+    in_bams
-    Array[File]     optional_reads_bais
     String          sample_name
     String          out_basename
     String?         docker="quay.io/broadinstitute/viral-core"
@@ -26,7 +25,7 @@ task merge_bams_one_sample {
             read_utils.py reheader_bam merged.bam sample_remap_table.txt "${out_basename}.bam" --loglevel DEBUG
         else
             # input was empty, so output should be empty (samtools doesn't like empty files)
-            touch "${out_basename}.bam" "${out_basename}.bai"
+            touch "${out_basename}.bam"
 
         fi
     }

--- a/pipes/WDL/tasks/tasks_reports.wdl
+++ b/pipes/WDL/tasks/tasks_reports.wdl
@@ -46,7 +46,7 @@ task plot_coverage {
     fi
 
     # collect figures of merit
-    samtools view -H ${aligned_reads_bam} | perl -n -e'/^@SQ.*LN:(\d+)/ && print "$1\n"' |  awk '{s+=$1}END{printf "%.0f\n", s}' | tee assembly_length
+    samtools view -H ${aligned_reads_bam} | perl -n -e'/^@SQ.*LN:(\d+)/ && print "$1\n"' |  awk '{ s+=$1 } END { printf "%.0f\n", s }' | tee assembly_length
     # report only primary alignments 260=exclude unaligned reads and secondary mappings
     samtools view -h -F 260 ${aligned_reads_bam} | samtools flagstat - | tee ${sample_name}.flagstat.txt
     grep properly ${sample_name}.flagstat.txt | cut -f 1 -d ' ' | tee read_pairs_aligned
@@ -61,7 +61,7 @@ task plot_coverage {
     Int    reads_aligned                 = read_int("reads_aligned")
     Int    read_pairs_aligned            = read_int("read_pairs_aligned")
     Int    bases_aligned                 = read_int("bases_aligned")
-    Float  mean_coverage                = read_float("mean_coverage")
+    Float  mean_coverage                 = read_float("mean_coverage")
     String viralngs_version              = read_string("VERSION")
   }
 

--- a/pipes/WDL/tasks/tasks_reports.wdl
+++ b/pipes/WDL/tasks/tasks_reports.wdl
@@ -28,8 +28,9 @@ task plot_coverage {
 
       # plot coverage
       reports.py plot_coverage \
-        ${aligned_reads_bam} \
-        ${sample_name}.coverage_plot.pdf \
+        "${aligned_reads_bam}" \
+        "${sample_name}.coverage_plot.pdf" \
+        --outSummary "${sample_name}.coverage_plot.txt" \
         --plotFormat pdf \
         --plotWidth 1100 \
         --plotHeight 850 \
@@ -41,21 +42,23 @@ task plot_coverage {
         --loglevel=DEBUG
 
     else
-      touch ${sample_name}.coverage_plot.pdf
+      touch ${sample_name}.coverage_plot.pdf ${sample_name}.coverage_plot.txt
     fi
   }
 
   output {
     File   coverage_plot                 = "${sample_name}.coverage_plot.pdf"
+    File   coverage_tsv                  = "${sample_name}.coverage_plot.txt"
     String viralngs_version              = read_string("VERSION")
   }
 
   runtime {
     docker: "${docker}"
     memory: "3500 MB"
-    cpu: 4
+    cpu: 2
     disks: "local-disk 375 LOCAL"
-    dx_instance_type: "mem1_ssd1_v2_x8"
+    dx_instance_type: "mem1_ssd1_v2_x2"
+    preemptible: 1
   }
 }
 

--- a/pipes/WDL/tasks/tasks_reports.wdl
+++ b/pipes/WDL/tasks/tasks_reports.wdl
@@ -46,7 +46,7 @@ task plot_coverage {
     fi
 
     # collect figures of merit
-    samtools view -H ${aligned_reads_bam} | perl -n -e'/^@SQ.*LN:(\d+)/ && print "$1\n"' |  awk '{ s+=$1 } END { printf "%.0f\n", s }' | tee assembly_length
+    samtools view -H ${aligned_reads_bam} | perl -n -e'/^@SQ.*LN:(\d+)/ && print "$1\n"' |  awk \{s+=\$1\}END\{'printf "%.0f\n"',s\} | tee assembly_length
     # report only primary alignments 260=exclude unaligned reads and secondary mappings
     samtools view -h -F 260 ${aligned_reads_bam} | samtools flagstat - | tee ${sample_name}.flagstat.txt
     grep properly ${sample_name}.flagstat.txt | cut -f 1 -d ' ' | tee read_pairs_aligned

--- a/pipes/WDL/tasks/tasks_reports.wdl
+++ b/pipes/WDL/tasks/tasks_reports.wdl
@@ -46,7 +46,7 @@ task plot_coverage {
     fi
 
     # collect figures of merit
-    samtools view -H ${aligned_reads_bam} | perl -n -e'/^@SQ.*LN:(\d+)/ && print "$1\n"' | paste -sd+ - | bc | tee assembly_length
+    samtools view -H ${aligned_reads_bam} | perl -n -e'/^@SQ.*LN:(\d+)/ && print "$1\n"' |  awk '{s+=$1}END{printf "%.0f\n", s}' | tee assembly_length
     # report only primary alignments 260=exclude unaligned reads and secondary mappings
     samtools view -h -F 260 ${aligned_reads_bam} | samtools flagstat - | tee ${sample_name}.flagstat.txt
     grep properly ${sample_name}.flagstat.txt | cut -f 1 -d ' ' | tee read_pairs_aligned

--- a/pipes/WDL/tasks/tasks_reports.wdl
+++ b/pipes/WDL/tasks/tasks_reports.wdl
@@ -1,13 +1,7 @@
 
 task plot_coverage {
-  File     assembly_fasta
-  File     reads_unmapped_bam
+  File     aligned_reads_bam
   String   sample_name
-
-  File?    novocraft_license
-
-  String?  aligner="novoalign" # novoalign or bwa
-  String?  aligner_options
 
   Boolean? skip_mark_dupes=false
   Boolean? plot_only_non_duplicates=false
@@ -21,69 +15,20 @@ task plot_coverage {
 
     read_utils.py --version | tee VERSION
 
-    cp ${assembly_fasta} assembly.fasta
-    grep -v '^>' assembly.fasta | tr -d '\n' | wc -c | tee assembly_length
-
-    if [ `cat assembly_length` != "0" ]; then
-
-      # only perform the following if the reference is non-empty
-
-      if [ "${aligner}" == "novoalign" ]; then
-        read_utils.py novoindex \
-          assembly.fasta \
-          ${"--NOVOALIGN_LICENSE_PATH=" + novocraft_license} \
-          --loglevel=DEBUG
-      fi
-      read_utils.py index_fasta_picard assembly.fasta --loglevel=DEBUG
-      read_utils.py index_fasta_samtools assembly.fasta --loglevel=DEBUG
-
-      read_utils.py align_and_fix \
-        ${reads_unmapped_bam} \
-        assembly.fasta \
-        --outBamAll "${sample_name}.all.bam" \
-        --outBamFiltered "${sample_name}.mapped.bam" \
-        --aligner ${aligner} \
-        ${'--aligner_options "' + aligner_options + '"'} \
-        ${true='--skipMarkDupes' false="" skip_mark_dupes} \
-        --JVMmemory=3g \
-        ${"--NOVOALIGN_LICENSE_PATH=" + novocraft_license} \
-        --loglevel=DEBUG
-
-    else
-      touch "${sample_name}.all.bam" "${sample_name}.mapped.bam"
-
-    fi
-
-    # collect figures of merit
-    grep -v '^>' assembly.fasta | tr -d '\nNn' | wc -c | tee assembly_length_unambiguous
-    samtools view -c ${reads_unmapped_bam} | tee reads_provided
-    samtools view -c ${sample_name}.mapped.bam | tee reads_aligned
-    # report only primary alignments 260=exclude unaligned reads and secondary mappings
-    samtools view -h -F 260 ${sample_name}.all.bam | samtools flagstat - | tee ${sample_name}.all.bam.flagstat.txt
-    grep properly ${sample_name}.all.bam.flagstat.txt | cut -f 1 -d ' ' | tee read_pairs_aligned
-    samtools view ${sample_name}.mapped.bam | cut -f10 | tr -d '\n' | wc -c | tee bases_aligned
-    #echo $(( $(cat bases_aligned) / $(cat assembly_length) )) | tee mean_coverage
-    python -c "print (float("`cat bases_aligned`")/"`cat assembly_length`") if "`cat assembly_length`">0 else 0" > mean_coverage
-
-    # index mapped bam if non-empty
+    samtools view -c ${aligned_reads_bam} | tee reads_aligned
     if [ `cat reads_aligned` != "0" ]; then
-      samtools index ${sample_name}.mapped.bam
-    fi
+      samtools index -@ `nproc` ${aligned_reads_bam}
 
-    # fastqc mapped bam
-    reports.py fastqc ${sample_name}.mapped.bam ${sample_name}.mapped_fastqc.html --out_zip ${sample_name}.mapped_fastqc.zip
+      PLOT_DUPE_OPTION=""
+      if [[ "${skip_mark_dupes}" != "true" ]]; then
+        PLOT_DUPE_OPTION="${true='--plotOnlyNonDuplicates' false="" plot_only_non_duplicates}"
+      fi
+      
+      BINNING_OPTION="${true='--binLargePlots' false="" bin_large_plots}"
 
-    PLOT_DUPE_OPTION=""
-    if [[ "${skip_mark_dupes}" != "true" ]]; then
-      PLOT_DUPE_OPTION="${true='--plotOnlyNonDuplicates' false="" plot_only_non_duplicates}"
-    fi
-    
-    BINNING_OPTION="${true='--binLargePlots' false="" bin_large_plots}"
-
-    # plot coverage
-    if [ $(cat reads_aligned) != 0 ]; then
+      # plot coverage
       reports.py plot_coverage \
-        ${sample_name}.mapped.bam \
+        ${aligned_reads_bam} \
         ${sample_name}.coverage_plot.pdf \
         --plotFormat pdf \
         --plotWidth 1100 \
@@ -94,27 +39,14 @@ task plot_coverage {
         --binningSummaryStatistic ${binning_summary_statistic} \
         --plotTitle "${sample_name} coverage plot" \
         --loglevel=DEBUG
+
     else
       touch ${sample_name}.coverage_plot.pdf
     fi
   }
 
   output {
-    File   aligned_bam                   = "${sample_name}.all.bam"
-    File   aligned_bam_idx               = "${sample_name}.all.bai"
-    File   aligned_bam_flagstat          = "${sample_name}.all.bam.flagstat.txt"
-    File   aligned_only_reads_bam        = "${sample_name}.mapped.bam"
-    File   aligned_only_reads_bam_idx    = "${sample_name}.mapped.bai"
-    File   aligned_only_reads_fastqc     = "${sample_name}.mapped_fastqc.html"
-    File   aligned_only_reads_fastqc_zip = "${sample_name}.mapped_fastqc.zip"
     File   coverage_plot                 = "${sample_name}.coverage_plot.pdf"
-    Int    assembly_length               = read_int("assembly_length")
-    Int    assembly_length_unambiguous   = read_int("assembly_length_unambiguous")
-    Int    reads_provided                = read_int("reads_provided")
-    Int    reads_aligned                 = read_int("reads_aligned")
-    Int    read_pairs_aligned            = read_int("read_pairs_aligned")
-    Int    bases_aligned                 = read_int("bases_aligned")
-    Float  mean_coverage                 = read_float("mean_coverage")
     String viralngs_version              = read_string("VERSION")
   }
 

--- a/pipes/WDL/tasks/tasks_reports.wdl
+++ b/pipes/WDL/tasks/tasks_reports.wdl
@@ -46,7 +46,7 @@ task plot_coverage {
     fi
 
     # collect figures of merit
-    samtools view -H ${aligned_reads_bam} | perl -n -e'/^@SQ.*LN:(\d+)/ && print "$1\n"' |  awk \{s+=\$1\}END\{'printf "%.0f\n"',s\} | tee assembly_length
+    samtools view -H ${aligned_reads_bam} | perl -n -e'/^@SQ.*LN:(\d+)/ && print "$1\n"' |  python -c "import sys; print(sum(int(x) for x in sys.stdin))" | tee assembly_length
     # report only primary alignments 260=exclude unaligned reads and secondary mappings
     samtools view -h -F 260 ${aligned_reads_bam} | samtools flagstat - | tee ${sample_name}.flagstat.txt
     grep properly ${sample_name}.flagstat.txt | cut -f 1 -d ' ' | tee read_pairs_aligned

--- a/pipes/WDL/workflows/align_and_plot.wdl
+++ b/pipes/WDL/workflows/align_and_plot.wdl
@@ -2,19 +2,13 @@ import "../tasks/tasks_reports.wdl" as reports
 import "../tasks/tasks_assembly.wdl" as assembly
 
 workflow align_and_plot {
-    File  reads_unmapped_bam
-
     call assembly.align_reads as align {
         input:
-            reference_fasta    = reference_fasta,
-            reads_unmapped_bam = reads_unmapped_bam,
             aligner_options    = "-r Random -l 30 -g 40 -x 20 -t 502"
     }
-
     call reports.plot_coverage {
         input:
-            reads_unmapped_bam = reads_unmapped_bam,
-            aligner_options = "-r Random -l 30 -g 40 -x 20 -t 502",
-            sample_name = basename(basename(basename(reads_unmapped_bam, ".bam"), ".taxfilt"), ".clean")
+            aligned_reads_bam = align.aligned_only_reads_bam,
+            sample_name = basename(basename(basename(align.aligned_only_reads_bam, ".bam"), ".mapped"), ".clean")
     }
 }

--- a/pipes/WDL/workflows/align_and_plot.wdl
+++ b/pipes/WDL/workflows/align_and_plot.wdl
@@ -1,7 +1,16 @@
 import "../tasks/tasks_reports.wdl" as reports
+import "../tasks/tasks_assembly.wdl" as assembly
 
 workflow align_and_plot {
     String  reads_unmapped_bam
+
+    call assembly.align_reads as align {
+        input:
+            reference_fasta    = reference_fasta,
+            reads_unmapped_bam = reads_unmapped_bam,
+            aligner_options    = "-r Random -l 30 -g 40 -x 20 -t 502"
+    }
+
     call reports.plot_coverage {
         input:
             reads_unmapped_bam = reads_unmapped_bam,

--- a/pipes/WDL/workflows/align_and_plot.wdl
+++ b/pipes/WDL/workflows/align_and_plot.wdl
@@ -2,7 +2,7 @@ import "../tasks/tasks_reports.wdl" as reports
 import "../tasks/tasks_assembly.wdl" as assembly
 
 workflow align_and_plot {
-    String  reads_unmapped_bam
+    File  reads_unmapped_bam
 
     call assembly.align_reads as align {
         input:

--- a/pipes/WDL/workflows/assemble_refbased.wdl
+++ b/pipes/WDL/workflows/assemble_refbased.wdl
@@ -69,7 +69,6 @@ workflow assemble_refbased {
     call read_utils.merge_bams_one_sample as merge_align_to_self {
         input:
             in_bams             = align_to_self.aligned_only_reads_bam,
-            optional_reads_bais = align_to_self.aligned_only_reads_bam_idx,
             sample_name         = sample_name,
             out_basename        = "${sample_name}.merge_align_to_self"
     }

--- a/pipes/WDL/workflows/assemble_refbased.wdl
+++ b/pipes/WDL/workflows/assemble_refbased.wdl
@@ -57,8 +57,9 @@ workflow assemble_refbased {
                 reads_unmapped_bam = reads_unmapped_bam,
                 novocraft_license  = novocraft_license,
                 skip_mark_dupes    = skip_mark_dupes,
-                sample_name        = "${sample_name}.align_to_self",
                 aligner_options    = "-r Random -l 40 -g 40 -x 20 -t 100"
+                ## (for bwa) -- aligner_options = "-k 12 -B 1"
+                ## (for novoalign) -- aligner_options = "-r Random -l 40 -g 40 -x 20 -t 501 -k"
         }
     }
 

--- a/pipes/WDL/workflows/assemble_refbased.wdl
+++ b/pipes/WDL/workflows/assemble_refbased.wdl
@@ -41,6 +41,11 @@ workflow assemble_refbased {
             sample_name         = sample_name
     }
 
+    call reports.MultiQC as multiqc_align_to_ref {
+        input:
+            input_files = align_to_ref.aligned_only_reads_fastqc_zip
+    }
+
     call assembly.refine_assembly_with_aligned_reads as call_consensus {
         input:
             reference_fasta   = reference_fasta,

--- a/pipes/WDL/workflows/assemble_refbased.wdl
+++ b/pipes/WDL/workflows/assemble_refbased.wdl
@@ -28,7 +28,7 @@ workflow assemble_refbased {
         }
     }
 
-    call read_utils.merge_bams as merge_align_to_ref {
+    call read_utils.merge_and_reheader_bams as merge_align_to_ref {
         input:
             in_bams             = ivar_trim.aligned_trimmed_bam,
             sample_name         = sample_name,
@@ -66,7 +66,7 @@ workflow assemble_refbased {
         }
     }
 
-    call read_utils.merge_bams as merge_align_to_self {
+    call read_utils.merge_and_reheader_bams as merge_align_to_self {
         input:
             in_bams             = align_to_self.aligned_only_reads_bam,
             sample_name         = sample_name,

--- a/pipes/WDL/workflows/assemble_refbased.wdl
+++ b/pipes/WDL/workflows/assemble_refbased.wdl
@@ -10,6 +10,7 @@ workflow assemble_refbased {
 
     File?           novocraft_license
     Boolean?        skip_mark_dupes=false
+    File?           trim_coords_bed
 
     scatter(reads_unmapped_bam in reads_unmapped_bams) {
         call assembly.align_reads as align_to_ref {
@@ -24,7 +25,8 @@ workflow assemble_refbased {
         }
         call assembly.ivar_trim {
             input:
-                aligned_bam = align_to_ref.aligned_only_reads_bam
+                aligned_bam = align_to_ref.aligned_only_reads_bam,
+                trim_coords_bed = trim_coords_bed
         }
     }
 

--- a/pipes/WDL/workflows/assemble_refbased.wdl
+++ b/pipes/WDL/workflows/assemble_refbased.wdl
@@ -28,7 +28,7 @@ workflow assemble_refbased {
         }
     }
 
-    call read_utils.merge_bams_one_sample as merge_align_to_ref {
+    call read_utils.merge_bams as merge_align_to_ref {
         input:
             in_bams             = ivar_trim.aligned_trimmed_bam,
             sample_name         = sample_name,
@@ -66,7 +66,7 @@ workflow assemble_refbased {
         }
     }
 
-    call read_utils.merge_bams_one_sample as merge_align_to_self {
+    call read_utils.merge_bams as merge_align_to_self {
         input:
             in_bams             = align_to_self.aligned_only_reads_bam,
             sample_name         = sample_name,

--- a/pipes/WDL/workflows/assemble_refbased.wdl
+++ b/pipes/WDL/workflows/assemble_refbased.wdl
@@ -30,7 +30,7 @@ workflow assemble_refbased {
 
     call read_utils.merge_bams_one_sample as merge_align_to_ref {
         input:
-            in_bams             = ivar_trim.aligned_trimmed_bam
+            in_bams             = ivar_trim.aligned_trimmed_bam,
             sample_name         = sample_name,
             out_basename        = "${sample_name}.align_to_ref.trimmed"
     }

--- a/pipes/WDL/workflows/assemble_refbased.wdl
+++ b/pipes/WDL/workflows/assemble_refbased.wdl
@@ -1,48 +1,77 @@
 import "../tasks/tasks_assembly.wdl" as assembly
 import "../tasks/tasks_reports.wdl" as reports
+import "../tasks/tasks_read_utils.wdl" as read_utils
 
 workflow assemble_refbased {
 
-  File     reference_fasta
-  File     reads_unmapped_bam
-  File?    novocraft_license
-  Boolean? skip_mark_dupes=false
+    String          sample_name
+    Array[File]+    reads_unmapped_bams
+    File            reference_fasta
 
-  String   sample_name = basename(basename(basename(reads_unmapped_bam, ".bam"), ".taxfilt"), ".clean")
+    File?           novocraft_license
+    Boolean?        skip_mark_dupes=false
 
-  call reports.plot_coverage as align_to_ref {
-    input:
-        assembly_fasta     = reference_fasta,
-        reads_unmapped_bam = reads_unmapped_bam,
-        novocraft_license  = novocraft_license,
-        skip_mark_dupes    = skip_mark_dupes,
-        sample_name        = "${sample_name}.align_to_ref",
-        aligner_options    = "-r Random -l 40 -g 40 -x 20 -t 501 -k"
-        ## (for bwa) -- aligner_options = "-k 12 -B 1"
-        ## (for novoalign) -- aligner_options = "-r Random -l 40 -g 40 -x 20 -t 501 -k"
-  }
+    scatter(reads_unmapped_bam in reads_unmapped_bams) {
+        call assembly.align_reads as align_to_ref {
+            input:
+                reference_fasta    = reference_fasta,
+                reads_unmapped_bam = reads_unmapped_bam,
+                novocraft_license  = novocraft_license,
+                skip_mark_dupes    = skip_mark_dupes,
+                aligner_options    = "-r Random -l 40 -g 40 -x 20 -t 501 -k"
+                ## (for bwa) -- aligner_options = "-k 12 -B 1"
+                ## (for novoalign) -- aligner_options = "-r Random -l 40 -g 40 -x 20 -t 501 -k"
+        }
+    }
 
-  call assembly.ivar_trim {
-    input:
-        aligned_bam = align_to_ref.aligned_only_reads_bam
-  }
+    call read_utils.merge_bams_one_sample as merge_align_to_ref {
+        input:
+            in_bams             = align_to_ref.aligned_only_reads_bam,
+            optional_reads_bais = align_to_ref.aligned_only_reads_bam_idx,
+            sample_name         = sample_name,
+            out_basename        = "${sample_name}.align_to_ref"
+    }
 
-  call assembly.refine_assembly_with_aligned_reads as call_consensus {
-    input:
-        reference_fasta   = reference_fasta,
-        reads_aligned_bam = ivar_trim.aligned_trimmed_bam,
-        sample_name       = sample_name,
-        novocraft_license = novocraft_license
-  }
+    call reports.plot_coverage as plot_ref_coverage {
+        input:
+            aligned_reads_bam   = merge_align_to_ref.out_bam
+    }
 
-  call reports.plot_coverage as align_to_self {
-    input:
-        assembly_fasta     = call_consensus.refined_assembly_fasta,
-        reads_unmapped_bam = reads_unmapped_bam,
-        novocraft_license  = novocraft_license,
-        skip_mark_dupes    = skip_mark_dupes,
-        sample_name        = "${sample_name}.align_to_self",
-        aligner_options    = "-r Random -l 40 -g 40 -x 20 -t 100"
-  }
+    call assembly.ivar_trim {
+        input:
+            aligned_bam = merge_align_to_ref.out_bam
+    }
 
+    call assembly.refine_assembly_with_aligned_reads as call_consensus {
+        input:
+            reference_fasta   = reference_fasta,
+            reads_aligned_bam = ivar_trim.aligned_trimmed_bam,
+            sample_name       = sample_name,
+            novocraft_license = novocraft_license
+    }
+
+    scatter(reads_unmapped_bam in reads_unmapped_bams) {
+        call assembly.align_reads as align_to_self {
+            input:
+                reference_fasta    = call_consensus.refined_assembly_fasta,
+                reads_unmapped_bam = reads_unmapped_bam,
+                novocraft_license  = novocraft_license,
+                skip_mark_dupes    = skip_mark_dupes,
+                sample_name        = "${sample_name}.align_to_self",
+                aligner_options    = "-r Random -l 40 -g 40 -x 20 -t 100"
+        }
+    }
+
+    call read_utils.merge_bams_one_sample as merge_align_to_self {
+        input:
+            in_bams             = align_to_self.aligned_only_reads_bam,
+            optional_reads_bais = align_to_self.aligned_only_reads_bam_idx,
+            sample_name         = sample_name,
+            out_basename        = "${sample_name}.merge_align_to_self"
+    }
+
+    call reports.plot_coverage as plot_self_coverage {
+        input:
+            aligned_reads_bam   = merge_align_to_self.out_bam
+    }
 }

--- a/pipes/WDL/workflows/assemble_refbased.wdl
+++ b/pipes/WDL/workflows/assemble_refbased.wdl
@@ -22,32 +22,30 @@ workflow assemble_refbased {
                 ## (for bwa) -- aligner_options = "-k 12 -B 1"
                 ## (for novoalign) -- aligner_options = "-r Random -l 40 -g 40 -x 20 -t 501 -k"
         }
+        call assembly.ivar_trim {
+            input:
+                aligned_bam = align_to_ref.aligned_only_reads_bam
+        }
     }
 
     call read_utils.merge_bams_one_sample as merge_align_to_ref {
         input:
-            in_bams             = align_to_ref.aligned_only_reads_bam,
-            optional_reads_bais = align_to_ref.aligned_only_reads_bam_idx,
+            in_bams             = ivar_trim.aligned_trimmed_bam
             sample_name         = sample_name,
-            out_basename        = "${sample_name}.align_to_ref"
+            out_basename        = "${sample_name}.align_to_ref.trimmed"
     }
 
     call reports.plot_coverage as plot_ref_coverage {
         input:
-            aligned_reads_bam   = merge_align_to_ref.out_bam
-    }
-
-    call assembly.ivar_trim {
-        input:
-            aligned_bam = merge_align_to_ref.out_bam
+            aligned_reads_bam   = merge_align_to_ref.out_bam,
+            sample_name         = sample_name
     }
 
     call assembly.refine_assembly_with_aligned_reads as call_consensus {
         input:
             reference_fasta   = reference_fasta,
-            reads_aligned_bam = ivar_trim.aligned_trimmed_bam,
-            sample_name       = sample_name,
-            novocraft_license = novocraft_license
+            reads_aligned_bam = merge_align_to_ref.out_bam,
+            sample_name       = sample_name
     }
 
     scatter(reads_unmapped_bam in reads_unmapped_bams) {
@@ -73,6 +71,7 @@ workflow assemble_refbased {
 
     call reports.plot_coverage as plot_self_coverage {
         input:
-            aligned_reads_bam   = merge_align_to_self.out_bam
+            aligned_reads_bam   = merge_align_to_self.out_bam,
+            sample_name         = sample_name
     }
 }

--- a/pipes/WDL/workflows/demux_plus.wdl
+++ b/pipes/WDL/workflows/demux_plus.wdl
@@ -36,9 +36,14 @@ workflow demux_plus {
         }
     }
 
-    call reports.MultiQC {
+    call reports.MultiQC as multiqc_raw {
         input:
             input_files = illumina_demux.raw_reads_fastqc_zip
+    }
+
+    call reports.MultiQC as multiqc_cleaned {
+        input:
+            input_files = deplete.cleaned_fastqc_zip
     }
 
     call metagenomics.krakenuniq as krakenuniq {

--- a/pipes/WDL/workflows/merge_bams.wdl
+++ b/pipes/WDL/workflows/merge_bams.wdl
@@ -1,5 +1,5 @@
 import "../tasks/tasks_read_utils.wdl" as read_utils
 
 workflow merge_bams {
-    call read_utils.merge_bams
+    call read_utils.merge_and_reheader_bams
 }

--- a/pipes/WDL/workflows/merge_bams.wdl
+++ b/pipes/WDL/workflows/merge_bams.wdl
@@ -1,5 +1,5 @@
-import "../tasks/tasks_demux.wdl" as demux
+import "../tasks/tasks_read_utils.wdl" as read_utils
 
 workflow merge_bams {
-    call demux.merge_and_reheader_bams
+    call read_utils.merge_bams
 }

--- a/test/input/WDL/test_inputs-assemble_refbased-local.json
+++ b/test/input/WDL/test_inputs-assemble_refbased-local.json
@@ -1,5 +1,5 @@
 {
-  "assemble_refbased.reads_unmapped_bam": "test/input/G5012.3.testreads.bam",
+  "assemble_refbased.reads_unmapped_bams": ["test/input/G5012.3.testreads.bam"],
   "assemble_refbased.reference_fasta": "test/input/ebov-makona.fasta",
-  "assemble_refbased.call_consensus.sample_name": "G5012.3"
+  "assemble_refbased.sample_name": "G5012.3"
 }

--- a/test/input/WDL/test_inputs-demux_plus-dnanexus.dx.json
+++ b/test/input/WDL/test_inputs-demux_plus-dnanexus.dx.json
@@ -11,6 +11,6 @@
   "stage-0.maxMismatches": 0,
   "stage-0.minimumQuality": 25,
 
-  "stage-6.krakenuniq_db_tar_lz4": { "$dnanexus_link": { "project": "project-F8PQ6380xf5bK0Qk0YPjB17P", "id": "file-FVzQ11806zFK7f5Z90KYy14z" } },
-  "stage-6.krona_taxonomy_db_tgz": { "$dnanexus_link": { "project": "project-F8PQ6380xf5bK0Qk0YPjB17P", "id": "file-Fg2p9bQ0xf5y05Vg0GJb12vb" } }
+  "stage-7.krakenuniq_db_tar_lz4": { "$dnanexus_link": { "project": "project-F8PQ6380xf5bK0Qk0YPjB17P", "id": "file-FVzQ11806zFK7f5Z90KYy14z" } },
+  "stage-7.krona_taxonomy_db_tgz": { "$dnanexus_link": { "project": "project-F8PQ6380xf5bK0Qk0YPjB17P", "id": "file-Fg2p9bQ0xf5y05Vg0GJb12vb" } }
 }


### PR DESCRIPTION
Optimizations and changes to reference based assembly pipeline to allow it to scale to very large data sets:
1. separate the short read alignment from the coverage plotting into separate WDL tasks
2. accept multiple bams of read inputs (all for the same sample)
3. scatter the short read alignments and ivar trim tasks per input bam
4. add merge bam steps after each scatter, reheader the bams to rewrite the `SM` field to what the user specifies
5. add multiqc summaries of fastqc plots
6. remove novoalign license requirement from consensus calling (which does not call aligners)
7. Closes #28 

Other tangential changes:
- demux_plus now emits multiqc report of cleaned reads (in addition to raw reads multiqc)
- merge_bams now easier to run if all you want to do is rename the sample (`SM`)