### PR TITLE
stop git tagging non-master branches on github staging / dockstore

### DIFF
--- a/travis/github-viral-ngs-staging.sh
+++ b/travis/github-viral-ngs-staging.sh
@@ -30,10 +30,14 @@ if [ -z "$TRAVIS_PULL_REQUEST_BRANCH" ]; then
 	git add -A -f
 	git diff-index --quiet HEAD || git commit -q -m "CI push github.com/broadinstitute/viral-pipelines:$VERSION"
 
-	git tag $VERSION
-	git push origin --tags
+	if [[ "$TRAVIS_BRANCH" == "master" ]]; then
+		# for dockstore, don't bother tagging every branch commit that is non-master -- just git push the branch instead
+		git tag $VERSION
+		git push origin --tags
+	fi
 
 	if [ -z "$TRAVIS_TAG" ]; then
+		# if TRAVIS_TAG is set, skip this, since a separate Travis build is already pushing master branch anyway
 		git push -f -u origin $TRAVIS_BRANCH
 	fi
 


### PR DESCRIPTION
This is meant to reduce noise / increase signal on our dockstore deploy. Non-master branch-commits will no longer have versioned tags assigned to them, but will simply retain their branch commits. Dockstore displays all github branches and tags under the "versions" tab of each workflow. This means that it will expose access to just the latest commit of each developer branch, but not all of the historical ones (while retaining the same named version scheme for all historical master commits).