### PR TITLE
travis github staging fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ jobs:
         - sudo apt-get update
         - sudo apt-get -y install shellcheck
       install:
-        - pip3 install miniwdl
+        - pip3 -q install miniwdl
       script:
         - travis/version-wdl-runtimes.sh
         - miniwdl check pipes/WDL/workflows/*.wdl
@@ -84,7 +84,7 @@ jobs:
         - sudo apt-get update
         - sudo apt-get -y install jq
       install:
-        - pip3 install miniwdl
+        - pip3 -q install miniwdl
       script:
         - travis/version-wdl-runtimes.sh
         - travis/tests-miniwdl.sh
@@ -112,7 +112,7 @@ jobs:
       env:
         - TRAVIS_JOB=deploy_github_staging
       install:
-        - pip3 install miniwdl
+        - pip3 -q install miniwdl
       script:
         - set -e -o pipefail
         - if [ -n "$TRAVIS_PULL_REQUEST_BRANCH" ]; then exit 0; fi
@@ -123,7 +123,6 @@ jobs:
         - travis/github-viral-ngs-staging.sh
         - cd viral-ngs-staging
         - if [ -z "$TRAVIS_TAG" ]; then git checkout -B $TRAVIS_BRANCH; fi
-        - git remote -v
         - ssh-add -l -E md5
         - rm -rf *; cp -a ../pipes ../travis/github-staging/* .
         - ../travis/dockstoreyml.sh pipes/WDL/flattened/*.wdl > .dockstore.yml
@@ -143,7 +142,7 @@ jobs:
         - set -e -o pipefail
         - openssl aes-256-cbc -K $encrypted_6def3e87f286_key -iv $encrypted_6def3e87f286_iv -in travis/viral-ngs-wdl.json.enc -out travis/viral-ngs-wdl.json -d
         - export DEST_DIR=`travis/list-docker-tags.sh | tail -1 | sed 's/:/\//'`
-        - pip3 install miniwdl
+        - pip3 -q install miniwdl
         - travis/version-wdl-runtimes.sh
         - travis/flatten-wdls.sh
       deploy:
@@ -164,7 +163,7 @@ jobs:
     #    - TRAVIS_JOB=deploy_github
     #  before_deploy:
     #    - set -e
-    #    - pip3 install miniwdl
+    #    - pip3 -q install miniwdl
     #    - travis/version-wdl-runtimes.sh
     #    - travis/flatten-wdls.sh
     #  deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -122,7 +122,7 @@ jobs:
         - travis/flatten-wdls.sh > /dev/null
         - travis/github-viral-ngs-staging.sh
         - cd viral-ngs-staging
-        - git checkout -B $TRAVIS_BRANCH
+        - if [ -z "$TRAVIS_TAG" ]; then git checkout -B $TRAVIS_BRANCH; fi
         - git remote -v
         - ssh-add -l -E md5
         - rm -rf *; cp -a ../pipes ../travis/github-staging/* .
@@ -130,8 +130,8 @@ jobs:
         - git add -A -f
         - git commit -q -m "CI push github.com/broadinstitute/viral-pipelines:$VERSION"
         - git tag $VERSION
-        - git push -f -u origin $TRAVIS_BRANCH
         - git push origin --tags
+        - if [ -z "$TRAVIS_TAG" ]; then git push -f -u origin $TRAVIS_BRANCH; fi
 
     - language: python
       stage: build

--- a/.travis.yml
+++ b/.travis.yml
@@ -114,25 +114,9 @@ jobs:
       install:
         - pip3 -q install miniwdl
       script:
-        - set -e -o pipefail
-        - if [ -n "$TRAVIS_PULL_REQUEST_BRANCH" ]; then exit 0; fi
-        - export VERSION=$(travis/list-docker-tags.sh | cut -f 2 -d ":" | tail -1); echo "version - $VERSION"
-        - eval `ssh-agent`
-        - travis/version-wdl-runtimes.sh
-        - travis/flatten-wdls.sh > /dev/null
         - travis/github-viral-ngs-staging.sh
-        - cd viral-ngs-staging
-        - if [ -z "$TRAVIS_TAG" ]; then git checkout -B $TRAVIS_BRANCH; fi
-        - ssh-add -l -E md5
-        - rm -rf *; cp -a ../pipes ../travis/github-staging/* .
-        - ../travis/dockstoreyml.sh pipes/WDL/flattened/*.wdl > .dockstore.yml
-        - git add -A -f
-        - git commit -q -m "CI push github.com/broadinstitute/viral-pipelines:$VERSION"
-        - git tag $VERSION
-        - git push origin --tags
-        - if [ -z "$TRAVIS_TAG" ]; then git push -f -u origin $TRAVIS_BRANCH; fi
       after_failure:
-        - sleep 5
+        - sleep 10
 
     - language: python
       stage: build

--- a/.travis.yml
+++ b/.travis.yml
@@ -131,6 +131,8 @@ jobs:
         - git tag $VERSION
         - git push origin --tags
         - if [ -z "$TRAVIS_TAG" ]; then git push -f -u origin $TRAVIS_BRANCH; fi
+      after_failure:
+        - sleep 5
 
     - language: python
       stage: build

--- a/travis/github-viral-ngs-staging.sh
+++ b/travis/github-viral-ngs-staging.sh
@@ -28,7 +28,7 @@ if [ -z "$TRAVIS_PULL_REQUEST_BRANCH" ]; then
 	rm -rf *; cp -a ../pipes ../travis/github-staging/* .
 	../travis/dockstoreyml.sh pipes/WDL/flattened/*.wdl > .dockstore.yml
 	git add -A -f
-	git commit -q -m "CI push github.com/broadinstitute/viral-pipelines:$VERSION"
+	git diff-index --quiet HEAD || git commit -q -m "CI push github.com/broadinstitute/viral-pipelines:$VERSION"
 
 	git tag $VERSION
 	git push origin --tags

--- a/travis/github-viral-ngs-staging.sh
+++ b/travis/github-viral-ngs-staging.sh
@@ -1,12 +1,40 @@
 #!/bin/bash
 set -e -o pipefail
 
-openssl aes-256-cbc \
-	-K $encrypted_fb18189f5cc1_key \
-	-iv $encrypted_fb18189f5cc1_iv \
-	-in travis/github-deploy-id_rsa.enc \
-	-out travis/github-deploy-id_rsa \
-	-d
-chmod 400 travis/github-deploy-id_rsa
-ssh-add travis/github-deploy-id_rsa
-git clone git@github.com:broadinstitute/viral-ngs-staging.git
+if [ -z "$TRAVIS_PULL_REQUEST_BRANCH" ]; then
+
+	travis/version-wdl-runtimes.sh
+	travis/flatten-wdls.sh > /dev/null
+
+	VERSION=$(travis/list-docker-tags.sh | cut -f 2 -d ":" | tail -1); echo "version - $VERSION"
+
+	eval $(ssh-agent)
+	openssl aes-256-cbc \
+		-K $encrypted_fb18189f5cc1_key \
+		-iv $encrypted_fb18189f5cc1_iv \
+		-in travis/github-deploy-id_rsa.enc \
+		-out travis/github-deploy-id_rsa \
+		-d
+	chmod 400 travis/github-deploy-id_rsa
+	ssh-add travis/github-deploy-id_rsa
+	ssh-add -l -E md5
+	git clone git@github.com:broadinstitute/viral-ngs-staging.git
+
+	cd viral-ngs-staging
+	if [ -z "$TRAVIS_TAG" ]; then
+		git checkout -B $TRAVIS_BRANCH
+	fi
+
+	rm -rf *; cp -a ../pipes ../travis/github-staging/* .
+	../travis/dockstoreyml.sh pipes/WDL/flattened/*.wdl > .dockstore.yml
+	git add -A -f
+	git commit -q -m "CI push github.com/broadinstitute/viral-pipelines:$VERSION"
+
+	git tag $VERSION
+	git push origin --tags
+
+	if [ -z "$TRAVIS_TAG" ]; then
+		git push -f -u origin $TRAVIS_BRANCH
+	fi
+
+fi


### PR DESCRIPTION
Most everything was working except for Travis behavior (in the `deploy_github_staging` Travis job) on tags and releases. This patches the behavior to skip git branch checkouts and pushes when `$TRAVIS_TAG` is set -- it will only create and push new tags instead.