### PR TITLE
change multiqc docker image

### DIFF
--- a/pipes/WDL/tasks/tasks_reports.wdl
+++ b/pipes/WDL/tasks/tasks_reports.wdl
@@ -303,7 +303,7 @@ task MultiQC {
     String?         config_yaml
 
     Int?            machine_mem_gb
-    String          docker = "ewels/multiqc:latest"
+    String          docker = "quay.io/biocontainers/multiqc:1.8--py_2"
   }
 
   parameter_meta {
@@ -356,7 +356,8 @@ task MultiQC {
         mv "${out_dir}/${report_filename}_report.html" "${out_dir}/${report_filename}.html"
       fi
 
-      tar -czvf "${report_filename}_data.tar.gz" "${out_dir}/${report_filename}_data"
+      #tar -czvf "${report_filename}_data.tar.gz" "${out_dir}/${report_filename}_data"
+      tar -c "${out_dir}/${report_filename}_data" | gzip -c > "${report_filename}_data.tar.gz"
   }
 
   output {


### PR DESCRIPTION
This changes the multiqc docker image to point to a biocontainers one. The one provided by the author has an ENTRYPOINT defined which appears to make it incompatible with execution on PAPIv2. Check associated DNAnexus CI tests (the only place where we currently run demux_plus / multiqc) before merging this PR.