### PR TITLE
add align_and_count_multiple_report workflow to aggregate multiple sp…

### DIFF
--- a/pipes/WDL/tasks/tasks_reports.wdl
+++ b/pipes/WDL/tasks/tasks_reports.wdl
@@ -191,6 +191,8 @@ task align_and_count_summary {
   input {
     Array[File]+  counts_txt
 
+    String?       output_prefix="count_summary"
+
     String        docker="quay.io/broadinstitute/viral-core"
   }
 
@@ -203,7 +205,7 @@ task align_and_count_summary {
   }
 
   output {
-    File   count_summary    = "count_summary.tsv"
+    File   count_summary    = "${output_prefix}.tsv"
     String viralngs_version = read_string("VERSION")
   }
 

--- a/pipes/WDL/tasks/tasks_reports.wdl
+++ b/pipes/WDL/tasks/tasks_reports.wdl
@@ -200,7 +200,7 @@ task align_and_count_summary {
     set -ex -o pipefail
 
     reports.py --version | tee VERSION
-    reports.py aggregate_alignment_counts ${sep=' ' counts_txt} count_summary.tsv \
+    reports.py aggregate_alignment_counts ${sep=' ' counts_txt} "${output_prefix}.tsv" \
       --loglevel=DEBUG
   }
 

--- a/pipes/WDL/tasks/tasks_reports.wdl
+++ b/pipes/WDL/tasks/tasks_reports.wdl
@@ -200,8 +200,7 @@ task align_and_count_summary {
     set -ex -o pipefail
 
     reports.py --version | tee VERSION
-    reports.py aggregate_alignment_counts ${sep=' ' counts_txt} "${output_prefix}.tsv" \
-      --loglevel=DEBUG
+    reports.py aggregate_alignment_counts ${sep=' ' counts_txt} "${output_prefix}".tsv --loglevel=DEBUG
   }
 
   output {

--- a/pipes/WDL/tasks/tasks_reports.wdl
+++ b/pipes/WDL/tasks/tasks_reports.wdl
@@ -197,11 +197,8 @@ task align_and_count_summary {
   command {
     set -ex -o pipefail
 
-    mkdir spike_summaries
-    cp ${sep=' ' counts_txt} spike_summaries/
-
     reports.py --version | tee VERSION
-    reports.py aggregate_spike_count spike_summaries/ count_summary.tsv \
+    reports.py aggregate_alignment_counts ${sep=' ' counts_txt} count_summary.tsv \
       --loglevel=DEBUG
   }
 

--- a/pipes/WDL/workflows/align_and_count_multiple_report.wdl
+++ b/pipes/WDL/workflows/align_and_count_multiple_report.wdl
@@ -1,0 +1,51 @@
+version 1.0
+
+import "../tasks/tasks_reports.wdl" as reports
+
+workflow align_and_count_multiple_report {
+    meta {
+        description: "Count the number of times reads map to provided reference sequences. Useful for counting spike-ins, etc."
+        author: "Broad Viral Genomics"
+        email:  "viral-ngs@broadinstitute.org"
+    }
+
+    input {
+        Array[File]+ reads_unmapped_bams
+        File ref_db
+    }
+
+    parameter_meta {
+        reads_unmapped_bams: {
+            description: "Unaligned reads in BAM format",
+            patterns: ["*.bam"]
+        }
+        ref_db: {
+            description: "File containing sequences against which reads should me aligned and counted",
+            patterns: ["*.fasta","*.fa"]
+        }
+    }
+
+    scatter(raw_reads in reads_unmapped_bams) {
+        call reports.align_and_count{
+            input:
+                reads_bam = raw_reads,
+                ref_db    = ref_db
+        }
+    }
+
+    call reports.align_and_count_summary {
+        input:
+            counts_txt = align_and_count.report
+    }
+
+    call reports.align_and_count_summary as align_and_count_summary_top_hits {
+        input:
+            counts_txt = align_and_count.report_top_hits
+    }
+
+    output {
+        File report               = align_and_count_summary.report
+        File report_top_hits      = align_and_count_summary_top_hits.report
+        String viral_core_version = align_and_count_summary.viralngs_version
+    }
+}

--- a/pipes/WDL/workflows/align_and_count_multiple_report.wdl
+++ b/pipes/WDL/workflows/align_and_count_multiple_report.wdl
@@ -26,7 +26,7 @@ workflow align_and_count_multiple_report {
     }
 
     scatter(raw_reads in reads_unmapped_bams) {
-        call reports.align_and_count{
+        call reports.align_and_count {
             input:
                 reads_bam = raw_reads,
                 ref_db    = ref_db

--- a/pipes/WDL/workflows/align_and_count_multiple_report.wdl
+++ b/pipes/WDL/workflows/align_and_count_multiple_report.wdl
@@ -40,12 +40,13 @@ workflow align_and_count_multiple_report {
 
     call reports.align_and_count_summary as align_and_count_summary_top_hits {
         input:
-            counts_txt = align_and_count.report_top_hits
+            counts_txt    = align_and_count.report_top_hits,
+            output_prefix = "count_summary_top_hits"
     }
 
     output {
-        File report               = align_and_count_summary.report
-        File report_top_hits      = align_and_count_summary_top_hits.report
+        File report               = align_and_count_summary.count_summary
+        File report_top_hits      = align_and_count_summary_top_hits.count_summary
         String viral_core_version = align_and_count_summary.viralngs_version
     }
 }

--- a/requirements-modules.txt
+++ b/requirements-modules.txt
@@ -1,7 +1,7 @@
 broadinstitute/viral-core=2.1.0
-broadinstitute/viral-assemble=2.0.21.0
-broadinstitute/viral-classify=2.0.21.3
-broadinstitute/viral-phylo=2.0.21.5
+broadinstitute/viral-assemble=2.1.0.0
+broadinstitute/viral-classify=2.1.0.0
+broadinstitute/viral-phylo=2.1.0.0
 broadinstitute/beast-beagle-cuda=1.10.5
 nextstrain/base=build-20200506T095107Z
 andersenlabapps/ivar=1.2.2

--- a/requirements-modules.txt
+++ b/requirements-modules.txt
@@ -1,4 +1,4 @@
-broadinstitute/viral-core=2.0.21
+broadinstitute/viral-core=2.1.0
 broadinstitute/viral-assemble=2.0.21.0
 broadinstitute/viral-classify=2.0.21.3
 broadinstitute/viral-phylo=2.0.21.5


### PR DESCRIPTION
 - add `align_and_count_multiple_report` workflow to aggregate multiple spike-in/alignment count reports from the `align_and_count` task (input multiple bam files, output two aggregate reports: one with all counts, one with top-3 counts per bam); 
 - bump viral-core dependency 2.0.21 -> 2.1.0 to have reports.py::aggregate_alignment_counts()

This should also fix an issue where count reports would result in empty summary output if they did not end with `*.spike_count.txt`.