### PR TITLE
rmdup VM resize and filter_bam_to_taxa bugfix

### DIFF
--- a/pipes/WDL/tasks/tasks_metagenomics.wdl
+++ b/pipes/WDL/tasks/tasks_metagenomics.wdl
@@ -665,11 +665,16 @@ task filter_bam_to_taxa {
 
     touch taxfilterargs
     TAXNAMELIST="${write_lines(select_first([taxonomic_names, []]))}"
-    if [ -n "$(cat $TAXNAMELIST)" ]; then echo "--taxNames" >> taxfilterargs; fi
+    if [ -n "$(cat $TAXNAMELIST)" ]; then
+      echo "--taxNames" >> taxfilterargs
+    fi
     cat $TAXNAMELIST >> taxfilterargs
 
-    TAX_IDs="${sep=' ' taxonomic_ids}"
-    if [ -n "$TAX_IDs" ]; then TAX_IDs="--taxIDs $TAX_IDs"; fi
+    TAXIDLIST="${write_lines(select_first([taxonomic_ids, []]))}"
+    if [ -n "$(cat $TAXIDLIST)" ]; then
+      echo "--taxIDs" >> taxfilterargs
+    fi
+    cat $TAXIDLIST >> taxfilterargs
 
     metagenomics.py --version | tee VERSION
 
@@ -681,7 +686,6 @@ task filter_bam_to_taxa {
       "${out_basename}.bam" \
       nodes.dmp \
       names.dmp \
-      $TAX_IDs \
       ${true='--exclude' false='' exclude_taxa} \
       ${true='--without-children' false='' withoutChildren} \
       ${'--minimum_hit_groups=' + minimum_hit_groups} \

--- a/pipes/WDL/tasks/tasks_read_utils.wdl
+++ b/pipes/WDL/tasks/tasks_read_utils.wdl
@@ -109,7 +109,7 @@ task rmdup_ubam {
     memory: select_first([machine_mem_gb, 7]) + " GB"
     cpu:    2
     disks:  "local-disk 375 LOCAL"
-    dx_instance_type: "mem1_ssd1_v2_x2"
+    dx_instance_type: "mem2_ssd1_v2_x2"
   }
 }
 


### PR DESCRIPTION
This PR does two small fixes
1. increase default DNAnexus VM size for rmdup_ubam task to give Picard FilterSamReads enough memory (now matches the normal `memory` runtime default)
2. bugfix filter_bam_to_taxa.taxonomic_ids input parsing, which was failing previously, and is now xargs-based.