### PR TITLE
viral-pipelines travis build staging and miniwdl

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,6 +61,19 @@ jobs:
     - language: python
       stage: build
       env:
+        - TRAVIS_JOB=test_miniwdl
+      install:
+        - set -e
+        - source travis/install-conda.sh
+        - conda install -y miniwdl shellcheck
+      script:
+        - set -e
+        - travis/version-wdl-runtimes.sh
+        - travis/tests-miniwdl.sh
+
+    - language: python
+      stage: build
+      env:
         - TRAVIS_JOB=deploy_dockstore
       install:
         - set -e

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,9 +22,25 @@ cache:
     - $HOME/miniconda
   timeout: 1000
 
+stages:
+  - validate
+  - build
+
 jobs:
   fast_finish: true
   include:
+    - language: python
+      stage: validate
+      env:
+        - TRAVIS_JOB=validate_wdl_miniwdl
+      install:
+        - set -e
+        - source travis/install-conda.sh
+        - conda install -y miniwdl shellcheck
+      script:
+        - set -e
+        - travis/version-wdl-runtimes.sh
+        - travis/validate-wdl-miniwdl.sh
 
     - language: java
       jdk: openjdk11
@@ -40,7 +56,6 @@ jobs:
         - set -e
         - travis/version-wdl-runtimes.sh
         - travis/relative-wdl-paths.sh
-        - travis/validate-wdl-womtool.sh
         - travis/build-dx.sh
         - travis/tests-dx.sh
 
@@ -65,7 +80,7 @@ jobs:
       install:
         - set -e
         - source travis/install-conda.sh
-        - conda install -y miniwdl shellcheck
+        - conda install -y miniwdl shellcheck jq
       script:
         - set -e
         - travis/version-wdl-runtimes.sh
@@ -82,7 +97,6 @@ jobs:
       script:
         - set -e
         - travis/version-wdl-runtimes.sh
-        - travis/validate-wdl-miniwdl.sh
         - travis/flatten-wdls.sh
         - echo "actual dockstore deploy not implemented yet"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,9 +44,22 @@ jobs:
 
     - language: java
       jdk: openjdk11
+      stage: validate
+      env:
+        - TRAVIS_JOB=validate_cromwell
+      install:
+        - travis/install-wdl.sh
+      script:
+        - set -e
+        - travis/version-wdl-runtimes.sh
+        - travis/relative-wdl-paths.sh
+        - travis/validate-wdl-womtool.sh
+
+    - language: java
+      jdk: openjdk11
       stage: build
       env:
-        - TRAVIS_JOB=build_dxWDL
+        - TRAVIS_JOB=deploy_dnanexus
         # DX_API_TOKEN (for DNAnexus builds) -- token #3, expires 12/31/2024
         - secure: "zAAxwXWwSDcwnLYHawc0+gbshV3UURAZWSyk8g99kXgFCRcgytacvUpRxd44mC+rlgL2RtS8+RPT11hO2zJ+4y0J0FBaC8d9R7aTzEAGKLHk11cfhMg63QMVBt/8Gz9HToeE0BJ8/JbNZr+IZ01dD8GNDRA4FcFj+8maTpp4nrQ5/leDdmUwzkV1XfMiE+0/wR3KttKvqzHy6+6gRTAKbTeSxPICvWpHKlIYkIxFcEoH+3SNxgwWU9jZqG29MRt3/ikzZMBW/T2O9g+tY/5vKRqxm9aqWChFgjrpWRZDwvZqvwdxizokoVfReLZES3Ls//YSKzfFJG2GZ6a2vhAbfjcUkbRnyPOcZPwK+sE91Pq7FgFwL4N8BV63j6GQ5VrHZxe0b6spw8gvlkEjjhBgN1178lcxnp75QANNJ8AprZBqi3MzTQOTlgRZRAsDWTLgpXODrcDib76pg3af+JK5PQb0ncRVps9Z09u2EJ8fk9MGCDB6iw7XFedPPCxlx6MyIp2ywF4v9mkQXUBafYo67KRyPaojUUDGFkJsylYxzGHvvp0PrU93cp8zvDg4NqUkrbgEdGVvPF+qmXxT9MpfLc/yZ4vfhtKfZuQUGmNw+5WfTa3RYbJDEowN6noWCdXBZ67SrusKrok3TxIJV25vxXrFVhD/u/3ermysu7xA9ss="
         - DX_PROJECT=project-F8PQ6380xf5bK0Qk0YPjB17P
