### PR TITLE
bump viral-core to 2.1.6

### DIFF
--- a/requirements-modules.txt
+++ b/requirements-modules.txt
@@ -1,4 +1,4 @@
-broadinstitute/viral-core=2.1.4
+broadinstitute/viral-core=2.1.5
 broadinstitute/viral-assemble=2.1.4.0
 broadinstitute/viral-classify=2.1.4.0
 broadinstitute/viral-phylo=2.1.4.0

--- a/requirements-modules.txt
+++ b/requirements-modules.txt
@@ -1,4 +1,4 @@
-broadinstitute/viral-core=2.1.5
+broadinstitute/viral-core=2.1.6
 broadinstitute/viral-assemble=2.1.4.0
 broadinstitute/viral-classify=2.1.4.0
 broadinstitute/viral-phylo=2.1.4.0


### PR DESCRIPTION
bump viral-core from 2.1.4 to 2.1.6, fixing a number of upstream bugs