### PR TITLE
build demux_plus_launcher and demux_only_launcher

### DIFF
--- a/pipes/dnax/dx-launcher/demux_launcher.yml
+++ b/pipes/dnax/dx-launcher/demux_launcher.yml
@@ -1,8 +1,8 @@
 # DNAnexus applet to build with dx-yml-build which can be found here:
 # https://gist.githubusercontent.com/mlin/3cce81f54a640c3f62a2725acbc98283/raw/e071dfe1989c31f6267334106115620770e6d21c/dx-yml-build
 # To build, save this file as dxapp.yml and run that script alongside.
-name: demux_launcher
-title: demux_launcher
+name: DEFAULT_DEMUX_WORKFLOW_NAME
+title: DEFAULT_DEMUX_WORKFLOW_NAME
 dxapi: 1.0.0
 version: 0.0.1
 description: Launches demux/demux-plus workflow on each lane of a sequencing run, given the incremental uploader sentinel record.

--- a/pipes/dnax/dx-launcher/dx-yml-build
+++ b/pipes/dnax/dx-launcher/dx-yml-build
@@ -8,11 +8,11 @@
 import os, sys
 import yaml, json
 
-with open('dxapp.yml') as infile:
+with open(sys.argv[1]) as infile:
     data = yaml.load(infile)
     data["00COMMENT"] = "This dxapp.json has been generated from dxapp.yml automatically using dx-yml-build"
     with open('dxapp.json', 'w') as outfile:
         json.dump(data, outfile, sort_keys=True, indent=2)
         outfile.write('\n')
 
-os.execvp("dx", ["dx", "build"] + sys.argv[1:])
+os.execvp("dx", ["dx", "build"] + sys.argv[2:])

--- a/pipes/dnax/dx-launcher/dx-yml-build
+++ b/pipes/dnax/dx-launcher/dx-yml-build
@@ -5,14 +5,20 @@
 #
 # Requires PyYAML (apt-get install python-yaml OR pip install pyyaml)
 
-import os, sys
+import os, sys, shutil
 import yaml, json
 
-with open(sys.argv[1]) as infile:
+app_yaml_path=sys.argv[1]
+app_basename=os.path.splitext(os.path.basename(app_yaml_path))[0]
+
+output_json_filename=app_basename+'.json'
+
+with open(app_yaml_path) as infile:
     data = yaml.load(infile)
-    data["00COMMENT"] = "This dxapp.json has been generated from dxapp.yml automatically using dx-yml-build"
-    with open('dxapp.json', 'w') as outfile:
+    data["00COMMENT"] = "This {}.json has been generated from {} automatically using dx-yml-build".format(app_basename,app_yaml_path)
+    with open(output_json_filename, 'w') as outfile:
         json.dump(data, outfile, sort_keys=True, indent=2)
         outfile.write('\n')
 
+shutil.copy2(output_json_filename,"dxapp.json")
 os.execvp("dx", ["dx", "build"] + sys.argv[2:])

--- a/travis/build-dx.sh
+++ b/travis/build-dx.sh
@@ -62,7 +62,7 @@ echo -e "consolidate_run_tarballs\t$dx_id" >> $COMPILE_SUCCESS
 demux_workflows_to_build="demux_plus demux_only"
 for wf_name in $(echo "${demux_workflows_to_build}"); do
   echo "Building applet ${wf_name}..."
-  demux_workflow_id=$(grep "${wf_name}" $COMPILE_SUCCESS | cut -f 2)
+  demux_workflow_id=$(grep "^${wf_name}\s" $COMPILE_SUCCESS | cut -f 2)
   pushd pipes/dnax/dx-launcher
   sed "s/DEFAULT_DEMUX_WORKFLOW_ID/$demux_workflow_id/" demux_launcher.yml \
     | sed "s/DEFAULT_DEMUX_WORKFLOW_NAME/${wf_name}_launcher/" \

