### PR TITLE
more ram

### DIFF
--- a/pipes/WDL/tasks/tasks_metagenomics.wdl
+++ b/pipes/WDL/tasks/tasks_metagenomics.wdl
@@ -657,6 +657,7 @@ task filter_bam_to_taxa {
     Boolean        exclude_taxa=false
     String         out_filename_suffix = "filtered"
 
+    Int?           machine_mem_gb
     String         docker="quay.io/broadinstitute/viral-classify"
   }
 
@@ -721,10 +722,10 @@ task filter_bam_to_taxa {
 
   runtime {
     docker: "${docker}"
-    memory: "13 GB"
+    memory: select_first([machine_mem_gb, 26]) + " GB"
     disks: "local-disk 375 LOCAL"
-    cpu: 2
-    dx_instance_type: "mem3_ssd1_v2_x2"
+    cpu: 4
+    dx_instance_type: "mem3_ssd1_v2_x4"
   }
 
 }

--- a/pipes/WDL/tasks/tasks_reports.wdl
+++ b/pipes/WDL/tasks/tasks_reports.wdl
@@ -177,7 +177,7 @@ task align_and_count {
   }
 
   runtime {
-    memory: select_first([machine_mem_gb, 3]) + " GB"
+    memory: select_first([machine_mem_gb, 15]) + " GB"
     cpu: 4
     docker: "${docker}"
     disks: "local-disk 375 LOCAL"


### PR DESCRIPTION
more ram for filter_bam_reads_to_taxa which currently relies on Picard FilterSamReads which loads an entire read list into memory (and for large runs, 13GB RAM isn't enough). Ultimately, we really ought to address [this](https://github.com/broadinstitute/viral-core/issues/22), but this is the current workaround.