### PR TITLE
travis small tweaks

### DIFF
--- a/travis/build-dx.sh
+++ b/travis/build-dx.sh
@@ -24,15 +24,6 @@ for workflow in pipes/WDL/workflows/*.wdl; do
     workflow_name=`basename $workflow .wdl`
 	  echo "Building $workflow to DNAnexus: /build/$VERSION/$workflow_name"
 
-    test_input_json_wdl="test/input/WDL/test_inputs-$workflow_name-dnanexus.json"
-    if [ -f "$test_input_json_wdl" ]; then
-      CMD_INPUT="-inputs $test_input_json_wdl"
-      # blank this out until we're sure we want to test it this way...
-      CMD_INPUT=""
-    else
-      CMD_INPUT=""
-    fi
-
     defaults_json="pipes/dnax/dx-defaults-$workflow_name.json"
     if [ -f "$defaults_json" ]; then
       CMD_DEFAULTS="-defaults $defaults_json"
@@ -44,7 +35,8 @@ for workflow in pipes/WDL/workflows/*.wdl; do
     CMD_DEFAULTS+=" -extras $extras_json"
 
 	  dx_id=$(java -jar dxWDL.jar compile \
-      $workflow $CMD_INPUT $CMD_DEFAULTS -f -verbose \
+      $workflow $CMD_DEFAULTS -f -verbose \
+      -leaveWorkflowsOpen \
       -imports pipes/WDL/tasks/ \
       -project $DX_PROJECT \
       -destination /build/$VERSION/$workflow_name)

--- a/travis/dockstoreyml.sh
+++ b/travis/dockstoreyml.sh
@@ -7,4 +7,6 @@ for WDL in $*; do
 	echo " - name: $(basename $WDL .wdl)"
 	echo "   subclass: WDL"
 	echo "   primaryDescriptorPath: $WDL"
+	echo "   testParameterFiles:"
+	echo "    - empty.json"
 done

--- a/travis/install-wdl.sh
+++ b/travis/install-wdl.sh
@@ -19,7 +19,7 @@ cached_fetch_jar_from_github () {
 
 cached_fetch_jar_from_github broadinstitute cromwell womtool 49
 cached_fetch_jar_from_github broadinstitute cromwell cromwell 49
-cached_fetch_jar_from_github dnanexus dxWDL dxWDL v1.45
+cached_fetch_jar_from_github dnanexus dxWDL dxWDL v1.46.4
 
 TGZ=dx-toolkit-v0.293.0-ubuntu-16.04-amd64.tar.gz
 if [ ! -f $CACHE_DIR/$TGZ ]; then

--- a/travis/install-wdl.sh
+++ b/travis/install-wdl.sh
@@ -19,7 +19,7 @@ cached_fetch_jar_from_github () {
 
 cached_fetch_jar_from_github broadinstitute cromwell womtool 49
 cached_fetch_jar_from_github broadinstitute cromwell cromwell 49
-cached_fetch_jar_from_github dnanexus dxWDL dxWDL v1.46.4
+cached_fetch_jar_from_github dnanexus dxWDL dxWDL v1.45
 
 TGZ=dx-toolkit-v0.293.0-ubuntu-16.04-amd64.tar.gz
 if [ ! -f $CACHE_DIR/$TGZ ]; then


### PR DESCRIPTION
- Travis: dxWDL: build with `-leaveWorkflowsOpen` to make them behave more like we're used to (when it's allowed)
- Travis: dockstore: add a `testParameterFiles` to the dockstore.yml for the 1.9 api