### PR TITLE
parameterize runtime memory via machine_mem_gb input

### DIFF
--- a/pipes/WDL/tasks/tasks_assembly.wdl
+++ b/pipes/WDL/tasks/tasks_assembly.wdl
@@ -12,6 +12,7 @@ task assemble {
     # do this in two steps in case the input doesn't actually have "taxfilt" in the name
     String   sample_name = basename(basename(reads_unmapped_bam, ".bam"), ".taxfilt")
 
+    Int?     machine_mem_gb
     String?  docker="quay.io/broadinstitute/viral-assemble"
 
 
@@ -85,7 +86,7 @@ task assemble {
 
     runtime {
         docker: "${docker}"
-        memory: "15 GB"
+        memory: select_first([machine_mem_gb, 15]) + " GB"
         cpu: 4
         disks: "local-disk 375 LOCAL"
         dx_instance_type: "mem1_ssd1_v2_x8"
@@ -108,6 +109,7 @@ task scaffold {
     Int?         nucmer_min_cluster
     Float?       scaffold_min_pct_contig_aligned
 
+    Int?         machine_mem_gb
     String?      docker="quay.io/broadinstitute/viral-assemble"
 
     # do this in multiple steps in case the input doesn't actually have "assembly1-x" in the name
@@ -174,7 +176,7 @@ task scaffold {
 
     runtime {
         docker: "${docker}"
-        memory: "15 GB"
+        memory: select_first([machine_mem_gb, 15]) + " GB"
         cpu: 4
         disks: "local-disk 375 LOCAL"
         dx_instance_type: "mem1_ssd1_v2_x8"
@@ -188,6 +190,7 @@ task ivar_trim {
     Int?    sliding_window
     Int?    min_quality
 
+    Int?    machine_mem_gb
     String? docker="andersenlabapps/ivar:1.2.1"
 
     String  bam_basename=basename(aligned_bam, ".bam")
@@ -211,7 +214,7 @@ task ivar_trim {
 
     runtime {
         docker: "${docker}"
-        memory: "7 GB"
+        memory: select_first([machine_mem_gb, 7]) + " GB"
         cpu: 4
         disks: "local-disk 375 LOCAL"
         dx_instance_type: "mem1_ssd1_v2_x4"
@@ -228,6 +231,7 @@ task align_reads {
   String?  aligner_options
   Boolean? skip_mark_dupes=false
 
+  Int?     machine_mem_gb
   String?  docker="quay.io/broadinstitute/viral-core"
 
   String   sample_name = basename(basename(basename(reads_unmapped_bam, ".bam"), ".taxfilt"), ".clean")
@@ -303,7 +307,7 @@ task align_reads {
 
   runtime {
     docker: "${docker}"
-    memory: "7000 MB"
+    memory: select_first([machine_mem_gb, 7]) + " GB"
     cpu: 8
     disks: "local-disk 375 LOCAL"
     dx_instance_type: "mem1_ssd1_v2_x8"
@@ -320,6 +324,7 @@ task refine_assembly_with_aligned_reads {
     Float?   major_cutoff=0.5
     Int?     min_coverage=2
 
+    Int?     machine_mem_gb
     String?  docker="quay.io/broadinstitute/viral-assemble"
 
     command {
@@ -371,7 +376,7 @@ task refine_assembly_with_aligned_reads {
 
     runtime {
         docker: "${docker}"
-        memory: "7 GB"
+        memory: select_first([machine_mem_gb, 7]) + " GB"
         cpu: 8
         disks: "local-disk 375 LOCAL"
         dx_instance_type: "mem1_ssd1_v2_x8"
@@ -389,6 +394,7 @@ task refine {
     Float?  major_cutoff=0.5
     Int?    min_coverage=1
 
+    Int?    machine_mem_gb
     String? docker="quay.io/broadinstitute/viral-assemble"
 
     String  assembly_basename=basename(basename(assembly_fasta, ".fasta"), ".scaffold")
@@ -428,7 +434,7 @@ task refine {
 
     runtime {
         docker: "${docker}"
-        memory: "7 GB"
+        memory: select_first([machine_mem_gb, 7]) + " GB"
         cpu: 8
         disks: "local-disk 375 LOCAL"
         dx_instance_type: "mem1_ssd1_v2_x8"
@@ -460,6 +466,7 @@ task refine_2x_and_plot {
 
     String? plot_coverage_novoalign_options="-r Random -l 40 -g 40 -x 20 -t 100 -k"
 
+    Int?    machine_mem_gb
     String? docker="quay.io/broadinstitute/viral-assemble"
 
     # do this in two steps in case the input doesn't actually have "cleaned" in the name
@@ -572,7 +579,7 @@ task refine_2x_and_plot {
 
     runtime {
         docker: "${docker}"
-        memory: "7 GB"
+        memory: select_first([machine_mem_gb, 7]) + " GB"
         cpu: 8
         disks: "local-disk 375 LOCAL"
         dx_instance_type: "mem1_ssd1_v2_x8"

--- a/pipes/WDL/tasks/tasks_demux.wdl
+++ b/pipes/WDL/tasks/tasks_demux.wdl
@@ -2,6 +2,8 @@
 task merge_tarballs {
   Array[File]+  tar_chunks
   String        out_filename
+
+  Int?          machine_mem_gb
   String?       docker="quay.io/broadinstitute/viral-core"
 
   command {
@@ -25,7 +27,7 @@ task merge_tarballs {
 
   runtime {
     docker: "${docker}"
-    memory: "7 GB"
+    memory: select_first([machine_mem_gb, 7]) + " GB"
     cpu: 16
     disks: "local-disk 2625 LOCAL"
     dx_instance_type: "mem1_ssd2_v2_x16"
@@ -54,6 +56,7 @@ task illumina_demux {
   Int?    maxRecordsInRam
   Boolean? forceGC=true
 
+  Int?    machine_mem_gb
   String? docker="quay.io/broadinstitute/viral-core"
 
   command {
@@ -246,7 +249,7 @@ task illumina_demux {
 
   runtime {
     docker: "${docker}"
-    memory: "200 GB"
+    memory: select_first([machine_mem_gb, 240]) + " GB"
     cpu: 32
     disks: "local-disk 2625 LOCAL"
     dx_instance_type: "mem3_ssd2_v2_x32"

--- a/pipes/WDL/tasks/tasks_demux.wdl
+++ b/pipes/WDL/tasks/tasks_demux.wdl
@@ -249,7 +249,7 @@ task illumina_demux {
 
   runtime {
     docker: "${docker}"
-    memory: select_first([machine_mem_gb, 240]) + " GB"
+    memory: select_first([machine_mem_gb, 200]) + " GB"
     cpu: 32
     disks: "local-disk 2625 LOCAL"
     dx_instance_type: "mem3_ssd2_v2_x32"

--- a/pipes/WDL/tasks/tasks_interhost.wdl
+++ b/pipes/WDL/tasks/tasks_interhost.wdl
@@ -6,6 +6,8 @@ task multi_align_mafft_ref {
   Int?           mafft_maxIters
   Float?         mafft_ep
   Float?         mafft_gapOpeningPenalty
+
+  Int?           machine_mem_gb
   String?        docker="quay.io/broadinstitute/viral-phylo"
 
   command {
@@ -31,7 +33,7 @@ task multi_align_mafft_ref {
 
   runtime {
     docker: "${docker}"
-    memory: "28 GB"
+    memory: select_first([machine_mem_gb, 28]) + " GB"
     cpu: 8
     dx_instance_type: "mem2_ssd1_v2_x8"
   }
@@ -43,6 +45,8 @@ task multi_align_mafft {
   Int?           mafft_maxIters
   Float?         mafft_ep
   Float?         mafft_gapOpeningPenalty
+
+  Int?           machine_mem_gb
   String?        docker="quay.io/broadinstitute/viral-phylo"
 
   command {
@@ -68,7 +72,7 @@ task multi_align_mafft {
 
   runtime {
     docker: "${docker}"
-    memory: "7 GB"
+    memory: select_first([machine_mem_gb, 7]) + " GB"
     cpu: 8
     dx_instance_type: "mem1_ssd1_v2_x8"
   }
@@ -77,6 +81,8 @@ task multi_align_mafft {
 task index_ref {
   File     referenceGenome
   File?    novocraft_license
+
+  Int?     machine_mem_gb
   String?  docker="quay.io/broadinstitute/viral-core"
 
   command {
@@ -97,7 +103,7 @@ task index_ref {
   }
   runtime {
     docker: "${docker}"
-    memory: "4 GB"
+    memory: select_first([machine_mem_gb, 4]) + " GB"
   }
 }
 

--- a/pipes/WDL/tasks/tasks_intrahost.wdl
+++ b/pipes/WDL/tasks/tasks_intrahost.wdl
@@ -1,15 +1,16 @@
 
 task isnvs_per_sample {
-  File mapped_bam
-  File assembly_fasta
+  File    mapped_bam
+  File    assembly_fasta
 
-  Int? threads
-  Int? minReadsPerStrand
-  Int? maxBias
+  Int?    threads
+  Int?    minReadsPerStrand
+  Int?    maxBias
 
-  String?  docker="quay.io/broadinstitute/viral-phylo"
+  Int?    machine_mem_gb
+  String? docker="quay.io/broadinstitute/viral-phylo"
 
-  String sample_name = basename(basename(basename(mapped_bam, ".bam"), ".all"), ".mapped")
+  String  sample_name = basename(basename(basename(mapped_bam, ".bam"), ".all"), ".mapped")
 
   command {
     intrahost.py --version | tee VERSION
@@ -29,22 +30,24 @@ task isnvs_per_sample {
   }
   runtime {
     docker: "${docker}"
-    memory: "7 GB"
+    memory: select_first([machine_mem_gb, 7]) + " GB"
     dx_instance_type: "mem1_ssd1_v2_x8"
   }
 }
 
 
 task isnvs_vcf {
-  Array[File] vphaser2Calls # vphaser output; ex. vphaser2.${sample}.txt.gz
-  Array[File] perSegmentMultiAlignments # aligned_##.fasta, where ## is segment number
-  File reference_fasta
+  Array[File]    vphaser2Calls # vphaser output; ex. vphaser2.${sample}.txt.gz
+  Array[File]    perSegmentMultiAlignments # aligned_##.fasta, where ## is segment number
+  File           reference_fasta
 
   Array[String]? snpEffRef # list of accessions to build/find snpEff database
   Array[String]? sampleNames # list of sample names
-  String? emailAddress # email address passed to NCBI if we need to download reference sequences
-  Boolean naiveFilter=false
-  String? docker="quay.io/broadinstitute/viral-phylo"
+  String?        emailAddress # email address passed to NCBI if we need to download reference sequences
+  Boolean        naiveFilter=false
+
+  Int?           machine_mem_gb
+  String?        docker="quay.io/broadinstitute/viral-phylo"
 
   command {
     set -ex -o pipefail
@@ -90,7 +93,7 @@ task isnvs_vcf {
   }
   runtime {
     docker: "${docker}"
-    memory: "4 GB"
+    memory: select_first([machine_mem_gb, 4]) + " GB"
     dx_instance_type: "mem1_ssd1_v2_x4"
   }
 }

--- a/pipes/WDL/tasks/tasks_metagenomics.wdl
+++ b/pipes/WDL/tasks/tasks_metagenomics.wdl
@@ -3,7 +3,8 @@ task krakenuniq {
   File        krakenuniq_db_tar_lz4  # {database.kdb,taxonomy}
   File        krona_taxonomy_db_tgz  # taxonomy.tab
 
-  String?     docker="quay.io/broadinstitute/viral-classify"
+  Int?    machine_mem_gb
+  String? docker="quay.io/broadinstitute/viral-classify"
 
 #  parameter_meta {
 #    krakenuniq_db_tar_lz4: "stream"
@@ -84,7 +85,7 @@ task krakenuniq {
 
   runtime {
     docker: "${docker}"
-    memory: "240 GB"
+    memory: select_first([machine_mem_gb, 240]) + " GB"
     cpu: 32
     disks: "local-disk 375 LOCAL"
     dx_instance_type: "mem3_ssd1_v2_x32"
@@ -101,6 +102,8 @@ task build_krakenuniq_db {
   Int?        minimizerLen
   Int?        kmerLen
   Int?        maxDbSize
+
+  Int?        machine_mem_gb
   String?     docker="quay.io/broadinstitute/viral-classify"
 
   command {
@@ -145,7 +148,7 @@ task build_krakenuniq_db {
 
   runtime {
     docker: "${docker}"
-    memory: "240 GB"
+    memory: select_first([machine_mem_gb, 240]) + " GB"
     disks: "local-disk 375 LOCAL"
     cpu: 32
     dx_instance_type: "mem3_ssd1_v2_x32"
@@ -158,6 +161,7 @@ task kraken {
   File        kraken_db_tar_lz4      # {database.kdb,taxonomy}
   File        krona_taxonomy_db_tgz  # taxonomy.tab
 
+  Int?        machine_mem_gb
   String?     docker="quay.io/broadinstitute/viral-classify"
 
 #  parameter_meta {
@@ -225,7 +229,7 @@ task kraken {
 
   runtime {
     docker: "${docker}"
-    memory: "240 GB"
+    memory: select_first([machine_mem_gb, 240]) + " GB"
     cpu: 32
     disks: "local-disk 375 HDD"
     dx_instance_type: "mem3_ssd1_v2_x32"
@@ -242,6 +246,8 @@ task build_kraken_db {
   Int?        minimizerLen
   Int?        kmerLen
   Int?        maxDbSize
+
+  Int?        machine_mem_gb
   String?     docker="quay.io/broadinstitute/viral-classify"
 
   command {
@@ -286,7 +292,7 @@ task build_kraken_db {
 
   runtime {
     docker: "${docker}"
-    memory: "240 GB"
+    memory: select_first([machine_mem_gb, 240]) + " GB"
     disks: "local-disk 375 HDD"
     cpu: 32
     dx_instance_type: "mem3_ssd1_v2_x32"
@@ -303,6 +309,8 @@ task krona {
   Int?     taxid_column
   Int?     score_column
   Int?     magnitude_column
+
+  Int?     machine_mem_gb
   String?  docker="quay.io/broadinstitute/viral-classify"
 
   String  input_basename = basename(classified_reads_txt_gz, ".txt.gz")
@@ -339,7 +347,7 @@ task krona {
 
   runtime {
     docker: "${docker}"
-    memory: "3 GB"
+    memory: select_first([machine_mem_gb, 3]) + " GB"
     cpu: 1
     disks: "local-disk 50 HDD"
     dx_instance_type: "mem1_ssd2_v2_x2"
@@ -350,6 +358,7 @@ task krona_merge {
   Array[File]  krona_reports
   String       out_basename
 
+  Int?         machine_mem_gb
   String?      docker="biocontainers/krona:v2.7.1_cv1"
 
   command {
@@ -365,7 +374,7 @@ task krona_merge {
 
   runtime {
     docker: "${docker}"
-    memory: "3 GB"
+    memory: select_first([machine_mem_gb, 3]) + " GB"
     cpu: 1
     disks: "local-disk 50 HDD"
     dx_instance_type: "mem1_ssd2_v2_x2"
@@ -380,6 +389,7 @@ task filter_bam_to_taxa {
   Array[Int]?    taxonomic_ids
   Boolean?       withoutChildren=false
 
+  Int?           machine_mem_gb
   String?        docker="quay.io/broadinstitute/viral-classify"
 
   String         input_basename = basename(classified_bam, ".bam")
@@ -428,7 +438,7 @@ task filter_bam_to_taxa {
 
   runtime {
     docker: "${docker}"
-    memory: "4 GB"
+    memory: select_first([machine_mem_gb, 4]) + " GB"
     disks: "local-disk 375 LOCAL"
     cpu: 1
     dx_instance_type: "mem1_ssd2_v2_x2"
@@ -442,6 +452,7 @@ task kaiju {
   File     ncbi_taxonomy_db_tgz # taxonomy/{nodes.dmp, names.dmp}
   File     krona_taxonomy_db_tgz  # taxonomy/taxonomy.tab
 
+  Int?     machine_mem_gb
   String?  docker="quay.io/broadinstitute/viral-classify"
 
   String   input_basename = basename(reads_unmapped_bam, ".bam")
@@ -501,7 +512,7 @@ task kaiju {
 
   runtime {
     docker: "${docker}"
-    memory: "100 GB"
+    memory: select_first([machine_mem_gb, 100]) + " GB"
     cpu: 16
     disks: "local-disk 375 LOCAL"
     dx_instance_type: "mem3_ssd1_v2_x16"

--- a/pipes/WDL/tasks/tasks_metagenomics.wdl
+++ b/pipes/WDL/tasks/tasks_metagenomics.wdl
@@ -85,10 +85,10 @@ task krakenuniq {
 
   runtime {
     docker: "${docker}"
-    memory: select_first([machine_mem_gb, 240]) + " GB"
+    memory: select_first([machine_mem_gb, 320]) + " GB"
     cpu: 32
     disks: "local-disk 375 LOCAL"
-    dx_instance_type: "mem3_ssd1_v2_x32"
+    dx_instance_type: "mem3_ssd1_v2_x48"
     preemptible: 0
   }
 }
@@ -229,10 +229,10 @@ task kraken {
 
   runtime {
     docker: "${docker}"
-    memory: select_first([machine_mem_gb, 240]) + " GB"
+    memory: select_first([machine_mem_gb, 320]) + " GB"
     cpu: 32
     disks: "local-disk 375 HDD"
-    dx_instance_type: "mem3_ssd1_v2_x32"
+    dx_instance_type: "mem3_ssd1_v2_x48"
     preemptible: 0
   }
 }

--- a/pipes/WDL/tasks/tasks_ncbi.wdl
+++ b/pipes/WDL/tasks/tasks_ncbi.wdl
@@ -3,6 +3,8 @@ task download_fasta {
   String         out_prefix
   Array[String]+ accessions
   String         emailAddress
+
+  Int?           machine_mem_gb
   String?        docker="quay.io/broadinstitute/viral-phylo"
 
   command {
@@ -20,7 +22,7 @@ task download_fasta {
   }
   runtime {
     docker: "${docker}"
-    memory: "3 GB"
+    memory: select_first([machine_mem_gb, 3]) + " GB"
     cpu: 2
     dx_instance_type: "mem1_ssd1_v2_x2"
   }
@@ -30,6 +32,8 @@ task download_annotations {
   Array[String]+ accessions
   String         emailAddress
   String         combined_out_prefix
+
+  Int?           machine_mem_gb
   String?        docker="quay.io/broadinstitute/viral-phylo"
 
   command {
@@ -57,7 +61,7 @@ task download_annotations {
 
   runtime {
     docker: "${docker}"
-    memory: "3 GB"
+    memory: select_first([machine_mem_gb, 3]) + " GB"
     cpu: 2
     dx_instance_type: "mem1_ssd1_v2_x2"
   }
@@ -70,6 +74,7 @@ task annot_transfer {
 
   Array[Int]   chr_nums=range(length(multi_aln_fasta))
 
+  Int?         machine_mem_gb
   String?      docker="quay.io/broadinstitute/viral-phylo"
 
   command {
@@ -96,7 +101,7 @@ task annot_transfer {
   }
   runtime {
     docker: "${docker}"
-    memory: "3 GB"
+    memory: select_first([machine_mem_gb, 3]) + " GB"
     cpu: 2
     dx_instance_type: "mem1_ssd1_v2_x2"
   }
@@ -113,6 +118,8 @@ task prepare_genbank {
   String       comment # TO DO: make this optional
   String       organism
   String       molType = "cRNA"
+
+  Int?         machine_mem_gb
   String?      docker="quay.io/broadinstitute/viral-phylo"
 
   command {
@@ -147,7 +154,7 @@ task prepare_genbank {
 
   runtime {
     docker: "${docker}"
-    memory: "3 GB"
+    memory: select_first([machine_mem_gb, 3]) + " GB"
     cpu: 2
     dx_instance_type: "mem1_ssd1_v2_x2"
   }

--- a/pipes/WDL/tasks/tasks_ncbi_tools.wdl
+++ b/pipes/WDL/tasks/tasks_ncbi_tools.wdl
@@ -4,6 +4,8 @@ task Fetch_SRA_to_BAM {
 
     input {
         String  SRA_ID
+
+        Int?    machine_mem_gb
         String  docker = "quay.io/broadinstitute/ncbi-tools"
     }
 
@@ -66,7 +68,7 @@ task Fetch_SRA_to_BAM {
 
     runtime {
         cpu:     4
-        memory:  "15 GB"
+        memory:  select_first([machine_mem_gb, 15]) + " GB"
         disks:   "local-disk 750 LOCAL"
         dx_instance_type: "mem2_ssd1_v2_x4"
         docker:  "${docker}"

--- a/pipes/WDL/tasks/tasks_nextstrain.wdl
+++ b/pipes/WDL/tasks/tasks_nextstrain.wdl
@@ -26,6 +26,8 @@ task filter_segments {
         File  all_samples_fasta
         Int?  segment = 1
         File? pre_assembled_samples_fasta
+
+        Int? machine_mem_gb
     }
     command <<<
     python3 <<CODE
@@ -54,7 +56,7 @@ task filter_segments {
     >>>
     runtime {
         docker : "python"
-        memory : "3 GB"
+        memory : select_first([machine_mem_gb, 3]) + " GB"
         cpu :    1
         disks: "local-disk 375 LOCAL"
         dx_instance_type: "mem1_ssd1_v2_x2"
@@ -75,6 +77,7 @@ task augur_mafft_align {
         Boolean? fill_gaps = true
         Boolean? remove_reference = true
 
+        Int?     machine_mem_gb
         String   docker = "nextstrain/base"
     }
     command {
@@ -90,7 +93,7 @@ task augur_mafft_align {
     }
     runtime {
         docker: docker
-        memory: "104 GB"
+        memory: select_first([machine_mem_gb, 104]) + " GB"
         cpu :   16
         disks:  "local-disk 375 LOCAL"
         preemptible: 2
@@ -113,6 +116,7 @@ task draft_augur_tree {
         File?    exclude_sites
         File?    vcf_reference
 
+        Int?     machine_mem_gb
         String   docker = "nextstrain/base"
     }
     command {
@@ -126,7 +130,7 @@ task draft_augur_tree {
     }
     runtime {
         docker: docker
-        memory: "30 GB"
+        memory: select_first([machine_mem_gb, 30]) + " GB"
         cpu :   16
         disks:  "local-disk 375 LOCAL"
         dx_instance_type: "mem1_ssd1_v2_x16"
@@ -139,27 +143,28 @@ task draft_augur_tree {
 
 task refine_augur_tree {
     input {
-        File   raw_tree
-        File   aligned_fasta
-        File   metadata
-        String basename
+        File     raw_tree
+        File     aligned_fasta
+        File     metadata
+        String   basename
 
-        Int? gen_per_year
+        Int?     gen_per_year
         Boolean? clock_rate = false
         Boolean? clock_std_dev = false
         Boolean? keep_root = false
-        String? root
+        String?  root
         Boolean? covariance = false
         Boolean? no_covariance = false
         Boolean? keep_polytomies = false
-        Int? precision
+        Int?     precision
         Boolean? date_confidence = false
-        String? date_inference 
-        String? branch_length_inference
+        String?  date_inference 
+        String?  branch_length_inference
         Boolean? clock_filter_iqd = false
-        String? divergence_units
-        File? vcf_reference
+        String?  divergence_units
+        File?    vcf_reference
 
+        Int?     machine_mem_gb
         String   docker = "nextstrain/base"
     }
     command {
@@ -187,7 +192,7 @@ task refine_augur_tree {
     }
     runtime {
         docker: docker
-        memory: "30 GB"
+        memory: select_first([machine_mem_gb, 30]) + " GB"
         cpu :   16
         disks: "local-disk 375 LOCAL"
         dx_instance_type: "mem1_ssd1_v2_x16"
@@ -201,17 +206,18 @@ task refine_augur_tree {
 
 task ancestral_tree {
     input {
-        File refined_tree
-        File aligned_fasta
-        String basename
+        File     refined_tree
+        File     aligned_fasta
+        String   basename
 
-        String? inference
+        String?  inference
         Boolean? keep_ambiguous = false
         Boolean? infer_ambiguous = false
         Boolean? keep_overhangs = false
-        File? vcf_reference
-        File? output_vcf
+        File?    vcf_reference
+        File?    output_vcf
 
+        Int?     machine_mem_gb
         String   docker = "nextstrain/base"
     }
     command {
@@ -229,7 +235,7 @@ task ancestral_tree {
     }
     runtime {
         docker: docker
-        memory: "7 GB"
+        memory: select_first([machine_mem_gb, 7]) + " GB"
         cpu :   4
         disks: "local-disk 50 HDD"
         dx_instance_type: "mem1_ssd1_v2_x4"
@@ -252,7 +258,8 @@ task translate_augur_tree {
         File?  vcf_reference_output
         File?  vcf_reference
 
-        String   docker = "nextstrain/base"
+        Int?   machine_mem_gb
+        String docker = "nextstrain/base"
     }
     command {
         augur translate --tree ~{refined_tree} \
@@ -265,7 +272,7 @@ task translate_augur_tree {
     }
     runtime {
         docker: docker
-        memory: "3 GB"
+        memory: select_first([machine_mem_gb, 3]) + " GB"
         cpu :   2
         disks:  "local-disk 50 HDD"
         dx_instance_type: "mem1_ssd1_v2_x2"
@@ -286,7 +293,8 @@ task export_auspice_json {
         File   aa_muts
         String basename
 
-        String   docker = "nextstrain/base"
+        Int?   machine_mem_gb
+        String docker = "nextstrain/base"
     }
     command {
         augur export v2 --tree ~{refined_tree} \
@@ -297,7 +305,7 @@ task export_auspice_json {
     }
     runtime {
         docker: docker
-        memory: "3 GB"
+        memory: select_first([machine_mem_gb, 3]) + " GB"
         cpu :   2
         disks:  "local-disk 100 HDD"
         dx_instance_type: "mem1_ssd1_v2_x2"

--- a/pipes/WDL/tasks/tasks_read_utils.wdl
+++ b/pipes/WDL/tasks/tasks_read_utils.wdl
@@ -4,6 +4,8 @@ task merge_and_reheader_bams {
     String?         sample_name
     File?           reheader_table # tsv with 3 cols: field, old value, new value
     String          out_basename
+
+    Int?            machine_mem_gb
     String?         docker="quay.io/broadinstitute/viral-core"
 
     command {
@@ -45,7 +47,7 @@ task merge_and_reheader_bams {
 
     runtime {
         docker: "${docker}"
-        memory: "3 GB"
+        memory: select_first([machine_mem_gb, 3]) + " GB"
         cpu: 4
         disks: "local-disk 750 LOCAL"
         dx_instance_type: "mem1_ssd2_v2_x4"
@@ -59,6 +61,7 @@ task downsample_bams {
   Boolean?     deduplicateBefore=false
   Boolean?     deduplicateAfter=false
 
+  Int?         machine_mem_gb
   String?      docker="quay.io/broadinstitute/viral-core"
 
   command {
@@ -89,7 +92,7 @@ task downsample_bams {
   }
   runtime {
     docker: "${docker}"
-    memory: "3 GB"
+    memory: select_first([machine_mem_gb, 3]) + " GB"
     cpu:    4
     disks:  "local-disk 750 LOCAL"
     dx_instance_type: "mem1_ssd1_v2_x4"

--- a/pipes/WDL/tasks/tasks_reports.wdl
+++ b/pipes/WDL/tasks/tasks_reports.wdl
@@ -173,7 +173,7 @@ task spikein_report {
   }
 
   runtime {
-    memory: select_first([machine_mem_gb, 3]) + " GB"
+    memory: select_first([machine_mem_gb, 7]) + " GB"
     cpu: 2
     docker: "${docker}"
     disks: "local-disk 375 LOCAL"

--- a/pipes/WDL/tasks/tasks_reports.wdl
+++ b/pipes/WDL/tasks/tasks_reports.wdl
@@ -8,6 +8,7 @@ task plot_coverage {
   Boolean? bin_large_plots=false
   String?  binning_summary_statistic="max" # max or min
 
+  Int?     machine_mem_gb
   String?  docker="quay.io/broadinstitute/viral-core"
   
   command {
@@ -67,10 +68,10 @@ task plot_coverage {
 
   runtime {
     docker: "${docker}"
-    memory: "3500 MB"
+    memory: select_first([machine_mem_gb, 7]) + " GB"
     cpu: 2
     disks: "local-disk 375 LOCAL"
-    dx_instance_type: "mem1_ssd1_v2_x2"
+    dx_instance_type: "mem1_ssd1_v2_x4"
     preemptible: 1
   }
 }
@@ -80,6 +81,8 @@ task coverage_report {
   Array[File]+ mapped_bams
   Array[File]  mapped_bam_idx # optional.. speeds it up if you provide it, otherwise we auto-index
   String       out_report_name="coverage_report.txt"
+
+  Int?         machine_mem_gb
   String?      docker="quay.io/broadinstitute/viral-core"
 
   command {
@@ -97,7 +100,7 @@ task coverage_report {
 
   runtime {
     docker: "${docker}"
-    memory: "2000 MB"
+    memory: select_first([machine_mem_gb, 2]) + " GB"
     cpu: 2
     disks: "local-disk 375 LOCAL"
     dx_instance_type: "mem1_ssd2_v2_x4"
@@ -107,7 +110,10 @@ task coverage_report {
 
 task fastqc {
   File     reads_bam
+
+  Int?     machine_mem_gb
   String?  docker="quay.io/broadinstitute/viral-core"
+
   String   reads_basename=basename(reads_bam, ".bam")
 
   command {
@@ -123,7 +129,7 @@ task fastqc {
   }
 
   runtime {
-    memory: "2 GB"
+    memory: select_first([machine_mem_gb, 2]) + " GB"
     cpu: 1
     docker: "${docker}"
     disks: "local-disk 375 LOCAL"
@@ -138,6 +144,7 @@ task spikein_report {
   Int?    minScoreToFilter = 60
   Int?    topNHits = 3
 
+  Int?    machine_mem_gb
   String? docker="quay.io/broadinstitute/viral-core"
 
   String  reads_basename=basename(reads_bam, ".bam")
@@ -166,7 +173,7 @@ task spikein_report {
   }
 
   runtime {
-    memory: "3 GB"
+    memory: select_first([machine_mem_gb, 3]) + " GB"
     cpu: 2
     docker: "${docker}"
     disks: "local-disk 375 LOCAL"
@@ -176,6 +183,8 @@ task spikein_report {
 
 task spikein_summary {
   Array[File]+  spikein_count_txt
+
+  Int?          machine_mem_gb
   String?       docker="quay.io/broadinstitute/viral-core"
 
   command {
@@ -195,7 +204,7 @@ task spikein_summary {
   }
 
   runtime {
-    memory: "3 GB"
+    memory: select_first([machine_mem_gb, 3]) + " GB"
     cpu: 2
     docker: "${docker}"
     disks: "local-disk 50 SSD"
@@ -209,6 +218,7 @@ task aggregate_metagenomics_reports {
   String       aggregate_taxlevel_focus                 = "species" # species,genus,family,order,class,phylum,kingdom,superkingdom
   Int?         aggregate_top_N_hits                     = 5 # only include the top N hits from a given sample in the aggregte report
 
+  Int?         machine_mem_gb
   String?      docker="quay.io/broadinstitute/viral-classify"
 
   String       aggregate_taxon_heading = sub(aggregate_taxon_heading_space_separated, " ", "_") # replace spaces with underscores for use in filename
@@ -234,7 +244,7 @@ task aggregate_metagenomics_reports {
 
   runtime {
     docker: "${docker}"
-    memory: "4 GB"
+    memory: select_first([machine_mem_gb, 4]) + " GB"
     cpu: 1
     disks: "local-disk 50 SSD"
     dx_instance_type: "mem1_ssd2_v2_x2"
@@ -273,6 +283,7 @@ task MultiQC {
   File? config  # directory
   String? config_yaml
 
+  Int?   machine_mem_gb
   String docker = "ewels/multiqc:latest"
 
   String input_directory="multiqc-input"
@@ -330,7 +341,7 @@ task MultiQC {
   }
 
   runtime {
-    memory: "2 GB"
+    memory: select_first([machine_mem_gb, 2]) + " GB"
     cpu: 1
     docker: "${docker}"
     disks: "local-disk 375 LOCAL"

--- a/pipes/WDL/tasks/tasks_taxon_filter.wdl
+++ b/pipes/WDL/tasks/tasks_taxon_filter.wdl
@@ -180,6 +180,7 @@ task merge_one_per_sample {
   Array[File]+ inputBams
   Boolean?     rmdup=false
 
+  Int?         machine_mem_gb
   String?      docker="quay.io/broadinstitute/viral-core"
 
   command {

--- a/pipes/WDL/tasks/tasks_taxon_filter.wdl
+++ b/pipes/WDL/tasks/tasks_taxon_filter.wdl
@@ -12,6 +12,7 @@ task deplete_taxa {
   Boolean?     clear_tags = false
   String?      tags_to_clear_space_separated = "XT X0 X1 XA AM SM BQ CT XN OC OP"
 
+  Int?         machine_mem_gb
   String?      docker="quay.io/broadinstitute/viral-classify"
 
   String       bam_basename = basename(raw_reads_unmapped_bam, ".bam")
@@ -73,7 +74,7 @@ task deplete_taxa {
   }
   runtime {
     docker: "${docker}"
-    memory: "15 GB"
+    memory: select_first([machine_mem_gb, 15]) + " GB"
     cpu: 8
     disks: "local-disk 375 LOCAL"
     dx_instance_type: "mem1_ssd1_v2_x8"
@@ -94,6 +95,7 @@ task filter_to_taxon {
   Int?     negative_control_reads_threshold = 0
   String?  neg_control_prefixes_space_separated = "neg water NTC"
 
+  Int?     machine_mem_gb
   String?  docker="quay.io/broadinstitute/viral-classify"
 
   # do this in two steps in case the input doesn't actually have "cleaned" in the name
@@ -137,7 +139,7 @@ task filter_to_taxon {
   }
   runtime {
     docker: "${docker}"
-    memory: "14 GB"
+    memory: select_first([machine_mem_gb, 15]) + " GB"
     cpu: 16
     disks: "local-disk 375 LOCAL"
     dx_instance_type: "mem1_ssd1_v2_x8"
@@ -146,7 +148,10 @@ task filter_to_taxon {
 
 task build_lastal_db {
   File    sequences_fasta
+
+  Int?    machine_mem_gb
   String? docker="quay.io/broadinstitute/viral-classify"
+
   String  db_name = basename(sequences_fasta, ".fasta")
 
   command {
@@ -163,7 +168,7 @@ task build_lastal_db {
 
   runtime {
     docker: "${docker}"
-    memory: "7 GB"
+    memory: select_first([machine_mem_gb, 7]) + " GB"
     cpu: 2
     disks: "local-disk 375 LOCAL"
     dx_instance_type: "mem1_ssd1_v2_x4"
@@ -207,7 +212,7 @@ task merge_one_per_sample {
   }
 
   runtime{
-    memory: "7 GB"
+    memory: select_first([machine_mem_gb, 7]) + " GB"
     cpu: 4
     docker: "${docker}"
     disks: "local-disk 750 LOCAL"


### PR DESCRIPTION
parameterize runtime memory via the optional input `machine_mem_gb`, defaulting to the same hard-coded values before if `machine_mem_gb` is null. This also raises the memory value in a few places to be closer to the resources of the specified DNAnexus instances.