### PR TITLE
version ncbi-tools docker image

### DIFF
--- a/requirements-modules.txt
+++ b/requirements-modules.txt
@@ -3,5 +3,6 @@ broadinstitute/viral-assemble=2.1.0.0
 broadinstitute/viral-classify=2.1.0.0
 broadinstitute/viral-phylo=2.1.0.0
 broadinstitute/beast-beagle-cuda=1.10.5
+broadinstitute/ncbi-tools=2.10.7.0
 nextstrain/base=build-20200506T095107Z
 andersenlabapps/ivar=1.2.2


### PR DESCRIPTION
WDL tasks that used quay.io/broadinstitute/ncbi-tools were previously referencing the `:latest` tag instead of a pinned version number. This pins it to the latest release version.