@@ -70,7 +83,6 @@ jobs:
         - set -e
         - travis/version-wdl-runtimes.sh
         - travis/relative-wdl-paths.sh
-        - travis/validate-wdl-womtool.sh
         - travis/tests-cromwell.sh
 
     - language: python

--- a/.travis.yml
+++ b/.travis.yml
@@ -72,18 +72,18 @@ jobs:
         - travis/build-dx.sh
         - travis/tests-dx.sh
 
-    - language: java
-      jdk: openjdk11
-      stage: build
-      env:
-        - TRAVIS_JOB=test_cromwell
-      install:
-        - travis/install-wdl.sh
-      script:
-        - set -e
-        - travis/version-wdl-runtimes.sh
-        - travis/relative-wdl-paths.sh
-        - travis/tests-cromwell.sh
+    #- language: java
+    #  jdk: openjdk11
+    #  stage: build
+    #  env:
+    #    - TRAVIS_JOB=test_cromwell
+    #  install:
+    #    - travis/install-wdl.sh
+    #  script:
+    #    - set -e
+    #    - travis/version-wdl-runtimes.sh
+    #    - travis/relative-wdl-paths.sh
+    #    - travis/tests-cromwell.sh
 
     - language: python
       stage: build

--- a/pipes/WDL/tasks/tasks_reports.wdl
+++ b/pipes/WDL/tasks/tasks_reports.wdl
@@ -284,7 +284,7 @@ task MultiQC {
 
       mkdir -p ${input_directory} ${out_dir}
 
-      mv ${sep=' ' input_files} ${input_directory}
+      ln -s ${sep=' ' input_files} ${input_directory}
 
       multiqc \
       ${true="--force" false="" force} \

--- a/pipes/WDL/workflows/align_and_plot.wdl
+++ b/pipes/WDL/workflows/align_and_plot.wdl
@@ -2,9 +2,11 @@ import "../tasks/tasks_reports.wdl" as reports
 import "../tasks/tasks_assembly.wdl" as assembly
 
 workflow align_and_plot {
+	String? aligner_options = "-r Random -l 30 -g 40 -x 20 -t 502"
+
     call assembly.align_reads as align {
         input:
-            aligner_options    = "-r Random -l 30 -g 40 -x 20 -t 502"
+            aligner_options = aligner_options
     }
     call reports.plot_coverage {
         input:

--- a/test/input/WDL/test_inputs-align_and_plot-local.json
+++ b/test/input/WDL/test_inputs-align_and_plot-local.json
@@ -1,0 +1,6 @@
+{
+  "align_and_plot.align.reads_unmapped_bam": "test/input/G5012.3.subset.bam",
+  "align_and_plot.align.reference_fasta": "test/input/ebov-makona.fasta",
+  "align_and_plot.align.aligner": "bwa",
+  "align_and_plot.align.aligner_options": "-B 1"
+}

--- a/test/input/WDL/test_inputs-align_and_plot-local.json
+++ b/test/input/WDL/test_inputs-align_and_plot-local.json
@@ -2,5 +2,5 @@
   "align_and_plot.align.reads_unmapped_bam": "test/input/G5012.3.subset.bam",
   "align_and_plot.align.reference_fasta": "test/input/ebov-makona.fasta",
   "align_and_plot.align.aligner": "bwa",
-  "align_and_plot.align.aligner_options": "-B 1"
+  "align_and_plot.aligner_options": "-B 1"
 }

--- a/test/input/WDL/test_inputs-demux_plus-dnanexus.dx.json
+++ b/test/input/WDL/test_inputs-demux_plus-dnanexus.dx.json
@@ -11,6 +11,6 @@
   "stage-0.maxMismatches": 0,
   "stage-0.minimumQuality": 25,
 
-  "stage-7.krakenuniq_db_tar_lz4": { "$dnanexus_link": { "project": "project-F8PQ6380xf5bK0Qk0YPjB17P", "id": "file-FVzQ11806zFK7f5Z90KYy14z" } },
+  "stage-7.krakenuniq_db_tar_lz4": { "$dnanexus_link": { "project": "project-F8PQ6380xf5bK0Qk0YPjB17P", "id": "file-F86qZg809y3Qvp7j7vgFKj4Z" } },
   "stage-7.krona_taxonomy_db_tgz": { "$dnanexus_link": { "project": "project-F8PQ6380xf5bK0Qk0YPjB17P", "id": "file-Fg2p9bQ0xf5y05Vg0GJb12vb" } }
 }

--- a/test/input/WDL/test_inputs-demux_plus-dnanexus.dx.json
+++ b/test/input/WDL/test_inputs-demux_plus-dnanexus.dx.json
@@ -11,6 +11,6 @@
   "stage-0.maxMismatches": 0,
   "stage-0.minimumQuality": 25,
 
-  "stage-7.krakenuniq_db_tar_lz4": { "$dnanexus_link": { "project": "project-F8PQ6380xf5bK0Qk0YPjB17P", "id": "file-F86qZg809y3Qvp7j7vgFKj4Z" } },
+  "stage-7.krakenuniq_db_tar_lz4": { "$dnanexus_link": { "project": "project-F8PQ6380xf5bK0Qk0YPjB17P", "id": "file-FVzQ11806zFK7f5Z90KYy14z" } },
   "stage-7.krona_taxonomy_db_tgz": { "$dnanexus_link": { "project": "project-F8PQ6380xf5bK0Qk0YPjB17P", "id": "file-Fg2p9bQ0xf5y05Vg0GJb12vb" } }
 }

