### PR TITLE
demux_plus multiqc outputs

### DIFF
--- a/pipes/WDL/tasks/tasks_reports.wdl
+++ b/pipes/WDL/tasks/tasks_reports.wdl
@@ -317,6 +317,10 @@ task MultiQC {
       ${"--cl-config " + config_yaml } \
       ${input_directory}
 
+      if [ -n "${file_name}" ]; then
+        mv "${file_name}" "${out_dir}/${file_name}"
+      fi
+
       tar -czvf "${report_filename}_data.tar.gz" "${out_dir}/${report_filename}_data"
   }
 

--- a/pipes/WDL/tasks/tasks_reports.wdl
+++ b/pipes/WDL/tasks/tasks_reports.wdl
@@ -317,16 +317,16 @@ task MultiQC {
       ${"--cl-config " + config_yaml } \
       ${input_directory}
 
-      if [ -n "${file_name}" ]; then
-        mv "${file_name}" "${out_dir}/${file_name}"
+      if [ -z "${file_name}" ]; then
+        mv "${out_dir}${report_filename}_report.html" "${out_dir}/${report_filename}.html"
       fi
 
       tar -czvf "${report_filename}_data.tar.gz" "${out_dir}/${report_filename}_data"
   }
 
   output {
-      File multiqc_report = out_dir + "/" + report_filename + "_report.html"
-      File multiqc_data_dir_tarball = report_filename + "_data.tar.gz"
+      File multiqc_report            = "${out_dir}/${report_filename}.html"
+      File multiqc_data_dir_tarball  = "${report_filename}_data.tar.gz"
   }
 
   runtime {

--- a/pipes/WDL/tasks/tasks_reports.wdl
+++ b/pipes/WDL/tasks/tasks_reports.wdl
@@ -318,7 +318,7 @@ task MultiQC {
       ${input_directory}
 
       if [ -z "${file_name}" ]; then
-        mv "${out_dir}${report_filename}_report.html" "${out_dir}/${report_filename}.html"
+        mv "${out_dir}/${report_filename}_report.html" "${out_dir}/${report_filename}.html"
       fi
 
       tar -czvf "${report_filename}_data.tar.gz" "${out_dir}/${report_filename}_data"

--- a/pipes/WDL/workflows/demux_plus.wdl
+++ b/pipes/WDL/workflows/demux_plus.wdl
@@ -39,13 +39,13 @@ workflow demux_plus {
     call reports.MultiQC as multiqc_raw {
         input:
             input_files = illumina_demux.raw_reads_fastqc_zip,
-            file_name   = "multiqc-raw"
+            file_name   = "multiqc-raw.html"
     }
 
     call reports.MultiQC as multiqc_cleaned {
         input:
             input_files = deplete.cleaned_fastqc_zip,
-            file_name   = "multiqc-cleaned"
+            file_name   = "multiqc-cleaned.html"
     }
 
     call metagenomics.krakenuniq as krakenuniq {

--- a/pipes/WDL/workflows/demux_plus.wdl
+++ b/pipes/WDL/workflows/demux_plus.wdl
@@ -38,12 +38,14 @@ workflow demux_plus {
 
     call reports.MultiQC as multiqc_raw {
         input:
-            input_files = illumina_demux.raw_reads_fastqc_zip
+            input_files = illumina_demux.raw_reads_fastqc_zip,
+            file_name   = "multiqc-raw"
     }
 
     call reports.MultiQC as multiqc_cleaned {
         input:
-            input_files = deplete.cleaned_fastqc_zip
+            input_files = deplete.cleaned_fastqc_zip,
+            file_name   = "multiqc-cleaned"
     }
 
     call metagenomics.krakenuniq as krakenuniq {


### PR DESCRIPTION
Give both multiqc reports distinct output filenames!

The demux_plus workflow has two calls to MultiQC: one summarizing reports on all raw reads and one on cleaned reads, but they had the same output file names (which gets confusing on dnanexus where all task outputs are in the same folder). This PR updates them to emit separate filenames.