--- a/travis/build-dx.sh
+++ b/travis/build-dx.sh
@@ -50,18 +50,24 @@ for workflow in pipes/WDL/workflows/*.wdl; do
   fi
 done
 
-# Special case: build demux_launcher (a native DNAnexus applet), embedding the
-# demux_plus workflow ID as a default input
-demux_plus_workflow_id=$(grep demux_plus $COMPILE_SUCCESS | cut -f 2)
+# build consolidate_run_tarballs (native DNAnexus applet) applet
 pushd pipes/dnax/dx-launcher
-cp consolidate_run_tarballs.yml dxapp.yml
-dx_id=$(./dx-yml-build -a --destination /build/$VERSION/ | jq -r ".id")
+cp consolidate_run_tarballs.yml consolidate_run_tarballs_dxapp.yml
+dx_id=$(./dx-yml-build consolidate_run_tarballs_dxapp.yml -a --destination /build/$VERSION/ | jq -r ".id")
 echo -e "consolidate_run_tarballs\t$dx_id" >> $COMPILE_SUCCESS
-sed "s/DEFAULT_DEMUX_WORKFLOW_ID/$demux_plus_workflow_id/" demux_launcher.yml \
-  | sed "s/DEFAULT_CONSOLIDATE_RUN_TARBALLS_APPLET_ID/$dx_id/" > dxapp.yml
-dx_id=$(./dx-yml-build -a --destination /build/$VERSION/ | jq -r ".id")
-popd
-echo -e "demux_launcher\t$dx_id" >> $COMPILE_SUCCESS
+
+# Special case: build demux launchers (native DNAnexus applets), embedding the
+# demux workflow ID as a default input 
+demux_workflows_to_build="demux_plus demux_only"
+for wf_name in $(echo "${demux_workflows_to_build}"); do
+  demux_workflow_id=$(grep "${wf_name}" $COMPILE_SUCCESS | cut -f 2)  
+  sed "s/DEFAULT_DEMUX_WORKFLOW_ID/$demux_workflow_id/" demux_launcher.yml \
+    | sed "s/DEFAULT_DEMUX_WORKFLOW_NAME/${wf_name}_launcher/" \
+    | sed "s/DEFAULT_CONSOLIDATE_RUN_TARBALLS_APPLET_ID/$dx_id/" > "${wf_name}_dxapp.yml"
+  dx_id=$(./dx-yml-build ${wf_name}_dxapp.yml -a --destination /build/$VERSION/ | jq -r ".id")
+  popd
+  echo -e "${wf_name}_launcher\t$dx_id" >> $COMPILE_SUCCESS
+done
 
 # the presence of this file in the project denotes successful build
 dx upload --brief --no-progress --destination /build/$VERSION/ $COMPILE_SUCCESS

--- a/travis/build-dx.sh
+++ b/travis/build-dx.sh
@@ -60,6 +60,7 @@ echo -e "consolidate_run_tarballs\t$dx_id" >> $COMPILE_SUCCESS
 # demux workflow ID as a default input 
 demux_workflows_to_build="demux_plus demux_only"
 for wf_name in $(echo "${demux_workflows_to_build}"); do
+  echo "Building applet ${wf_name...}"
   demux_workflow_id=$(grep "${wf_name}" $COMPILE_SUCCESS | cut -f 2)  
   sed "s/DEFAULT_DEMUX_WORKFLOW_ID/$demux_workflow_id/" demux_launcher.yml \
     | sed "s/DEFAULT_DEMUX_WORKFLOW_NAME/${wf_name}_launcher/" \

--- a/travis/build-dx.sh
+++ b/travis/build-dx.sh
@@ -61,7 +61,7 @@ echo -e "consolidate_run_tarballs\t$dx_id" >> $COMPILE_SUCCESS
 # demux workflow ID as a default input 
 demux_workflows_to_build="demux_plus demux_only"
 for wf_name in $(echo "${demux_workflows_to_build}"); do
-  echo "Building applet ${wf_name...}"
+  echo "Building applet ${wf_name}..."
   demux_workflow_id=$(grep "${wf_name}" $COMPILE_SUCCESS | cut -f 2)
   pushd pipes/dnax/dx-launcher
   sed "s/DEFAULT_DEMUX_WORKFLOW_ID/$demux_workflow_id/" demux_launcher.yml \

--- a/travis/build-dx.sh
+++ b/travis/build-dx.sh
@@ -54,6 +54,7 @@ done
 pushd pipes/dnax/dx-launcher
 cp consolidate_run_tarballs.yml consolidate_run_tarballs_dxapp.yml
 dx_id=$(./dx-yml-build consolidate_run_tarballs_dxapp.yml -a --destination /build/$VERSION/ | jq -r ".id")
+popd
 echo -e "consolidate_run_tarballs\t$dx_id" >> $COMPILE_SUCCESS
 
 # Special case: build demux launchers (native DNAnexus applets), embedding the
@@ -61,7 +62,8 @@ echo -e "consolidate_run_tarballs\t$dx_id" >> $COMPILE_SUCCESS
 demux_workflows_to_build="demux_plus demux_only"
 for wf_name in $(echo "${demux_workflows_to_build}"); do
   echo "Building applet ${wf_name...}"
-  demux_workflow_id=$(grep "${wf_name}" $COMPILE_SUCCESS | cut -f 2)  
+  demux_workflow_id=$(grep "${wf_name}" $COMPILE_SUCCESS | cut -f 2)
+  pushd pipes/dnax/dx-launcher
   sed "s/DEFAULT_DEMUX_WORKFLOW_ID/$demux_workflow_id/" demux_launcher.yml \
     | sed "s/DEFAULT_DEMUX_WORKFLOW_NAME/${wf_name}_launcher/" \
     | sed "s/DEFAULT_CONSOLIDATE_RUN_TARBALLS_APPLET_ID/$dx_id/" > "${wf_name}_dxapp.yml"

--- a/travis/tests-dx.sh
+++ b/travis/tests-dx.sh
@@ -78,7 +78,6 @@ else
   demux_name="demux_only"
 fi
 
-set -x
 # Special case: run test for the demux_(plus|only)_launcher native applet (which invokes
 # the demux_(plus|only) WDL workflow)
 demux_launcher_id=$(grep "^${demux_name}_launcher\s" $COMPILE_SUCCESS | cut -f 2)
@@ -99,4 +98,3 @@ echo -e "${demux_name}_launcher\t$demux_launcher_id\t$dx_job_id" >> $TEST_LAUNCH
 
 # the presence of this file in the project denotes all tests launched
 dx upload --brief --no-progress --destination /build/$VERSION/ $TEST_LAUNCH_ALL
-set +x

--- a/travis/tests-dx.sh
+++ b/travis/tests-dx.sh
@@ -78,14 +78,15 @@ else
   demux_name="demux_only"
 fi
 
+set -x
 # Special case: run test for the demux_(plus|only)_launcher native applet (which invokes
 # the demux_(plus|only) WDL workflow)
 demux_launcher_id=$(grep "${demux_name}_launcher" $COMPILE_SUCCESS | cut -f 2)
 
 demux_workflow_id=$(grep "${demux_name}" $COMPILE_SUCCESS | cut -f 2)
 
-timeout_args=$(dx_run_timeout_args $demux_workflow_id $demux_launcher_id )
-dx_job_id=$(dx run $demux_launcher_id \
+timeout_args=$(dx_run_timeout_args $demux_workflow_id $demux_launcher_id)
+dx_job_id=$(dx run "${demux_launcher_id}" \
   -y --brief \
   -i upload_sentinel_record=record-Bv8qkgQ0jy198GK0QVz2PV8Y \
   -i demux_workflow_id=${demux_workflow_id} \
@@ -98,3 +99,4 @@ echo -e "${demux_name}_launcher\t$demux_launcher_id\t$dx_job_id" >> $TEST_LAUNCH
 
 # the presence of this file in the project denotes all tests launched
 dx upload --brief --no-progress --destination /build/$VERSION/ $TEST_LAUNCH_ALL
+set +x

--- a/travis/tests-dx.sh
+++ b/travis/tests-dx.sh
@@ -81,9 +81,9 @@ fi
 set -x
 # Special case: run test for the demux_(plus|only)_launcher native applet (which invokes
 # the demux_(plus|only) WDL workflow)
-demux_launcher_id=$(grep "${demux_name}_launcher" $COMPILE_SUCCESS | cut -f 2)
+demux_launcher_id=$(grep "^${demux_name}_launcher\s" $COMPILE_SUCCESS | cut -f 2)
 
-demux_workflow_id=$(grep "${demux_name}" $COMPILE_SUCCESS | cut -f 2)
+demux_workflow_id=$(grep "^${demux_name}\s" $COMPILE_SUCCESS | cut -f 2)
 
 timeout_args=$(dx_run_timeout_args $demux_workflow_id $demux_launcher_id)
 dx_job_id=$(dx run "${demux_launcher_id}" \

--- a/travis/tests-dx.sh
+++ b/travis/tests-dx.sh
@@ -80,21 +80,21 @@ fi
 
 # Special case: run test for the demux_(plus|only)_launcher native applet (which invokes
 # the demux_(plus|only) WDL workflow)
-demux_launcher_id=$(grep ${demux_name}_launcher $COMPILE_SUCCESS | cut -f 2)
+demux_launcher_id=$(grep "${demux_name}_launcher" $COMPILE_SUCCESS | cut -f 2)
 
-demux_workflow_id=$(grep ${demux_name} $COMPILE_SUCCESS | cut -f 2)
+demux_workflow_id=$(grep "${demux_name}" $COMPILE_SUCCESS | cut -f 2)
 
-timeout_args=$(dx_run_timeout_args $demux_workflow_id $demux_launcher_id)
-dx_job_id=$(dx run \
-  $demux_launcher_id -y --brief \
+timeout_args=$(dx_run_timeout_args $demux_workflow_id $demux_launcher_id )
+dx_job_id=$(dx run $demux_launcher_id \
+  -y --brief \
   -i upload_sentinel_record=record-Bv8qkgQ0jy198GK0QVz2PV8Y \
   -i demux_workflow_id=${demux_workflow_id} \
   --name "$VERSION ${demux_name}_launcher" \
   -i folder=/tests/$VERSION/${demux_name}_launcher \
   --extra-args $timeout_args \
   )
-echo "Launched demux_launcher as $dx_job_id"
-echo -e "demux_launcher\t$demux_launcher_id\t$dx_job_id" >> $TEST_LAUNCH_ALL
+echo "Launched ${demux_name}_launcher as $dx_job_id"
+echo -e "${demux_name}_launcher\t$demux_launcher_id\t$dx_job_id" >> $TEST_LAUNCH_ALL
 
 # the presence of this file in the project denotes all tests launched
 dx upload --brief --no-progress --destination /build/$VERSION/ $TEST_LAUNCH_ALL

--- a/travis/tests-dx.sh
+++ b/travis/tests-dx.sh
@@ -70,25 +70,27 @@ for workflow in pipes/WDL/workflows/*.wdl; do
   fi
 done
 
-# Special case: run test for the demux_launcher native applet (which invokes
-# the demux_plus WDL workflow)
-demux_launcher_id=$(grep demux_launcher $COMPILE_SUCCESS | cut -f 2)
-
 # only run demux_plus if this is on master or tagged branch
 if [ "$TRAVIS_BRANCH" = "master" -o -n "$TRAVIS_TAG" ]; then
-  demux_workflow_id=$(grep demux_plus $COMPILE_SUCCESS | cut -f 2)
+  demux_name="demux_plus"
 else
   # otherwise just run the (faster) demux_only
-  demux_workflow_id=$(grep demux_only $COMPILE_SUCCESS | cut -f 2)
+  demux_name="demux_only"
 fi
+
+# Special case: run test for the demux_(plus|only)_launcher native applet (which invokes
+# the demux_(plus|only) WDL workflow)
+demux_launcher_id=$(grep ${demux_name}_launcher $COMPILE_SUCCESS | cut -f 2)
+
+demux_workflow_id=$(grep ${demux_name} $COMPILE_SUCCESS | cut -f 2)
 
 timeout_args=$(dx_run_timeout_args $demux_workflow_id $demux_launcher_id)
 dx_job_id=$(dx run \
   $demux_launcher_id -y --brief \
   -i upload_sentinel_record=record-Bv8qkgQ0jy198GK0QVz2PV8Y \
   -i demux_workflow_id=${demux_workflow_id} \
-  --name "$VERSION demux_launcher" \
-  -i folder=/tests/$VERSION/demux_launcher \
+  --name "$VERSION ${demux_name}_launcher" \
+  -i folder=/tests/$VERSION/${demux_name}_launcher \
   --extra-args $timeout_args \
   )
 echo "Launched demux_launcher as $dx_job_id"


### PR DESCRIPTION
This PR adds a build for a new native DNAnexus applet, `demux_only_launcher`, and renames the previous one `demux_launcher` -> `demux_plus_launcher` so there are now two launchers available:
 - `demux_plus_launcher`
 - `demux_only_launcher`

Having two demux launchers supports greater flexibility of which demux workflow is started after automated upload via [dx-streaming-upload](https://github.com/dnanexus-rnd/dx-streaming-upload/blob/master/files/monitor_runs.py).