--- a/test/input/WDL/test_outputs-assemble_denovo_with_deplete-local.json
+++ b/test/input/WDL/test_outputs-assemble_denovo_with_deplete-local.json
@@ -2,7 +2,6 @@
     "assemble_denovo_with_deplete.assemble.subsample_read_count": 17402,
     "assemble_denovo_with_deplete.scaffold.assembly_preimpute_length_unambiguous": 18901,
     "assemble_denovo_with_deplete.scaffold.assembly_preimpute_length": 18901,
-    "assemble_denovo_with_deplete.refine_2x_and_plot.mean_coverage": 93.7324624289735,
     "assemble_denovo_with_deplete.refine_2x_and_plot.bases_aligned": 1765076,
     "assemble_denovo_with_deplete.refine_2x_and_plot.read_pairs_aligned": 16800,
     "assemble_denovo_with_deplete.refine_2x_and_plot.reads_aligned": 17476,

--- a/test/input/WDL/test_outputs-assemble_denovo_with_deplete-local.json
+++ b/test/input/WDL/test_outputs-assemble_denovo_with_deplete-local.json
@@ -1,0 +1,14 @@
+{
+    "assemble_denovo_with_deplete.assemble.subsample_read_count": 17402,
+    "assemble_denovo_with_deplete.scaffold.assembly_preimpute_length_unambiguous": 18901,
+    "assemble_denovo_with_deplete.scaffold.assembly_preimpute_length": 18901,
+    "assemble_denovo_with_deplete.refine_2x_and_plot.mean_coverage": 93.7324624289735,
+    "assemble_denovo_with_deplete.refine_2x_and_plot.bases_aligned": 1765076,
+    "assemble_denovo_with_deplete.refine_2x_and_plot.read_pairs_aligned": 16800,
+    "assemble_denovo_with_deplete.refine_2x_and_plot.reads_aligned": 17476,
+    "assemble_denovo_with_deplete.refine_2x_and_plot.assembly_length_unambiguous": 18831,
+    "assemble_denovo_with_deplete.refine_2x_and_plot.assembly_length": 18831,
+    "assemble_denovo_with_deplete.filter_to_taxon.filter_read_count_post": 18710,
+    "assemble_denovo_with_deplete.deplete_taxa.depletion_read_count_post": 18710,
+    "assemble_denovo_with_deplete.deplete_taxa.depletion_read_count_pre": 18710
+}

--- a/test/input/WDL/test_outputs-assemble_refbased-local.json
+++ b/test/input/WDL/test_outputs-assemble_refbased-local.json
@@ -1,0 +1,12 @@
+{
+  "assemble_refbased.plot_self_coverage.bases_aligned": 1765581,
+  "assemble_refbased.plot_self_coverage.read_pairs_aligned": 16798,
+  "assemble_refbased.plot_self_coverage.reads_aligned": 17481,
+  "assemble_refbased.plot_self_coverage.assembly_length": 18872,
+  "assemble_refbased.plot_ref_coverage.bases_aligned": 1800325,
+  "assemble_refbased.plot_ref_coverage.read_pairs_aligned": 17266,
+  "assemble_refbased.plot_ref_coverage.reads_aligned": 17825,
+  "assemble_refbased.plot_ref_coverage.assembly_length": 18959,
+  "assemble_refbased.call_consensus.assembly_length_unambiguous": 18872,
+  "assemble_refbased.call_consensus.assembly_length": 18872
+}

