### PR TITLE
Port all WDLs to 1.0

### DIFF
--- a/pipes/WDL/tasks/tasks_assembly.wdl
+++ b/pipes/WDL/tasks/tasks_assembly.wdl
@@ -241,6 +241,10 @@ task ivar_trim {
 }
 
 task align_reads {
+  meta {
+    description: "Align unmapped reads to a reference genome, either using novoalign (default) or bwa. Produces an aligned bam file (including all unmapped reads), an aligned-only bam file, both sorted and indexed, along with samtools flagstat output, fastqc stats (on mapped only reads), and some basic figures of merit."
+  }
+
   input {
     File     reference_fasta
     File     reads_unmapped_bam
@@ -337,6 +341,10 @@ task align_reads {
 }
 
 task refine_assembly_with_aligned_reads {
+    meta {
+      description: "This step refines/polishes a genome based on short read alignments, producing a new consensus genome. Uses GATK3 Unified Genotyper to produce new consensus. Produces new genome (fasta), variant calls (VCF), and figures of merit."
+    }
+
     input {
       File     reference_fasta
       File     reads_aligned_bam
@@ -407,6 +415,10 @@ task refine_assembly_with_aligned_reads {
 }
 
 task refine {
+    meta {
+      description: "This step refines/polishes a genome based on unmapped short reads, aligning them (with either novoalign or bwa), and producing a new consensus genome. Uses GATK3 Unified Genotyper to produce new consensus. Produces new genome (fasta), variant calls (VCF), and figures of merit."
+    }
+
     input {
       File    assembly_fasta
       File    reads_unmapped_bam
@@ -468,7 +480,7 @@ task refine {
 
 task refine_2x_and_plot {
     meta {
-      description: "This combined task exists just to streamline the two calls to assembly.refine and one call to reports.plot_coverage that almost every assembly workflow uses. It saves on instance spin up and docker pull times, file staging time, and all steps contained here have similar hardware requirements. It is also extremely rare for analyses to branch off of intermediate products between these three steps. The more atomic WDL tasks are still available for custom workflows."
+      description: "This combined task exists just to streamline the two calls to assembly.refine and one call to reports.plot_coverage that many denovo assembly workflows use. It saves on instance spin up and docker pull times, file staging time, and all steps contained here have similar hardware requirements. The more atomic WDL tasks are still available for custom workflows (see refine, refine_assembly_with_aligned_reads, align_reads, etc)."
     }
 
     input {

--- a/pipes/WDL/tasks/tasks_demux.wdl
+++ b/pipes/WDL/tasks/tasks_demux.wdl
@@ -1,10 +1,13 @@
+version 1.0
 
 task merge_tarballs {
-  Array[File]+  tar_chunks
-  String        out_filename
+  input {
+    Array[File]+  tar_chunks
+    String        out_filename
 
-  Int?          machine_mem_gb
-  String?       docker="quay.io/broadinstitute/viral-core"
+    Int?          machine_mem_gb
+    String?       docker="quay.io/broadinstitute/viral-core"
+  }
 
   command {
     set -ex -o pipefail
@@ -36,28 +39,29 @@ task merge_tarballs {
 }
 
 task illumina_demux {
+  input {
+    File    flowcell_tgz
+    Int?    lane=1
+    File?   samplesheet
+    File?   runinfo
+    String? sequencingCenter
 
-  File    flowcell_tgz
-  Int?    lane=1
-  File?   samplesheet
-  File?   runinfo
-  String? sequencingCenter
+    String? flowcell
+    Int?    minimumBaseQuality = 10
+    Int?    maxMismatches = 0
+    Int?    minMismatchDelta
+    Int?    maxNoCalls
+    String? readStructure
+    Int?    minimumQuality
+    Int?    threads
+    String? runStartDate
+    Int?    maxReadsInRamPerTile
+    Int?    maxRecordsInRam
+    Boolean? forceGC=true
 
-  String? flowcell
-  Int?    minimumBaseQuality = 10
-  Int?    maxMismatches = 0
-  Int?    minMismatchDelta
-  Int?    maxNoCalls
-  String? readStructure
-  Int?    minimumQuality
-  Int?    threads
-  String? runStartDate
-  Int?    maxReadsInRamPerTile
-  Int?    maxRecordsInRam
-  Boolean? forceGC=true
-
-  Int?    machine_mem_gb
-  String? docker="quay.io/broadinstitute/viral-core"
+    Int?    machine_mem_gb
+    String? docker="quay.io/broadinstitute/viral-core"
+  }
 
   command {
     set -ex -o pipefail

--- a/pipes/WDL/tasks/tasks_interhost.wdl
+++ b/pipes/WDL/tasks/tasks_interhost.wdl
@@ -1,14 +1,17 @@
+version 1.0
 
 task multi_align_mafft_ref {
-  File           reference_fasta
-  Array[File]+   assemblies_fasta # fasta files, one per sample, multiple chrs per file okay
-  String         fasta_basename = basename(reference_fasta, '.fasta')
-  Int?           mafft_maxIters
-  Float?         mafft_ep
-  Float?         mafft_gapOpeningPenalty
+  input {
+    File           reference_fasta
+    Array[File]+   assemblies_fasta # fasta files, one per sample, multiple chrs per file okay
+    String         fasta_basename = basename(reference_fasta, '.fasta')
+    Int?           mafft_maxIters
+    Float?         mafft_ep
+    Float?         mafft_gapOpeningPenalty
 
-  Int?           machine_mem_gb
-  String?        docker="quay.io/broadinstitute/viral-phylo"
+    Int?           machine_mem_gb
+    String?        docker="quay.io/broadinstitute/viral-phylo"
+  }
 
   command {
     interhost.py --version | tee VERSION
@@ -40,14 +43,16 @@ task multi_align_mafft_ref {
 }
 
 task multi_align_mafft {
-  Array[File]+   assemblies_fasta # fasta files, one per sample, multiple chrs per file okay
-  String         out_prefix = "aligned"
-  Int?           mafft_maxIters
-  Float?         mafft_ep
-  Float?         mafft_gapOpeningPenalty
+  input {
+    Array[File]+   assemblies_fasta # fasta files, one per sample, multiple chrs per file okay
+    String         out_prefix = "aligned"
+    Int?           mafft_maxIters
+    Float?         mafft_ep
+    Float?         mafft_gapOpeningPenalty
 
-  Int?           machine_mem_gb
-  String?        docker="quay.io/broadinstitute/viral-phylo"
+    Int?           machine_mem_gb
+    String?        docker="quay.io/broadinstitute/viral-phylo"
+  }
 
   command {
     interhost.py --version | tee VERSION
@@ -79,11 +84,13 @@ task multi_align_mafft {
 }
 
 task index_ref {
-  File     referenceGenome
-  File?    novocraft_license
+  input {
+    File     referenceGenome
+    File?    novocraft_license
 
-  Int?     machine_mem_gb
-  String?  docker="quay.io/broadinstitute/viral-core"
+    Int?     machine_mem_gb
+    String?  docker="quay.io/broadinstitute/viral-core"
+  }
 
   command {
     read_utils.py --version | tee VERSION
@@ -108,12 +115,14 @@ task index_ref {
 }
 
 task trimal_clean_msa {
-  File     in_aligned_fasta
+  input {
+    File     in_aligned_fasta
 
-  Int?     machine_mem_gb
-  String?  docker="quay.io/biocontainers/trimal:1.4.1--h6bb024c_3"
+    Int?     machine_mem_gb
+    String?  docker="quay.io/biocontainers/trimal:1.4.1--h6bb024c_3"
 
-  String   input_basename = basename(basename(in_aligned_fasta, ".fasta"), ".fa")
+    String   input_basename = basename(basename(in_aligned_fasta, ".fasta"), ".fa")
+  }
 
   command {
     trimal -fasta -automated1 -in "${in_aligned_fasta}" -out "${input_basename}_trimal_cleaned.fasta"

--- a/pipes/WDL/tasks/tasks_intrahost.wdl
+++ b/pipes/WDL/tasks/tasks_intrahost.wdl
@@ -41,17 +41,25 @@ task isnvs_per_sample {
 
 task isnvs_vcf {
   input {
-    Array[File]    vphaser2Calls # vphaser output; ex. vphaser2.${sample}.txt.gz
-    Array[File]    perSegmentMultiAlignments # aligned_##.fasta, where ## is segment number
+    Array[File]    vphaser2Calls
+    Array[File]    perSegmentMultiAlignments
     File           reference_fasta
 
-    Array[String]? snpEffRef # list of accessions to build/find snpEff database
-    Array[String]? sampleNames # list of sample names
-    String?        emailAddress # email address passed to NCBI if we need to download reference sequences
+    Array[String]? snpEffRef
+    Array[String]? sampleNames
+    String?        emailAddress
     Boolean        naiveFilter=false
 
     Int?           machine_mem_gb
     String?        docker="quay.io/broadinstitute/viral-phylo"
+  }
+
+  parameter_meta {
+    vphaser2Calls:             { description: "vphaser output; ex. vphaser2.<sample>.txt.gz" }
+    perSegmentMultiAlignments: { description: "aligned_##.fasta, where ## is segment number" }
+    snpEffRef:                 { description: "list of accessions to build/find snpEff database" }
+    sampleNames:               { description: "list of sample names" }
+    emailAddress:              { description: "email address passed to NCBI if we need to download reference sequences" }
   }
 
   command {

--- a/pipes/WDL/tasks/tasks_intrahost.wdl
+++ b/pipes/WDL/tasks/tasks_intrahost.wdl
@@ -1,16 +1,19 @@
+version 1.0
 
 task isnvs_per_sample {
-  File    mapped_bam
-  File    assembly_fasta
+  input {
+    File    mapped_bam
+    File    assembly_fasta
 
-  Int?    threads
-  Int?    minReadsPerStrand
-  Int?    maxBias
+    Int?    threads
+    Int?    minReadsPerStrand
+    Int?    maxBias
 
-  Int?    machine_mem_gb
-  String? docker="quay.io/broadinstitute/viral-phylo"
+    Int?    machine_mem_gb
+    String? docker="quay.io/broadinstitute/viral-phylo"
 
-  String  sample_name = basename(basename(basename(mapped_bam, ".bam"), ".all"), ".mapped")
+    String  sample_name = basename(basename(basename(mapped_bam, ".bam"), ".all"), ".mapped")
+  }
 
   command {
     intrahost.py --version | tee VERSION
@@ -37,17 +40,19 @@ task isnvs_per_sample {
 
 
 task isnvs_vcf {
-  Array[File]    vphaser2Calls # vphaser output; ex. vphaser2.${sample}.txt.gz
-  Array[File]    perSegmentMultiAlignments # aligned_##.fasta, where ## is segment number
-  File           reference_fasta
+  input {
+    Array[File]    vphaser2Calls # vphaser output; ex. vphaser2.${sample}.txt.gz
+    Array[File]    perSegmentMultiAlignments # aligned_##.fasta, where ## is segment number
+    File           reference_fasta
 
-  Array[String]? snpEffRef # list of accessions to build/find snpEff database
-  Array[String]? sampleNames # list of sample names
-  String?        emailAddress # email address passed to NCBI if we need to download reference sequences
-  Boolean        naiveFilter=false
+    Array[String]? snpEffRef # list of accessions to build/find snpEff database
+    Array[String]? sampleNames # list of sample names
+    String?        emailAddress # email address passed to NCBI if we need to download reference sequences
+    Boolean        naiveFilter=false
 
-  Int?           machine_mem_gb
-  String?        docker="quay.io/broadinstitute/viral-phylo"
+    Int?           machine_mem_gb
+    String?        docker="quay.io/broadinstitute/viral-phylo"
+  }
 
   command {
     set -ex -o pipefail

--- a/pipes/WDL/tasks/tasks_metagenomics.wdl
+++ b/pipes/WDL/tasks/tasks_metagenomics.wdl
@@ -1,15 +1,14 @@
+version 1.0
+
 task krakenuniq {
-  Array[File] reads_unmapped_bam
-  File        krakenuniq_db_tar_lz4  # {database.kdb,taxonomy}
-  File        krona_taxonomy_db_tgz  # taxonomy.tab
+  input {
+    Array[File] reads_unmapped_bam
+    File        krakenuniq_db_tar_lz4  # {database.kdb,taxonomy}
+    File        krona_taxonomy_db_tgz  # taxonomy.tab
 
-  Int?    machine_mem_gb
-  String? docker="quay.io/broadinstitute/viral-classify"
-
-#  parameter_meta {
-#    krakenuniq_db_tar_lz4: "stream"
-#    krona_taxonomy_db_tgz: "stream"
-#  }
+    Int?        machine_mem_gb
+    String?     docker="quay.io/broadinstitute/viral-classify"
+  }
 
   command {
     set -ex -o pipefail
@@ -94,17 +93,19 @@ task krakenuniq {
 }
 
 task build_krakenuniq_db {
-  File        genome_fastas_tarball
-  File        taxonomy_db_tarball
-  String      db_basename
+  input {
+    File        genome_fastas_tarball
+    File        taxonomy_db_tarball
+    String      db_basename
 
-  Boolean?    subsetTaxonomy
-  Int?        minimizerLen
-  Int?        kmerLen
-  Int?        maxDbSize
+    Boolean?    subsetTaxonomy
+    Int?        minimizerLen
+    Int?        kmerLen
+    Int?        maxDbSize
 
-  Int?        machine_mem_gb
-  String?     docker="quay.io/broadinstitute/viral-classify"
+    Int?        machine_mem_gb
+    String?     docker="quay.io/broadinstitute/viral-classify"
+  }
 
   command {
     set -ex -o pipefail
@@ -157,17 +158,14 @@ task build_krakenuniq_db {
 }
 
 task kraken {
-  Array[File] reads_unmapped_bam
-  File        kraken_db_tar_lz4      # {database.kdb,taxonomy}
-  File        krona_taxonomy_db_tgz  # taxonomy.tab
+  input {
+    Array[File] reads_unmapped_bam
+    File        kraken_db_tar_lz4      # {database.kdb,taxonomy}
+    File        krona_taxonomy_db_tgz  # taxonomy.tab
 
-  Int?        machine_mem_gb
-  String?     docker="quay.io/broadinstitute/viral-classify"
-
-#  parameter_meta {
-#    kraken_db_tar_lz4:     "stream"
-#    krona_taxonomy_db_tgz: "stream"
-#  }
+    Int?        machine_mem_gb
+    String?     docker="quay.io/broadinstitute/viral-classify"
+  }
 
   command {
     set -ex -o pipefail
@@ -238,17 +236,19 @@ task kraken {
 }
 
 task build_kraken_db {
-  File        genome_fastas_tarball
-  File        taxonomy_db_tarball
-  String      db_basename
+  input {
+    File        genome_fastas_tarball
+    File        taxonomy_db_tarball
+    String      db_basename
 
-  Boolean?    subsetTaxonomy
-  Int?        minimizerLen
-  Int?        kmerLen
-  Int?        maxDbSize
+    Boolean?    subsetTaxonomy
+    Int?        minimizerLen
+    Int?        kmerLen
+    Int?        maxDbSize
 
-  Int?        machine_mem_gb
-  String?     docker="quay.io/broadinstitute/viral-classify"
+    Int?        machine_mem_gb
+    String?     docker="quay.io/broadinstitute/viral-classify"
+  }
 
   command {
     set -ex -o pipefail
@@ -301,17 +301,19 @@ task build_kraken_db {
 }
 
 task krona {
-  File     classified_reads_txt_gz
-  File     krona_taxonomy_db_tgz
+  input {
+    File     classified_reads_txt_gz
+    File     krona_taxonomy_db_tgz
 
-  String?  input_type
-  Int?     query_column
-  Int?     taxid_column
-  Int?     score_column
-  Int?     magnitude_column
+    String?  input_type
+    Int?     query_column
+    Int?     taxid_column
+    Int?     score_column
+    Int?     magnitude_column
 
-  Int?     machine_mem_gb
-  String?  docker="quay.io/broadinstitute/viral-classify"
+    Int?     machine_mem_gb
+    String?  docker="quay.io/broadinstitute/viral-classify"
+  }
 
   String  input_basename = basename(classified_reads_txt_gz, ".txt.gz")
 
@@ -355,11 +357,13 @@ task krona {
 }
 
 task krona_merge {
-  Array[File]  krona_reports
-  String       out_basename
+  input {
+    Array[File]  krona_reports
+    String       out_basename
 
-  Int?         machine_mem_gb
-  String?      docker="biocontainers/krona:v2.7.1_cv1"
+    Int?         machine_mem_gb
+    String?      docker="biocontainers/krona:v2.7.1_cv1"
+  }
 
   command {
     set -ex -o pipefail
@@ -382,21 +386,19 @@ task krona_merge {
 }
 
 task filter_bam_to_taxa {
-  File           classified_bam
-  File           classified_reads_txt_gz
-  File           ncbi_taxonomy_db_tgz # nodes.dmp names.dmp
-  Array[String]? taxonomic_names
-  Array[Int]?    taxonomic_ids
-  Boolean?       withoutChildren=false
+  input {
+    File           classified_bam
+    File           classified_reads_txt_gz
+    File           ncbi_taxonomy_db_tgz # nodes.dmp names.dmp
+    Array[String]? taxonomic_names
+    Array[Int]?    taxonomic_ids
+    Boolean?       withoutChildren=false
 
-  Int?           machine_mem_gb
-  String?        docker="quay.io/broadinstitute/viral-classify"
+    Int?           machine_mem_gb
+    String?        docker="quay.io/broadinstitute/viral-classify"
+  }
 
   String         input_basename = basename(classified_bam, ".bam")
-
-#  parameter_meta {
-#    ncbi_taxonomy_db_tgz: "stream"
-#  }
 
   command {
     set -ex -o pipefail
@@ -447,21 +449,17 @@ task filter_bam_to_taxa {
 }
 
 task kaiju {
-  File     reads_unmapped_bam
-  File     kaiju_db_lz4  # <something>.fmi
-  File     ncbi_taxonomy_db_tgz # taxonomy/{nodes.dmp, names.dmp}
-  File     krona_taxonomy_db_tgz  # taxonomy/taxonomy.tab
+  input {
+    File     reads_unmapped_bam
+    File     kaiju_db_lz4  # <something>.fmi
+    File     ncbi_taxonomy_db_tgz # taxonomy/{nodes.dmp, names.dmp}
+    File     krona_taxonomy_db_tgz  # taxonomy/taxonomy.tab
 
-  Int?     machine_mem_gb
-  String?  docker="quay.io/broadinstitute/viral-classify"
+    Int?     machine_mem_gb
+    String?  docker="quay.io/broadinstitute/viral-classify"
+  }
 
   String   input_basename = basename(reads_unmapped_bam, ".bam")
-
-#  parameter_meta {
-#    kaiju_db_lz4            : "stream" # for DNAnexus, until WDL implements the File| type
-#    ncbi_taxonomy_db_tgz    : "stream"
-#    krona_taxonomy_db_tgz   : "stream"
-#  }
 
   command {
     set -ex -o pipefail

--- a/pipes/WDL/tasks/tasks_ncbi.wdl
+++ b/pipes/WDL/tasks/tasks_ncbi.wdl
@@ -75,14 +75,20 @@ task download_annotations {
 
 task annot_transfer {
   input {
-    Array[File]+ multi_aln_fasta         # fasta; multiple alignments of sample sequences for each chromosome
-    File         reference_fasta         # fasta; all chromosomes in one file
-    Array[File]+ reference_feature_table # tbl; feature table corresponding to each chromosome in the alignment
-
-    Array[Int]   chr_nums=range(length(multi_aln_fasta))
+    Array[File]+ multi_aln_fasta
+    File         reference_fasta
+    Array[File]+ reference_feature_table
 
     Int?         machine_mem_gb
     String?      docker="quay.io/broadinstitute/viral-phylo"
+  }
+
+  Array[Int]   chr_nums=range(length(multi_aln_fasta))
+
+  parameter_meta {
+    multi_aln_fasta:         { description: "fasta; multiple alignments of sample sequences for each chromosome" }
+    reference_fasta:         { description: "fasta; all chromosomes in one file" }
+    reference_feature_table: { description: "tbl; feature table corresponding to each chromosome in the alignment" }
   }
 
   command {

--- a/pipes/WDL/tasks/tasks_ncbi.wdl
+++ b/pipes/WDL/tasks/tasks_ncbi.wdl
@@ -1,11 +1,14 @@
+version 1.0
 
 task download_fasta {
-  String         out_prefix
-  Array[String]+ accessions
-  String         emailAddress
+  input {
+    String         out_prefix
+    Array[String]+ accessions
+    String         emailAddress
 
-  Int?           machine_mem_gb
-  String?        docker="quay.io/broadinstitute/viral-phylo"
+    Int?           machine_mem_gb
+    String?        docker="quay.io/broadinstitute/viral-phylo"
+  }
 
   command {
     ncbi.py --version | tee VERSION
@@ -20,6 +23,7 @@ task download_fasta {
     File   sequences_fasta  = "${out_prefix}.fasta"
     String viralngs_version = read_string("VERSION")
   }
+
   runtime {
     docker: "${docker}"
     memory: select_first([machine_mem_gb, 3]) + " GB"
@@ -29,12 +33,14 @@ task download_fasta {
 }
 
 task download_annotations {
-  Array[String]+ accessions
-  String         emailAddress
-  String         combined_out_prefix
+  input {
+    Array[String]+ accessions
+    String         emailAddress
+    String         combined_out_prefix
 
-  Int?           machine_mem_gb
-  String?        docker="quay.io/broadinstitute/viral-phylo"
+    Int?           machine_mem_gb
+    String?        docker="quay.io/broadinstitute/viral-phylo"
+  }
 
   command {
     set -ex -o pipefail
@@ -68,14 +74,16 @@ task download_annotations {
 }
 
 task annot_transfer {
-  Array[File]+ multi_aln_fasta         # fasta; multiple alignments of sample sequences for each chromosome
-  File         reference_fasta         # fasta; all chromosomes in one file
-  Array[File]+ reference_feature_table # tbl; feature table corresponding to each chromosome in the alignment
+  input {
+    Array[File]+ multi_aln_fasta         # fasta; multiple alignments of sample sequences for each chromosome
+    File         reference_fasta         # fasta; all chromosomes in one file
+    Array[File]+ reference_feature_table # tbl; feature table corresponding to each chromosome in the alignment
 
-  Array[Int]   chr_nums=range(length(multi_aln_fasta))
+    Array[Int]   chr_nums=range(length(multi_aln_fasta))
 
-  Int?         machine_mem_gb
-  String?      docker="quay.io/broadinstitute/viral-phylo"
+    Int?         machine_mem_gb
+    String?      docker="quay.io/broadinstitute/viral-phylo"
+  }
 
   command {
     set -ex -o pipefail
@@ -99,6 +107,7 @@ task annot_transfer {
     Array[File] transferred_feature_tables = glob("*.tbl")
     String      viralngs_version           = read_string("VERSION")
   }
+
   runtime {
     docker: "${docker}"
     memory: select_first([machine_mem_gb, 3]) + " GB"
@@ -108,19 +117,21 @@ task annot_transfer {
 }
 
 task prepare_genbank {
-  Array[File]+ assemblies_fasta
-  Array[File]  annotations_tbl
-  File         authors_sbt
-  File         biosampleMap
-  File         genbankSourceTable
-  File?        coverage_table # summary.assembly.txt (from Snakemake) -- change this to accept a list of mapped bam files and we can create this table ourselves
-  String       sequencingTech
-  String       comment # TO DO: make this optional
-  String       organism
-  String       molType = "cRNA"
+  input {
+    Array[File]+ assemblies_fasta
+    Array[File]  annotations_tbl
+    File         authors_sbt
+    File         biosampleMap
+    File         genbankSourceTable
+    File?        coverage_table # summary.assembly.txt (from Snakemake) -- change this to accept a list of mapped bam files and we can create this table ourselves
+    String       sequencingTech
+    String       comment # TO DO: make this optional
+    String       organism
+    String       molType = "cRNA"
 
-  Int?         machine_mem_gb
-  String?      docker="quay.io/broadinstitute/viral-phylo"
+    Int?         machine_mem_gb
+    String?      docker="quay.io/broadinstitute/viral-phylo"
+  }
 
   command {
     set -ex -o pipefail
@@ -159,5 +170,3 @@ task prepare_genbank {
     dx_instance_type: "mem1_ssd1_v2_x2"
   }
 }
-
-

--- a/pipes/WDL/tasks/tasks_read_utils.wdl
+++ b/pipes/WDL/tasks/tasks_read_utils.wdl
@@ -1,12 +1,15 @@
+version 1.0
 
 task merge_and_reheader_bams {
-    Array[File]+    in_bams
-    String?         sample_name
-    File?           reheader_table # tsv with 3 cols: field, old value, new value
-    String          out_basename
+    input {
+      Array[File]+    in_bams
+      String?         sample_name
+      File?           reheader_table # tsv with 3 cols: field, old value, new value
+      String          out_basename
 
-    Int?            machine_mem_gb
-    String?         docker="quay.io/broadinstitute/viral-core"
+      Int?            machine_mem_gb
+      String?         docker="quay.io/broadinstitute/viral-core"
+    }
 
     command {
         set -ex -o pipefail
@@ -56,13 +59,15 @@ task merge_and_reheader_bams {
 }
 
 task downsample_bams {
-  Array[File]  reads_bam
-  Int?         readCount
-  Boolean?     deduplicateBefore=false
-  Boolean?     deduplicateAfter=false
+  input {
+    Array[File]  reads_bam
+    Int?         readCount
+    Boolean?     deduplicateBefore=false
+    Boolean?     deduplicateAfter=false
 
-  Int?         machine_mem_gb
-  String?      docker="quay.io/broadinstitute/viral-core"
+    Int?         machine_mem_gb
+    String?      docker="quay.io/broadinstitute/viral-core"
+  }
 
   command {
     if [[ "${deduplicateBefore}" == "true" ]]; then
@@ -90,6 +95,7 @@ task downsample_bams {
     Array[File] downsampled_bam  = glob("output/*.downsampled-*.bam")
     String      viralngs_version = read_string("VERSION")
   }
+
   runtime {
     docker: "${docker}"
     memory: select_first([machine_mem_gb, 3]) + " GB"
@@ -98,5 +104,3 @@ task downsample_bams {
     dx_instance_type: "mem1_ssd1_v2_x4"
   }
 }
-
-

--- a/pipes/WDL/tasks/tasks_read_utils.wdl
+++ b/pipes/WDL/tasks/tasks_read_utils.wdl
@@ -21,7 +21,7 @@ task merge_and_reheader_bams {
             read_utils.py merge_bams ${sep=' ' in_bams} merged.bam --JVMmemory="$mem_in_mb"m --loglevel DEBUG
         else
             echo "Skipping merge, only one input file"
-            cp ${select_first(in_bams)} merged.bam
+            cp ${sep=' ' in_bams} merged.bam
         fi    
 
         # remap all SM values to user specified value

--- a/pipes/WDL/tasks/tasks_read_utils.wdl
+++ b/pipes/WDL/tasks/tasks_read_utils.wdl
@@ -1,10 +1,14 @@
 version 1.0
 
 task merge_and_reheader_bams {
+    meta {
+      description: "Merge and/or reheader bam files using a mapping table. This task can modify read group tags in a BAM header field for single BAM files or as part of a BAM merge operation. The output is a single BAM file (given one or more input BAMs) and a three-column tab delimited text table that defines: the field, the old value, and the new value (e.g. LB, old_lib_name, new_lib_name or SM, old_sample_name, new_sample_name)"
+    }
+
     input {
       Array[File]+    in_bams
       String?         sample_name
-      File?           reheader_table # tsv with 3 cols: field, old value, new value
+      File?           reheader_table
       String          out_basename
 
       Int?            machine_mem_gb
@@ -59,6 +63,10 @@ task merge_and_reheader_bams {
 }
 
 task downsample_bams {
+  meta {
+    description: "Downsample reads in a BAM file randomly subsampling to a target read count. Read deduplication can occur either before or after random subsampling, or not at all (default: not at all)."
+  }
+
   input {
     Array[File]  reads_bam
     Int?         readCount

--- a/pipes/WDL/tasks/tasks_reports.wdl
+++ b/pipes/WDL/tasks/tasks_reports.wdl
@@ -224,15 +224,21 @@ task spikein_summary {
 task aggregate_metagenomics_reports {
   input {
     Array[File]+ kraken_summary_reports 
-    String       aggregate_taxon_heading_space_separated  = "Viruses" # The taxonomic heading to analyze. More than one can be specified.
-    String       aggregate_taxlevel_focus                 = "species" # species,genus,family,order,class,phylum,kingdom,superkingdom
-    Int?         aggregate_top_N_hits                     = 5 # only include the top N hits from a given sample in the aggregte report
+    String       aggregate_taxon_heading_space_separated  = "Viruses"
+    String       aggregate_taxlevel_focus                 = "species"
+    Int?         aggregate_top_N_hits                     = 5
 
     Int?         machine_mem_gb
     String?      docker="quay.io/broadinstitute/viral-classify"
-
-    String       aggregate_taxon_heading = sub(aggregate_taxon_heading_space_separated, " ", "_") # replace spaces with underscores for use in filename
   }
+
+  parameter_meta {
+    aggregate_taxon_heading_space_separated: { description: "The taxonomic heading to analyze. More than one can be specified." }
+    aggregate_taxlevel_focus:                { description: "species,genus,family,order,class,phylum,kingdom,superkingdom" }
+    aggregate_top_N_hits:                    { description: "only include the top N hits from a given sample in the aggregate report" }
+  }
+
+  String       aggregate_taxon_heading = sub(aggregate_taxon_heading_space_separated, " ", "_") # replace spaces with underscores for use in filename
 
   command {
     set -ex -o pipefail
@@ -265,38 +271,43 @@ task aggregate_metagenomics_reports {
 
 task MultiQC {
   input {
-    Array[File] input_files = []
-    Boolean force = false
-    Boolean dirs = false
-    Int? dirs_depth
-    Boolean full_names = false
-    String? title
-    String? comment
-    String? file_name
-    String out_dir = "./multiqc-output"
-    String? template
-    String? tag
-    String? ignore_analysis_files
-    String? ignore_sample_names
-    File? sample_names
-    File? file_with_list_of_input_paths
+    Array[File]     input_files = []
+
+    Boolean         force = false
+    Boolean         dirs = false
+    Int?            dirs_depth
+    Boolean         full_names = false
+    String?         title
+    String?         comment
+    String?         file_name
+    String          out_dir = "./multiqc-output"
+    String?         template
+    String?         tag
+    String?         ignore_analysis_files
+    String?         ignore_sample_names
+    File?           sample_names
+    File?           file_with_list_of_input_paths
     Array[String]+? exclude_modules
     Array[String]+? module_to_use
-    Boolean data_dir = false
-    Boolean no_data_dir = false
-    String? output_data_format # [tsv|yaml|json] default:tsv
-    Boolean zip_data_dir = false
-    Boolean export = false
-    Boolean flat = false
-    Boolean interactive = true
-    Boolean lint = false
-    Boolean pdf = false
-    Boolean megaQC_upload = false # Upload generated report to MegaQC if MegaQC options are found
-    File? config  # directory
-    String? config_yaml
+    Boolean         data_dir = false
+    Boolean         no_data_dir = false
+    String?         output_data_format
+    Boolean         zip_data_dir = false
+    Boolean         export = false
+    Boolean         flat = false
+    Boolean         interactive = true
+    Boolean         lint = false
+    Boolean         pdf = false
+    Boolean         megaQC_upload = false # Upload generated report to MegaQC if MegaQC options are found
+    File?           config  # directory
+    String?         config_yaml
 
-    Int?   machine_mem_gb
-    String docker = "ewels/multiqc:latest"
+    Int?            machine_mem_gb
+    String          docker = "ewels/multiqc:latest"
+  }
+
+  parameter_meta {
+    output_data_format: { description: "[tsv|yaml|json] default:tsv" }
   }
 
   String input_directory="multiqc-input"

--- a/pipes/WDL/tasks/tasks_reports.wdl
+++ b/pipes/WDL/tasks/tasks_reports.wdl
@@ -1,15 +1,18 @@
+version 1.0
 
 task plot_coverage {
-  File     aligned_reads_bam
-  String   sample_name
+  input {
+    File     aligned_reads_bam
+    String   sample_name
 
-  Boolean? skip_mark_dupes=false
-  Boolean? plot_only_non_duplicates=false
-  Boolean? bin_large_plots=false
-  String?  binning_summary_statistic="max" # max or min
+    Boolean? skip_mark_dupes=false
+    Boolean? plot_only_non_duplicates=false
+    Boolean? bin_large_plots=false
+    String?  binning_summary_statistic="max" # max or min
 
-  Int?     machine_mem_gb
-  String?  docker="quay.io/broadinstitute/viral-core"
+    Int?     machine_mem_gb
+    String?  docker="quay.io/broadinstitute/viral-core"
+  }
   
   command {
     set -ex -o pipefail
@@ -76,14 +79,15 @@ task plot_coverage {
   }
 }
 
-
 task coverage_report {
-  Array[File]+ mapped_bams
-  Array[File]  mapped_bam_idx # optional.. speeds it up if you provide it, otherwise we auto-index
-  String       out_report_name="coverage_report.txt"
+  input {
+    Array[File]+ mapped_bams
+    Array[File]  mapped_bam_idx # optional.. speeds it up if you provide it, otherwise we auto-index
+    String       out_report_name="coverage_report.txt"
 
-  Int?         machine_mem_gb
-  String?      docker="quay.io/broadinstitute/viral-core"
+    Int?         machine_mem_gb
+    String?      docker="quay.io/broadinstitute/viral-core"
+  }
 
   command {
     reports.py --version | tee VERSION
@@ -109,10 +113,12 @@ task coverage_report {
 
 
 task fastqc {
-  File     reads_bam
+  input {
+    File     reads_bam
 
-  Int?     machine_mem_gb
-  String?  docker="quay.io/broadinstitute/viral-core"
+    Int?     machine_mem_gb
+    String?  docker="quay.io/broadinstitute/viral-core"
+  }
 
   String   reads_basename=basename(reads_bam, ".bam")
 
@@ -137,15 +143,16 @@ task fastqc {
   }
 }
 
-
 task spikein_report {
-  File    reads_bam
-  File    spikein_db
-  Int?    minScoreToFilter = 60
-  Int?    topNHits = 3
+  input {
+    File    reads_bam
+    File    spikein_db
+    Int?    minScoreToFilter = 60
+    Int?    topNHits = 3
 
-  Int?    machine_mem_gb
-  String? docker="quay.io/broadinstitute/viral-core"
+    Int?    machine_mem_gb
+    String? docker="quay.io/broadinstitute/viral-core"
+  }
 
   String  reads_basename=basename(reads_bam, ".bam")
 
@@ -182,10 +189,12 @@ task spikein_report {
 }
 
 task spikein_summary {
-  Array[File]+  spikein_count_txt
+  input {
+    Array[File]+  spikein_count_txt
 
-  Int?          machine_mem_gb
-  String?       docker="quay.io/broadinstitute/viral-core"
+    Int?          machine_mem_gb
+    String?       docker="quay.io/broadinstitute/viral-core"
+  }
 
   command {
     set -ex -o pipefail
@@ -213,16 +222,18 @@ task spikein_summary {
 }
 
 task aggregate_metagenomics_reports {
-  Array[File]+ kraken_summary_reports 
-  String       aggregate_taxon_heading_space_separated  = "Viruses" # The taxonomic heading to analyze. More than one can be specified.
-  String       aggregate_taxlevel_focus                 = "species" # species,genus,family,order,class,phylum,kingdom,superkingdom
-  Int?         aggregate_top_N_hits                     = 5 # only include the top N hits from a given sample in the aggregte report
+  input {
+    Array[File]+ kraken_summary_reports 
+    String       aggregate_taxon_heading_space_separated  = "Viruses" # The taxonomic heading to analyze. More than one can be specified.
+    String       aggregate_taxlevel_focus                 = "species" # species,genus,family,order,class,phylum,kingdom,superkingdom
+    Int?         aggregate_top_N_hits                     = 5 # only include the top N hits from a given sample in the aggregte report
 
-  Int?         machine_mem_gb
-  String?      docker="quay.io/broadinstitute/viral-classify"
+    Int?         machine_mem_gb
+    String?      docker="quay.io/broadinstitute/viral-classify"
 
-  String       aggregate_taxon_heading = sub(aggregate_taxon_heading_space_separated, " ", "_") # replace spaces with underscores for use in filename
-  
+    String       aggregate_taxon_heading = sub(aggregate_taxon_heading_space_separated, " ", "_") # replace spaces with underscores for use in filename
+  }
+
   command {
     set -ex -o pipefail
 
@@ -253,38 +264,40 @@ task aggregate_metagenomics_reports {
 }
 
 task MultiQC {
-  Array[File] input_files = []
-  Boolean force = false
-  Boolean dirs = false
-  Int? dirs_depth
-  Boolean full_names = false
-  String? title
-  String? comment
-  String? file_name
-  String out_dir = "./multiqc-output"
-  String? template
-  String? tag
-  String? ignore_analysis_files
-  String? ignore_sample_names
-  File? sample_names
-  File? file_with_list_of_input_paths
-  Array[String]+? exclude_modules
-  Array[String]+? module_to_use
-  Boolean data_dir = false
-  Boolean no_data_dir = false
-  String? output_data_format # [tsv|yaml|json] default:tsv
-  Boolean zip_data_dir = false
-  Boolean export = false
-  Boolean flat = false
-  Boolean interactive = true
-  Boolean lint = false
-  Boolean pdf = false
-  Boolean megaQC_upload = false # Upload generated report to MegaQC if MegaQC options are found
-  File? config  # directory
-  String? config_yaml
+  input {
+    Array[File] input_files = []
+    Boolean force = false
+    Boolean dirs = false
+    Int? dirs_depth
+    Boolean full_names = false
+    String? title
+    String? comment
+    String? file_name
+    String out_dir = "./multiqc-output"
+    String? template
+    String? tag
+    String? ignore_analysis_files
+    String? ignore_sample_names
+    File? sample_names
+    File? file_with_list_of_input_paths
+    Array[String]+? exclude_modules
+    Array[String]+? module_to_use
+    Boolean data_dir = false
+    Boolean no_data_dir = false
+    String? output_data_format # [tsv|yaml|json] default:tsv
+    Boolean zip_data_dir = false
+    Boolean export = false
+    Boolean flat = false
+    Boolean interactive = true
+    Boolean lint = false
+    Boolean pdf = false
+    Boolean megaQC_upload = false # Upload generated report to MegaQC if MegaQC options are found
+    File? config  # directory
+    String? config_yaml
 
-  Int?   machine_mem_gb
-  String docker = "ewels/multiqc:latest"
+    Int?   machine_mem_gb
+    String docker = "ewels/multiqc:latest"
+  }
 
   String input_directory="multiqc-input"
   # get the basename in all wdl use the filename specified (sans ".html" extension, if specified)

--- a/pipes/WDL/tasks/tasks_taxon_filter.wdl
+++ b/pipes/WDL/tasks/tasks_taxon_filter.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
 task deplete_taxa {
-  meta { description: "Runs a full human read depletion pipeline and removes PCR duplicates" }
+  meta { description: "Runs a full human read depletion pipeline and removes PCR duplicates. Input database files (bmtaggerDbs, blastDbs, bwaDbs) may be any combination of: .fasta, .fasta.gz, or tarred up indexed fastas (using the software's indexing method) as .tar.gz, .tar.bz2, .tar.lz4, or .tar.zst." }
 
   input {
     File         raw_reads_unmapped_bam

--- a/pipes/WDL/tasks/tasks_taxon_filter.wdl
+++ b/pipes/WDL/tasks/tasks_taxon_filter.wdl
@@ -1,19 +1,20 @@
+version 1.0
 
-# ======================================================================
-# deplete: 
-#   Runs a full human read depletion pipeline and removes PCR duplicates
-# ======================================================================
 task deplete_taxa {
-  File         raw_reads_unmapped_bam
-  Array[File]? bmtaggerDbs  # .tar.gz, .tgz, .tar.bz2, .tar.lz4, .fasta, or .fasta.gz
-  Array[File]? blastDbs  # .tar.gz, .tgz, .tar.bz2, .tar.lz4, .fasta, or .fasta.gz
-  Array[File]? bwaDbs  # .tar.gz, .tgz, .tar.bz2, .tar.lz4, .fasta, or .fasta.gz
-  Int?         query_chunk_size
-  Boolean?     clear_tags = false
-  String?      tags_to_clear_space_separated = "XT X0 X1 XA AM SM BQ CT XN OC OP"
+  meta { description: "Runs a full human read depletion pipeline and removes PCR duplicates" }
 
-  Int?         machine_mem_gb
-  String?      docker="quay.io/broadinstitute/viral-classify"
+  input {
+    File         raw_reads_unmapped_bam
+    Array[File]? bmtaggerDbs  # .tar.gz, .tgz, .tar.bz2, .tar.lz4, .fasta, or .fasta.gz
+    Array[File]? blastDbs  # .tar.gz, .tgz, .tar.bz2, .tar.lz4, .fasta, or .fasta.gz
+    Array[File]? bwaDbs  # .tar.gz, .tgz, .tar.bz2, .tar.lz4, .fasta, or .fasta.gz
+    Int?         query_chunk_size
+    Boolean?     clear_tags = false
+    String?      tags_to_clear_space_separated = "XT X0 X1 XA AM SM BQ CT XN OC OP"
+
+    Int?         machine_mem_gb
+    String?      docker="quay.io/broadinstitute/viral-classify"
+  }
 
   String       bam_basename = basename(raw_reads_unmapped_bam, ".bam")
 
@@ -82,21 +83,19 @@ task deplete_taxa {
   }
 }
 
-
-# ======================================================================
-# filter_to_taxon: 
-#   This step reduces the read set to a specific taxon (usually the genus
-#   level or greater for the virus of interest)
-# ======================================================================
 task filter_to_taxon {
-  File     reads_unmapped_bam
-  File     lastal_db_fasta
-  Boolean? error_on_reads_in_neg_control = false
-  Int?     negative_control_reads_threshold = 0
-  String?  neg_control_prefixes_space_separated = "neg water NTC"
+  meta { description: "This step reduces the read set to a specific taxon (usually the genus level or greater for the virus of interest)" }
 
-  Int?     machine_mem_gb
-  String?  docker="quay.io/broadinstitute/viral-classify"
+  input {
+    File     reads_unmapped_bam
+    File     lastal_db_fasta
+    Boolean? error_on_reads_in_neg_control = false
+    Int?     negative_control_reads_threshold = 0
+    String?  neg_control_prefixes_space_separated = "neg water NTC"
+
+    Int?     machine_mem_gb
+    String?  docker="quay.io/broadinstitute/viral-classify"
+  }
 
   # do this in two steps in case the input doesn't actually have "cleaned" in the name
   String   bam_basename = basename(basename(reads_unmapped_bam, ".bam"), ".cleaned")
@@ -147,10 +146,12 @@ task filter_to_taxon {
 }
 
 task build_lastal_db {
-  File    sequences_fasta
+  input {
+    File    sequences_fasta
 
-  Int?    machine_mem_gb
-  String? docker="quay.io/broadinstitute/viral-classify"
+    Int?    machine_mem_gb
+    String? docker="quay.io/broadinstitute/viral-classify"
+  }
 
   String  db_name = basename(sequences_fasta, ".fasta")
 
@@ -176,12 +177,14 @@ task build_lastal_db {
 }
 
 task merge_one_per_sample {
-  String       out_bam_basename
-  Array[File]+ inputBams
-  Boolean?     rmdup=false
+  input {
+    String       out_bam_basename
+    Array[File]+ inputBams
+    Boolean?     rmdup=false
 
-  Int?         machine_mem_gb
-  String?      docker="quay.io/broadinstitute/viral-core"
+    Int?         machine_mem_gb
+    String?      docker="quay.io/broadinstitute/viral-core"
+  }
 
   command {
     set -ex -o pipefail
@@ -220,5 +223,3 @@ task merge_one_per_sample {
     dx_instance_type: "mem1_ssd2_v2_x4"
   }
 }
-
-

--- a/pipes/WDL/workflows/align_and_plot.wdl
+++ b/pipes/WDL/workflows/align_and_plot.wdl
@@ -1,8 +1,12 @@
+version 1.0
+
 import "../tasks/tasks_reports.wdl" as reports
 import "../tasks/tasks_assembly.wdl" as assembly
 
 workflow align_and_plot {
-	String? aligner_options = "-r Random -l 30 -g 40 -x 20 -t 502"
+    input {
+    	String? aligner_options = "-r Random -l 30 -g 40 -x 20 -t 502"
+    }
 
     call assembly.align_reads as align {
         input:

--- a/pipes/WDL/workflows/assemble_denovo.wdl
+++ b/pipes/WDL/workflows/assemble_denovo.wdl
@@ -1,9 +1,12 @@
+version 1.0
+
 import "../tasks/tasks_taxon_filter.wdl" as taxon_filter
 import "../tasks/tasks_assembly.wdl" as assembly
 
 workflow assemble_denovo {
-  
-  File reads_unmapped_bam
+  input {  
+    File reads_unmapped_bam
+  }
 
   call taxon_filter.filter_to_taxon {
     input:

--- a/pipes/WDL/workflows/assemble_denovo_with_deplete.wdl
+++ b/pipes/WDL/workflows/assemble_denovo_with_deplete.wdl
@@ -1,3 +1,5 @@
+version 1.0
+
 import "../tasks/tasks_taxon_filter.wdl" as taxon_filter
 import "../tasks/tasks_assembly.wdl" as assembly
 

--- a/pipes/WDL/workflows/assemble_denovo_with_deplete_and_isnv_calling.wdl
+++ b/pipes/WDL/workflows/assemble_denovo_with_deplete_and_isnv_calling.wdl
@@ -1,3 +1,5 @@
+version 1.0
+
 import "../tasks/tasks_taxon_filter.wdl" as taxon_filter
 import "../tasks/tasks_assembly.wdl" as assembly
 import "../tasks/tasks_intrahost.wdl" as intrahost

--- a/pipes/WDL/workflows/assemble_denovo_with_isnv_calling.wdl
+++ b/pipes/WDL/workflows/assemble_denovo_with_isnv_calling.wdl
@@ -1,9 +1,13 @@
+version 1.0
+
 import "../tasks/tasks_taxon_filter.wdl" as taxon_filter
 import "../tasks/tasks_assembly.wdl" as assembly
 import "../tasks/tasks_intrahost.wdl" as intrahost
 
 workflow assemble_denovo_with_isnv_calling {
-    File reads_unmapped_bam
+    input {
+        File reads_unmapped_bam
+    }
 
     call taxon_filter.filter_to_taxon {
         input:

--- a/pipes/WDL/workflows/assemble_refbased.wdl
+++ b/pipes/WDL/workflows/assemble_refbased.wdl
@@ -1,3 +1,5 @@
+version 1.0
+
 import "../tasks/tasks_assembly.wdl" as assembly
 import "../tasks/tasks_reports.wdl" as reports
 import "../tasks/tasks_read_utils.wdl" as read_utils
@@ -10,13 +12,15 @@ workflow assemble_refbased {
         email:  "viral-ngs@broadinstitute.org"
     }
 
-    String          sample_name
-    Array[File]+    reads_unmapped_bams
-    File            reference_fasta
+    input {
+        String          sample_name
+        Array[File]+    reads_unmapped_bams
+        File            reference_fasta
 
-    File?           novocraft_license
-    Boolean?        skip_mark_dupes=false
-    File?           trim_coords_bed
+        File?           novocraft_license
+        Boolean?        skip_mark_dupes=false
+        File?           trim_coords_bed
+    }
 
     scatter(reads_unmapped_bam in reads_unmapped_bams) {
         call assembly.align_reads as align_to_ref {

--- a/pipes/WDL/workflows/assemble_refbased_old.wdl
+++ b/pipes/WDL/workflows/assemble_refbased_old.wdl
@@ -1,3 +1,5 @@
+version 1.0
+
 import "../tasks/tasks_assembly.wdl" as assembly
 
 workflow assemble_refbased_old {

--- a/pipes/WDL/workflows/bams_multiqc.wdl
+++ b/pipes/WDL/workflows/bams_multiqc.wdl
@@ -1,7 +1,11 @@
+version 1.0
+
 import "../tasks/tasks_reports.wdl" as reports
 
 workflow bams_multiqc {
-    Array[File]+  read_bams
+    input {
+        Array[File]+  read_bams
+    }
 
     scatter(reads_bam in read_bams) {
         call reports.fastqc as fastqc {

--- a/pipes/WDL/workflows/classify_kaiju.wdl
+++ b/pipes/WDL/workflows/classify_kaiju.wdl
@@ -1,3 +1,5 @@
+version 1.0
+
 import "../tasks/tasks_metagenomics.wdl" as metagenomics
 
 workflow classify_kaiju {

--- a/pipes/WDL/workflows/classify_krakenuniq.wdl
+++ b/pipes/WDL/workflows/classify_krakenuniq.wdl
@@ -1,3 +1,5 @@
+version 1.0
+
 import "../tasks/tasks_metagenomics.wdl" as metagenomics
 import "../tasks/tasks_reports.wdl" as reports
 

--- a/pipes/WDL/workflows/contigs.wdl
+++ b/pipes/WDL/workflows/contigs.wdl
@@ -1,3 +1,5 @@
+version 1.0
+
 import "../tasks/tasks_metagenomics.wdl" as metagenomics
 import "../tasks/tasks_taxon_filter.wdl" as taxon_filter
 import "../tasks/tasks_assembly.wdl" as assembly

--- a/pipes/WDL/workflows/coverage_table.wdl
+++ b/pipes/WDL/workflows/coverage_table.wdl
@@ -1,3 +1,5 @@
+version 1.0
+
 import "../tasks/tasks_reports.wdl" as reports
 
 workflow coverage_table {

--- a/pipes/WDL/workflows/demux_metag.wdl
+++ b/pipes/WDL/workflows/demux_metag.wdl
@@ -1,3 +1,5 @@
+version 1.0
+
 #DX_SKIP_WORKFLOW
 
 import "../tasks/tasks_demux.wdl" as demux

--- a/pipes/WDL/workflows/demux_only.wdl
+++ b/pipes/WDL/workflows/demux_only.wdl
@@ -1,3 +1,5 @@
+version 1.0
+
 import "../tasks/tasks_demux.wdl" as tasks_demux
 import "../tasks/tasks_reports.wdl" as reports
 

--- a/pipes/WDL/workflows/demux_plus.wdl
+++ b/pipes/WDL/workflows/demux_plus.wdl
@@ -1,3 +1,5 @@
+version 1.0
+
 import "../tasks/tasks_demux.wdl" as demux
 import "../tasks/tasks_metagenomics.wdl" as metagenomics
 import "../tasks/tasks_taxon_filter.wdl" as taxon_filter
@@ -6,13 +8,15 @@ import "../tasks/tasks_reports.wdl" as reports
 
 workflow demux_plus {
 
-    call demux.illumina_demux as illumina_demux
+    input {
+        File spikein_db
+        File trim_clip_db
+        Array[File]? bmtaggerDbs  # .tar.gz, .tgz, .tar.bz2, .tar.lz4, .fasta, or .fasta.gz
+        Array[File]? blastDbs  # .tar.gz, .tgz, .tar.bz2, .tar.lz4, .fasta, or .fasta.gz
+        Array[File]? bwaDbs
+    }
 
-    File spikein_db
-    File trim_clip_db
-    Array[File]? bmtaggerDbs  # .tar.gz, .tgz, .tar.bz2, .tar.lz4, .fasta, or .fasta.gz
-    Array[File]? blastDbs  # .tar.gz, .tgz, .tar.bz2, .tar.lz4, .fasta, or .fasta.gz
-    Array[File]? bwaDbs
+    call demux.illumina_demux as illumina_demux
 
     scatter(raw_reads in illumina_demux.raw_reads_unaligned_bams) {
         call reports.spikein_report as spikein {

--- a/pipes/WDL/workflows/deplete_only.wdl
+++ b/pipes/WDL/workflows/deplete_only.wdl
@@ -1,3 +1,5 @@
+version 1.0
+
 import "../tasks/tasks_taxon_filter.wdl" as taxon_filter
 
 workflow deplete_only {

--- a/pipes/WDL/workflows/downsample.wdl
+++ b/pipes/WDL/workflows/downsample.wdl
@@ -1,3 +1,5 @@
+version 1.0
+
 import "../tasks/tasks_read_utils.wdl" as reads
 
 workflow downsample {

--- a/pipes/WDL/workflows/fastqc_only.wdl
+++ b/pipes/WDL/workflows/fastqc_only.wdl
@@ -1,3 +1,5 @@
+version 1.0
+
 import "../tasks/tasks_reports.wdl" as reports
 
 workflow fastqc_only {

--- a/pipes/WDL/workflows/fetch_annotations.wdl
+++ b/pipes/WDL/workflows/fetch_annotations.wdl
@@ -1,3 +1,5 @@
+version 1.0
+
 import "../tasks/tasks_ncbi.wdl" as ncbi
 
 workflow fetch_annotations {

--- a/pipes/WDL/workflows/filter_classified_bam_to_taxa.wdl
+++ b/pipes/WDL/workflows/filter_classified_bam_to_taxa.wdl
@@ -1,3 +1,5 @@
+version 1.0
+
 import "../tasks/tasks_metagenomics.wdl" as metagenomics
 
 workflow filter_classified_bam_to_taxa {

--- a/pipes/WDL/workflows/genbank.wdl
+++ b/pipes/WDL/workflows/genbank.wdl
@@ -1,10 +1,14 @@
+version 1.0
+
 import "../tasks/tasks_interhost.wdl" as interhost
 import "../tasks/tasks_ncbi.wdl" as ncbi
 
 workflow genbank {
 
-    File          reference_fasta
-    Array[File]+  assemblies_fasta     # one per genome
+    input {
+        File          reference_fasta
+        Array[File]+  assemblies_fasta     # one per genome
+    }
 
     call interhost.multi_align_mafft_ref as mafft {
         input:

--- a/pipes/WDL/workflows/isnvs_merge_to_vcf.wdl
+++ b/pipes/WDL/workflows/isnvs_merge_to_vcf.wdl
@@ -1,9 +1,13 @@
+version 1.0
+
 import "../tasks/tasks_interhost.wdl" as interhost
 import "../tasks/tasks_intrahost.wdl" as tasks_intrahost
 
 workflow isnvs_merge_to_vcf {
-    File          reference_fasta
-    Array[File]+  assemblies_fasta     # one per genome
+    input {
+        File          reference_fasta
+        Array[File]+  assemblies_fasta     # one per genome
+    }
 
     call interhost.multi_align_mafft_ref as mafft {
         input:

--- a/pipes/WDL/workflows/isnvs_one_sample.wdl
+++ b/pipes/WDL/workflows/isnvs_one_sample.wdl
@@ -1,3 +1,5 @@
+version 1.0
+
 import "../tasks/tasks_intrahost.wdl" as intrahost
 
 workflow isnvs_one_sample {

--- a/pipes/WDL/workflows/mafft.wdl
+++ b/pipes/WDL/workflows/mafft.wdl
@@ -1,3 +1,5 @@
+version 1.0
+
 import "../tasks/tasks_interhost.wdl" as interhost
 
 workflow mafft {

--- a/pipes/WDL/workflows/mafft_and_trim.wdl
+++ b/pipes/WDL/workflows/mafft_and_trim.wdl
@@ -1,3 +1,5 @@
+version 1.0
+
 import "../tasks/tasks_interhost.wdl" as interhost
 
 workflow mafft_and_trim {

--- a/pipes/WDL/workflows/merge_bams.wdl
+++ b/pipes/WDL/workflows/merge_bams.wdl
@@ -1,3 +1,5 @@
+version 1.0
+
 import "../tasks/tasks_read_utils.wdl" as read_utils
 
 workflow merge_bams {

--- a/pipes/WDL/workflows/merge_tar_chunks.wdl
+++ b/pipes/WDL/workflows/merge_tar_chunks.wdl
@@ -1,3 +1,5 @@
+version 1.0
+
 import "../tasks/tasks_demux.wdl" as demux
 
 workflow merge_tar_chunks {

--- a/pipes/WDL/workflows/multi_sample_assemble_kraken.wdl
+++ b/pipes/WDL/workflows/multi_sample_assemble_kraken.wdl
@@ -1,3 +1,5 @@
+version 1.0
+
 import "../tasks/tasks_demux.wdl" as demux
 import "../tasks/tasks_metagenomics.wdl" as metagenomics
 import "../tasks/tasks_taxon_filter.wdl" as taxon_filter
@@ -6,32 +8,24 @@ import "../tasks/tasks_reports.wdl" as reports
 
 workflow multi_sample_assemble_kraken {
 
-	Array[File]+ raw_uBAMs
-    Array[File]+ reference_genome_fasta
-    File spikein_db
-    File trim_clip_db
-    Array[File]? bmtaggerDbs  # .tar.gz, .tgz, .tar.bz2, .tar.lz4, .fasta, or .fasta.gz
-    Array[File]? blastDbs  # .tar.gz, .tgz, .tar.bz2, .tar.lz4, .fasta, or .fasta.gz
-    Array[File]? bwaDbs
+    input {
+    	Array[File]+ raw_uBAMs
+        Array[File]+ reference_genome_fasta
+    }
     
     scatter(raw_reads in raw_uBAMs) {
         call reports.spikein_report as spikein {
             input:
-                reads_bam = raw_reads,
-                spikein_db = spikein_db
+                reads_bam = raw_reads
         }
         call taxon_filter.deplete_taxa as deplete {
             input:
-                raw_reads_unmapped_bam = raw_reads,
-                bmtaggerDbs = bmtaggerDbs,
-                blastDbs = blastDbs,
-                bwaDbs = bwaDbs
+                raw_reads_unmapped_bam = raw_reads
         }
         call assembly.assemble as spades {
             input:
                 assembler = "spades",
                 reads_unmapped_bam = deplete.cleaned_bam,
-                trim_clip_db = trim_clip_db,
                 always_succeed = true
         }
         call assembly.scaffold {

--- a/pipes/WDL/workflows/multiqc_only.wdl
+++ b/pipes/WDL/workflows/multiqc_only.wdl
@@ -1,3 +1,5 @@
+version 1.0
+
 import "../tasks/tasks_reports.wdl" as reports
 
 workflow multiqc_only {

--- a/pipes/WDL/workflows/scaffold_and_refine.wdl
+++ b/pipes/WDL/workflows/scaffold_and_refine.wdl
@@ -1,7 +1,11 @@
+version 1.0
+
 import "../tasks/tasks_assembly.wdl" as assembly
 
 workflow scaffold_and_refine {
-    File reads_unmapped_bam
+    input {
+        File reads_unmapped_bam
+    }
 
     call assembly.scaffold {
         input:
@@ -13,5 +17,4 @@ workflow scaffold_and_refine {
             assembly_fasta = scaffold.scaffold_fasta,
             reads_unmapped_bam = reads_unmapped_bam
     }
-
 }

--- a/pipes/WDL/workflows/spikein.wdl
+++ b/pipes/WDL/workflows/spikein.wdl
@@ -1,3 +1,5 @@
+version 1.0
+
 import "../tasks/tasks_reports.wdl" as reports
 
 workflow spikein {

--- a/pipes/WDL/workflows/trimal.wdl
+++ b/pipes/WDL/workflows/trimal.wdl
@@ -1,3 +1,5 @@
+version 1.0
+
 import "../tasks/tasks_interhost.wdl" as interhost
 
 workflow trimal {


### PR DESCRIPTION
Closes #45 which I guess wasn't a big deal after all, even in Terra -- seems like default behavior is what we want. This PR converts all remaining draft-2 WDLs to 1.0. DNAnexus build products are [here](https://platform.dnanexus.com/projects/F8PQ6380xf5bK0Qk0YPjB17P/data/build/quay.io/broadinstitute/viral-pipelines-dev/2.0.20.3-45-geadfedb-dp-docs). Compiles and validates fine on miniWDL and Cromwell/womtool.

Danny