### PR TITLE
update dnanexus default kraken2 db

### DIFF
--- a/pipes/WDL/workflows/classify_multi.wdl
+++ b/pipes/WDL/workflows/classify_multi.wdl
@@ -112,6 +112,7 @@ workflow classify_multi {
                 assembler = "spades",
                 reads_unmapped_bam = rmdup_ubam.dedup_bam,
                 trim_clip_db = trim_clip_db,
+                spades_min_contig_len = 800,
                 always_succeed = true
         }
         if(defined(blast_db_tgz) && defined(krona_taxonomy_db_blast_tgz)) {

--- a/pipes/dnax/dx-defaults-classify_kraken2.json
+++ b/pipes/dnax/dx-defaults-classify_kraken2.json
@@ -1,6 +1,6 @@
 {
   "classify_kraken2.kraken2.kraken2_db_tgz":
-    "dx://file-Fpp4V6j0xf5bYPKQ5J13JVyj",
+    "dx://file-Fq1ZPzQ0GY2bkq6K8KKk82G3",
   "classify_kraken2.kraken2.krona_taxonomy_db_tgz":
     "dx://file-Fpp14j00xf5Xjq665v8v93z8"
 }

--- a/pipes/dnax/dx-defaults-classify_multi.json
+++ b/pipes/dnax/dx-defaults-classify_multi.json
@@ -6,7 +6,7 @@
     "dx://file-BXF0vYQ0QyBF509G9J12g927",
 
   "classify_multi.kraken2_db_tgz":
-    "dx://file-Fpp4V6j0xf5bYPKQ5J13JVyj",
+    "dx://file-Fq1ZPzQ0GY2bkq6K8KKk82G3",
   "classify_multi.krona_taxonomy_db_kraken2_tgz":
     "dx://file-Fpp14j00xf5Xjq665v8v93z8",
 

--- a/pipes/dnax/dx-defaults-demux_metag.json
+++ b/pipes/dnax/dx-defaults-demux_metag.json
@@ -11,7 +11,7 @@
     "dx://file-BXF0vYQ0QyBF509G9J12g927",
 
   "demux_metag.kraken2_db_tgz":
-    "dx://file-Fpp4V6j0xf5bYPKQ5J13JVyj",
+    "dx://file-Fq1ZPzQ0GY2bkq6K8KKk82G3",
   "demux_metag.krona_taxonomy_db_kraken2_tgz":
     "dx://file-Fpp14j00xf5Xjq665v8v93z8",
   "demux_metag.blast_db_tgz":


### PR DESCRIPTION
This updates the default kraken2 database in DNAnexus to use Simon's latest custom build which forces artificial sequence taxa to always win against bacteria instead of going through standard LCA.