--- a/travis/install-conda.sh
+++ b/travis/install-conda.sh
@@ -1,10 +1,6 @@
 #!/bin/bash
 set -e
 
-# debug for now
-rm -rf "$MINICONDA_DIR" "$CONDA_DEFAULT_ENV" # remove the directory in case we have an empty cached directory
-
-
 # the miniconda directory may exist if it has been restored from cache
 if [ -d "$MINICONDA_DIR" ] && [ -e "$MINICONDA_DIR/bin/conda" ] && [ -d "$CONDA_DEFAULT_ENV" ]; then
     echo "Miniconda install already present from cache: $MINICONDA_DIR"

--- a/travis/install-conda.sh
+++ b/travis/install-conda.sh
@@ -13,14 +13,13 @@ if [ -d "$MINICONDA_DIR" ] && [ -e "$MINICONDA_DIR/bin/conda" ] && [ -d "$CONDA_
 else # if it does not exist, we need to install miniconda
     echo "Downloading conda to $MINICONDA_DIR"
     rm -rf "$MINICONDA_DIR" "$CONDA_DEFAULT_ENV" # remove the directory in case we have an empty cached directory
-    curl -S https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh > miniconda.sh;
-    mkdir -p "$MINICONDA_DIR"
+    curl -S https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh > miniconda.sh
     bash miniconda.sh -b -p "$MINICONDA_DIR"
     chown -R "$USER" "$MINICONDA_DIR"
     export PATH="$MINICONDA_DIR/bin:$PATH"
     hash -r
-    source "$MINICONDA_DIR/bin/activate"
-    conda init
+    #source "$MINICONDA_DIR/bin/activate"
+    #conda init
     #echo "Installing conda"
     #conda install -y conda==4.6.14 # specify "conda update -c conda-canary conda" for pre-release conda
     conda config --set always_yes yes --set changeps1 no --set remote_max_retries 6 #--set channel_priority strict

--- a/travis/install-conda.sh
+++ b/travis/install-conda.sh
@@ -19,6 +19,8 @@ else # if it does not exist, we need to install miniconda
     chown -R "$USER" "$MINICONDA_DIR"
     export PATH="$MINICONDA_DIR/bin:$PATH"
     hash -r
+    source "$MINICONDA_DIR/bin/activate"
+    conda init
     #echo "Installing conda"
     #conda install -y conda==4.6.14 # specify "conda update -c conda-canary conda" for pre-release conda
     conda config --set always_yes yes --set changeps1 no --set remote_max_retries 6 #--set channel_priority strict

--- a/travis/install-conda.sh
+++ b/travis/install-conda.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e
-rm -rf $MINICONDA_DIR
+
 # the miniconda directory may exist if it has been restored from cache
 if [ -d "$MINICONDA_DIR" ] && [ -e "$MINICONDA_DIR/bin/conda" ] && [ -d "$CONDA_DEFAULT_ENV" ]; then
     echo "Miniconda install already present from cache: $MINICONDA_DIR"

--- a/travis/install-conda.sh
+++ b/travis/install-conda.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 set -e
 
+# debug for now
+rm -rf "$MINICONDA_DIR" "$CONDA_DEFAULT_ENV" # remove the directory in case we have an empty cached directory
+
+
 # the miniconda directory may exist if it has been restored from cache
 if [ -d "$MINICONDA_DIR" ] && [ -e "$MINICONDA_DIR/bin/conda" ] && [ -d "$CONDA_DEFAULT_ENV" ]; then
     echo "Miniconda install already present from cache: $MINICONDA_DIR"

--- a/travis/install-conda.sh
+++ b/travis/install-conda.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e
-
+rm -rf $MINICONDA_DIR
 # the miniconda directory may exist if it has been restored from cache
 if [ -d "$MINICONDA_DIR" ] && [ -e "$MINICONDA_DIR/bin/conda" ] && [ -d "$CONDA_DEFAULT_ENV" ]; then
     echo "Miniconda install already present from cache: $MINICONDA_DIR"

--- a/travis/install-conda.sh
+++ b/travis/install-conda.sh
@@ -10,6 +10,7 @@ else # if it does not exist, we need to install miniconda
     echo "Downloading conda to $MINICONDA_DIR"
     rm -rf "$MINICONDA_DIR" "$CONDA_DEFAULT_ENV" # remove the directory in case we have an empty cached directory
     curl -S https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh > miniconda.sh;
+    mkdir -p "$MINICONDA_DIR"
     bash miniconda.sh -b -p "$MINICONDA_DIR"
     chown -R "$USER" "$MINICONDA_DIR"
     export PATH="$MINICONDA_DIR/bin:$PATH"

--- a/travis/install-conda.sh
+++ b/travis/install-conda.sh
@@ -33,5 +33,11 @@ fi
 
 echo "Activating conda environment: $CONDA_DEFAULT_ENV"
 source activate $CONDA_DEFAULT_ENV
+conda config --set always_yes yes --set changeps1 no --set remote_max_retries 6 #--set channel_priority strict
+conda config --add channels defaults
+conda config --add channels bioconda
+conda config --add channels conda-forge
+#conda config --add channels broad-viral
+conda config --show-sources # print channels
 # update certs
 conda info -a # for debugging

--- a/travis/tests-miniwdl.sh
+++ b/travis/tests-miniwdl.sh
@@ -16,8 +16,10 @@ for workflow in ../pipes/WDL/workflows/*.wdl; do
 		echo "Executing $workflow_name using miniWDL on local instance"
 		miniwdl run -i $input_json -d $workflow_name/. --error-json $workflow
 		if [ -f $workflow_name/outputs.json ]; then
+			echo "$workflow_name SUCCESS -- outputs:"
+			cat $workflow_name/outputs.json
 			if [ -f $expected_output_json ]; then
-				echo "$workflow_name SUCCESS -- validating outputs"
+				echo "$workflow_name -- validating outputs"
 				touch expected actual
 				for k in `cat $expected_output_json | jq -r 'keys[]'`; do
 					echo -n "$k=" >> expected
@@ -26,9 +28,6 @@ for workflow in ../pipes/WDL/workflows/*.wdl; do
 					cat $workflow_name/outputs.json | jq -r '.["'$k'"]' >> actual
 				done
 				diff expected actual
-			else
-				echo "$workflow_name SUCCESS -- outputs:"
-				cat $workflow_name/outputs.json
 			fi
 		else
 			echo "$workflow_name FAILED"

--- a/travis/tests-miniwdl.sh
+++ b/travis/tests-miniwdl.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e  # intentionally allow for pipe failures below
+set -e -o pipefail  # intentionally allow for pipe failures below
 
 mkdir -p workflows
 ln -s test workflows/
@@ -13,9 +13,17 @@ for workflow in ../pipes/WDL/workflows/*.wdl; do
 	if [ -f $input_json ]; then
 		date
 		echo "validating $workflow"
+		wfname=`basename $workflow`
 		miniwdl check $workflow
 		echo "Executing $workflow_name using miniWDL on local instance"
-		miniwdl run -i $input_json $workflow
+		miniwdl run -i $input_json -d $wfname/. $workflow
+		if [ -f $wfname/outputs.json ]; then
+			echo "$wfname SUCCESS -- outputs:"
+			cat $wfname/outputs.json
+		else
+			echo "$wfname FAILED"
+			exit 1
+		fi
     fi
 done
 

--- a/travis/tests-miniwdl.sh
+++ b/travis/tests-miniwdl.sh
@@ -23,7 +23,7 @@ for workflow in ../pipes/WDL/workflows/*.wdl; do
 					echo -n "$k=" >> expected
 					echo -n "$k=" >> actual
 					cat $expected_output_json       | jq -r '.["'$k'"]' >> expected
-					cat $workflow_name/outputs.json | jq -r '.outputs["'$k'"]' >> actual
+					cat $workflow_name/outputs.json | jq -r '.["'$k'"]' >> actual
 				done
 				diff expected actual
 			else

--- a/travis/tests-miniwdl.sh
+++ b/travis/tests-miniwdl.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -e  # intentionally allow for pipe failures below
+
+mkdir -p workflows
+ln -s test workflows/
+cd workflows
+
+miniwdl run_self_test
+
+for workflow in ../pipes/WDL/workflows/*.wdl; do
+	workflow_name=$(basename $workflow .wdl)
+	input_json="test/input/WDL/test_inputs-$workflow_name-local.json"
+	if [ -f $input_json ]; then
+		date
+		echo "validating $workflow"
+		miniwdl check $workflow
+		echo "Executing $workflow_name using miniWDL on local instance"
+		miniwdl run -i $input_json $workflow
+    fi
+done
+
+cd -
+date
+echo "note: there is no testing of output correctness yet..."

--- a/travis/tests-miniwdl.sh
+++ b/travis/tests-miniwdl.sh
@@ -1,10 +1,23 @@
 #!/bin/bash
 set -ex -o pipefail
 
-mkdir -p workflows
-cp -r test workflows/
-cd workflows
+starting_dir="$(pwd)"
+test_dir="miniwdl_testing"
 
+function cleanup(){
+    echo "Cleaning up from miniwdl run; exit code: $?"
+    cd "$starting_dir"
+    if [ -d "$test_dir" ]; then
+      rm -r "$test_dir"
+    fi
+}
+trap cleanup EXIT SIGINT SIGQUIT SIGTERM
+
+mkdir $test_dir
+cp -r test $test_dir
+cd $test_dir
+
+# make sure our system has everything it needs to perform "miniwdl run" (e.g. docker swarm works)
 miniwdl run_self_test
 
 for workflow in ../pipes/WDL/workflows/*.wdl; do
@@ -14,19 +27,27 @@ for workflow in ../pipes/WDL/workflows/*.wdl; do
 	if [ -f $input_json ]; then
 		date
 		echo "Executing $workflow_name using miniWDL on local instance"
-		miniwdl run -i $input_json -d $workflow_name/. --error-json $workflow
+		# the following invocation with -d $workflow_name/. tells miniwdl not to create
+		# a timestamped subdirectory within $workflow_name/
+		time miniwdl run -i $input_json -d $workflow_name/. --error-json $workflow
+		# the existence of $workflow_name/outputs.json is a guarantee of successful execution
 		if [ -f $workflow_name/outputs.json ]; then
 			echo "$workflow_name SUCCESS -- outputs:"
 			cat $workflow_name/outputs.json
 			if [ -f $expected_output_json ]; then
 				echo "$workflow_name -- validating outputs"
 				touch expected actual
+				# here we create a key=value text table for the output in "actual" for only the
+				# subset of keys that are specified in $expected_output_json, ignoring any
+				# of the actual output values that aren't specified there.
 				for k in `cat $expected_output_json | jq -r 'keys[]'`; do
 					echo -n "$k=" >> expected
 					echo -n "$k=" >> actual
 					cat $expected_output_json       | jq -r '.["'$k'"]' >> expected
 					cat $workflow_name/outputs.json | jq -r '.["'$k'"]' >> actual
 				done
+				# diff returns non-zero (and triggers failure by set -e) if these are non-equal
+				# and prints all differences between expected and actual for this workflow at the same time
 				diff expected actual
 			fi
 		else
@@ -36,5 +57,5 @@ for workflow in ../pipes/WDL/workflows/*.wdl; do
 	fi
 done
 
-cd -
+cd "$starting_dir"
 date

--- a/travis/tests-miniwdl.sh
+++ b/travis/tests-miniwdl.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
-set -e -o pipefail  # intentionally allow for pipe failures below
+set -ex -o pipefail
 
 mkdir -p workflows
-ln -s test workflows/
+cp -r test workflows/
 cd workflows
 
 miniwdl run_self_test
@@ -13,15 +13,14 @@ for workflow in ../pipes/WDL/workflows/*.wdl; do
 	if [ -f $input_json ]; then
 		date
 		echo "validating $workflow"
-		wfname=`basename $workflow`
 		miniwdl check $workflow
 		echo "Executing $workflow_name using miniWDL on local instance"
 		miniwdl run -i $input_json -d $wfname/. $workflow
-		if [ -f $wfname/outputs.json ]; then
-			echo "$wfname SUCCESS -- outputs:"
-			cat $wfname/outputs.json
+		if [ -f $workflow_name/outputs.json ]; then
+			echo "$workflow_name SUCCESS -- outputs:"
+			cat $workflow_name/outputs.json
 		else
-			echo "$wfname FAILED"
+			echo "$workflow_name FAILED"
 			exit 1
 		fi
     fi

--- a/travis/tests-miniwdl.sh
+++ b/travis/tests-miniwdl.sh
@@ -15,7 +15,7 @@ for workflow in ../pipes/WDL/workflows/*.wdl; do
 		echo "validating $workflow"
 		miniwdl check $workflow
 		echo "Executing $workflow_name using miniWDL on local instance"
-		miniwdl run -i $input_json -d $workflow_name/. $workflow
+		miniwdl run -i $input_json -d $workflow_name/. --verbose --error-json $workflow
 		if [ -f $workflow_name/outputs.json ]; then
 			echo "$workflow_name SUCCESS -- outputs:"
 			cat $workflow_name/outputs.json

--- a/travis/tests-miniwdl.sh
+++ b/travis/tests-miniwdl.sh
@@ -10,22 +10,32 @@ miniwdl run_self_test
 for workflow in ../pipes/WDL/workflows/*.wdl; do
 	workflow_name=$(basename $workflow .wdl)
 	input_json="test/input/WDL/test_inputs-$workflow_name-local.json"
+	expected_output_json="test/input/WDL/test_outputs-$workflow_name-local.json"
 	if [ -f $input_json ]; then
 		date
-		echo "validating $workflow"
-		miniwdl check $workflow
 		echo "Executing $workflow_name using miniWDL on local instance"
-		miniwdl run -i $input_json -d $workflow_name/. --verbose --error-json $workflow
+		miniwdl run -i $input_json -d $workflow_name/. --error-json $workflow
 		if [ -f $workflow_name/outputs.json ]; then
-			echo "$workflow_name SUCCESS -- outputs:"
-			cat $workflow_name/outputs.json
+			if [ -f $expected_output_json ]; then
+				echo "$workflow_name SUCCESS -- validating outputs"
+				touch expected actual
+				for k in `cat $expected_output_json | jq -r 'keys[]'`; do
+					echo -n "$k=" >> expected
+					echo -n "$k=" >> actual
+					cat $expected_output_json       | jq -r '.["'$k'"]' >> expected
+					cat $workflow_name/outputs.json | jq -r '.outputs["'$k'"]' >> actual
+				done
+				diff expected actual
+			else
+				echo "$workflow_name SUCCESS -- outputs:"
+				cat $workflow_name/outputs.json
+			fi
 		else
 			echo "$workflow_name FAILED"
 			exit 1
 		fi
-    fi
+	fi
 done
 
 cd -
 date
-echo "note: there is no testing of output correctness yet..."

--- a/travis/tests-miniwdl.sh
+++ b/travis/tests-miniwdl.sh
@@ -15,7 +15,7 @@ for workflow in ../pipes/WDL/workflows/*.wdl; do
 		echo "validating $workflow"
 		miniwdl check $workflow
 		echo "Executing $workflow_name using miniWDL on local instance"
-		miniwdl run -i $input_json -d $wfname/. $workflow
+		miniwdl run -i $input_json -d $workflow_name/. $workflow
 		if [ -f $workflow_name/outputs.json ]; then
 			echo "$workflow_name SUCCESS -- outputs:"
 			cat $workflow_name/outputs.json


### PR DESCRIPTION
This PR:
1. Turns on travis build stages, so that WDL validation is done (by both miniwdl and womtool) before any other travis jobs even launch
2. Introduces a `miniwdl run` based local (travis vm) integration test of all pipelines with `test/input/WDL/test_inputs-*-local.json` inputs, similar to the cromwell test stage
3. Introduces *output validation* of miniwdl outputs -- this is the first time we actually ensure that any WDL outputs are what they are supposed to be. This tests only a specified subset of outputs that are present in `test/input/WDL/test_outputs-*-local.json`. Any output variables and values specified there are required to be the same as what `miniwdl run` returns -- a `diff` will be printed to stdout if there are discrepancies. Longer term we should consider using [pytest-wdl](https://pytest-wdl.readthedocs.io/en/stable/manual.html) instead, but this isn't a bad step towards that.
4. Comment out cromwell-local travis job, since it seems to be decently slower (~50%?) than the miniwdl travis job and is a very similar test
5. Fix one bug in the MultiQC Task discovered via the above process (WDL task code should assume input Files are immutable, so this changes one `mv` command to an `ln -s`, this was not causing problems on DNAnexus or cromwell-local, but did cause errors on miniwdl and might cause errors on PAPI).