### PR TITLE
nextstrain: add augur mask step

### DIFF
--- a/pipes/WDL/tasks/tasks_nextstrain.wdl
+++ b/pipes/WDL/tasks/tasks_nextstrain.wdl
@@ -186,6 +186,37 @@ task augur_mafft_align {
     }
 }
 
+task augur_mask_sites {
+    meta {
+        description: "Mask unwanted positions from alignment. See https://nextstrain-augur.readthedocs.io/en/stable/usage/cli/mask.html"
+    }
+    input {
+        File     sequences
+        File?    mask_bed
+
+        String   docker = "nextstrain/base"
+    }
+    String basename = basename(sequences, '.fasta')
+    command {
+        augur version > VERSION
+        augur mask --sequences ~{sequences} \
+            --mask ~{select_first([mask_bed, "/dev/null"])} \
+            --output ~{basename}_masked.fasta
+    }
+    runtime {
+        docker: docker
+        memory: "3 GB"
+        cpu :   2
+        disks:  "local-disk 100 HDD"
+        preemptible: 2
+        dx_instance_type: "mem1_ssd1_v2_x2"
+    }
+    output {
+        File masked_sequences = "~{basename}_masked.fasta"
+        String augur_version = read_string("VERSION")
+    }
+}
+
 task draft_augur_tree {
     meta {
         description: "Build a tree using a variety of methods. See https://nextstrain-augur.readthedocs.io/en/stable/usage/cli/tree.html"

--- a/pipes/WDL/workflows/build_augur_tree.wdl
+++ b/pipes/WDL/workflows/build_augur_tree.wdl
@@ -64,15 +64,19 @@ workflow build_augur_tree {
             ref_fasta = ref_fasta,
             basename  = virus
     }
+    call nextstrain.augur_mask_sites {
+        input:
+            sequences = augur_mafft_align.aligned_sequences
+    }
     call nextstrain.draft_augur_tree {
         input:
-            aligned_fasta  = augur_mafft_align.aligned_sequences,
+            aligned_fasta  = augur_mask_sites.masked_sequences,
             basename       = virus
     }
     call nextstrain.refine_augur_tree {
         input:
             raw_tree       = draft_augur_tree.aligned_tree,
-            aligned_fasta  = augur_mafft_align.aligned_sequences,
+            aligned_fasta  = augur_mask_sites.masked_sequences,
             metadata       = sample_metadata,
             basename       = virus
     }
@@ -88,7 +92,7 @@ workflow build_augur_tree {
     call nextstrain.ancestral_tree {
         input:
             refined_tree   = refine_augur_tree.tree_refined,
-            aligned_fasta  = augur_mafft_align.aligned_sequences,
+            aligned_fasta  = augur_mask_sites.masked_sequences,
             basename       = virus
     }
     call nextstrain.translate_augur_tree {
@@ -123,6 +127,7 @@ workflow build_augur_tree {
     output {
         File  combined_assembly_fasta    = concatenate.combined
         File  augur_aligned_fasta        = augur_mafft_align.aligned_sequences
+        File  masked_fasta        = augur_mask_sites.masked_sequences
         File  raw_tree                   = draft_augur_tree.aligned_tree
         File  refined_tree               = refine_augur_tree.tree_refined
         File  branch_lengths             = refine_augur_tree.branch_lengths


### PR DESCRIPTION
This adds an explicit `augur mask` task that gets run after the mafft alignment. Previously, we were using the `--exclude-sites` option to `augur tree` to get iqtree to ignore certain variants from the alignment. However, the original unmasked alignment was still being passed to `augur refine` and `augur ancestral`. This changes the workflow such that all downstream tasks never see the original mafft alignment--only the masked one.