### PR TITLE
nextstrain wdl updates

### DIFF
--- a/pipes/WDL/tasks/tasks_nextstrain.wdl
+++ b/pipes/WDL/tasks/tasks_nextstrain.wdl
@@ -645,7 +645,7 @@ task assign_clades_to_nodes {
         preemptible: 1
     }
     output {
-        File   node_clade_data_json = "~{out_basename}_node-clade-assignments.json"
+        File   node_clade_data_json = "~{out_basename}_clades.json"
         Int    max_ram_gb = ceil(read_float("MEM_BYTES")/1000000000)
         String augur_version      = read_string("VERSION")
     }

--- a/pipes/WDL/tasks/tasks_nextstrain.wdl
+++ b/pipes/WDL/tasks/tasks_nextstrain.wdl
@@ -83,8 +83,8 @@ task filter_subsample_sequences {
 
         Boolean  non_nucleotide=true
 
-        String?  min_date
-        String?  max_date
+        Float?   min_date
+        Float?   max_date
         Int?     min_length
         File?    priority
         Int?     subsample_seed

--- a/pipes/WDL/tasks/tasks_nextstrain.wdl
+++ b/pipes/WDL/tasks/tasks_nextstrain.wdl
@@ -202,7 +202,7 @@ task mafft_one_chr {
     }
     runtime {
         docker: docker
-        memory: "28 GB"
+        memory: "60 GB"
         cpu :   32
         disks:  "local-disk 100 HDD"
         preemptible: 1

--- a/pipes/WDL/tasks/tasks_nextstrain.wdl
+++ b/pipes/WDL/tasks/tasks_nextstrain.wdl
@@ -157,7 +157,7 @@ task custom_mafft_align {
         File     sequences
         File     ref_fasta
         String   basename
-        Boolean  remove_reference = true
+        Boolean  remove_reference = false
 
         String   docker = "quay.io/broadinstitute/viral-phylo"
     }
@@ -195,7 +195,7 @@ task custom_mafft_align {
         cpu :   32
         disks:  "local-disk 100 HDD"
         preemptible: 1
-        dx_instance_type: "mem1_ssd1_v2_x32"
+        dx_instance_type: "mem1_ssd1_v2_x36"
     }
     output {
         File   aligned_sequences = "~{basename}_aligned.fasta"

--- a/pipes/WDL/workflows/augur_from_assemblies.wdl
+++ b/pipes/WDL/workflows/augur_from_assemblies.wdl
@@ -58,7 +58,7 @@ workflow augur_from_assemblies {
                 sequences_fasta     = concatenate.combined,
                 sample_metadata_tsv = sample_metadata
     }
-    call nextstrain.augur_mafft_align {
+    call nextstrain.mafft_one_chr as mafft {
         input:
             sequences = filter_subsample_sequences.filtered_fasta,
             ref_fasta = ref_fasta,
@@ -66,11 +66,11 @@ workflow augur_from_assemblies {
     }
     call nextstrain.snp_sites {
         input:
-            msa_fasta = augur_mafft_align.aligned_sequences
+            msa_fasta = mafft.aligned_sequences
     }
     call nextstrain.augur_mask_sites {
         input:
-            sequences = augur_mafft_align.aligned_sequences
+            sequences = mafft.aligned_sequences
     }
     call nextstrain.draft_augur_tree {
         input:
@@ -125,7 +125,7 @@ workflow augur_from_assemblies {
 
     output {
         File  combined_assemblies = concatenate.combined
-        File  multiple_alignment  = augur_mafft_align.aligned_sequences
+        File  multiple_alignment  = mafft.aligned_sequences
         File  unmasked_snps       = snp_sites.snps_vcf
         File  masked_alignment    = augur_mask_sites.masked_sequences
         File  ml_tree             = draft_augur_tree.aligned_tree

--- a/pipes/WDL/workflows/augur_from_msa.wdl
+++ b/pipes/WDL/workflows/augur_from_msa.wdl
@@ -11,6 +11,7 @@ workflow augur_from_msa {
 
     input {
         File            msa_or_vcf
+        File?           sequence_ids_to_keep
         File            sample_metadata
         File            ref_fasta
         File            genbank_gb
@@ -22,6 +23,10 @@ workflow augur_from_msa {
         msa_or_vcf: {
           description: "Multiple sequence alignment (aligned fasta) or variants (vcf format).",
           patterns: ["*.fasta", "*.fa", "*.vcf", "*.vcf.gz"]
+        }
+        sequence_ids_to_keep: {
+          description: "Optional list of sequence IDs (one per line) to filter the msa_or_vcf to at the beginning (otherwise we compute on all sequences in msa_to_vcf).",
+          patterns: ["*.txt", "*.tsv"]
         }
         sample_metadata: {
           description: "Metadata in tab-separated text format. See https://nextstrain-augur.readthedocs.io/en/stable/faq/metadata.html for details.",
@@ -44,9 +49,14 @@ workflow augur_from_msa {
         }
     }
 
+    call nextstrain.filter_sequences_to_list {
+        input:
+            sequences = msa_or_vcf,
+            keep_list = sequence_ids_to_keep
+    }
     call nextstrain.augur_mask_sites {
         input:
-            sequences = msa_or_vcf
+            sequences = filter_sequences_to_list.filtered_fasta
     }
     call nextstrain.draft_augur_tree {
         input:

--- a/pipes/WDL/workflows/filter_sequences.wdl
+++ b/pipes/WDL/workflows/filter_sequences.wdl
@@ -1,0 +1,11 @@
+version 1.0
+
+import "../tasks/tasks_nextstrain.wdl" as nextstrain
+
+workflow filter_sequences {
+    meta {
+        description: "Filter and subsample a sequence set. See https://nextstrain-augur.readthedocs.io/en/stable/usage/cli/filter.html"
+    }
+
+    call nextstrain.filter_subsample_sequences as filter
+}

--- a/pipes/WDL/workflows/mafft_iqtree.wdl
+++ b/pipes/WDL/workflows/mafft_iqtree.wdl
@@ -1,0 +1,59 @@
+version 1.0
+
+import "../tasks/tasks_nextstrain.wdl" as nextstrain
+
+workflow mafft_iqtree {
+    meta {
+        description: "Align assemblies, mask sites, build tree."
+        author: "Broad Viral Genomics"
+        email:  "viral-ngs@broadinstitute.org"
+    }
+
+    input {
+        Array[File]     assembly_fastas
+        File            ref_fasta
+    }
+
+    parameter_meta {
+        assembly_fastas: {
+          description: "Set of assembled genomes to align and build trees. These must represent a single chromosome/segment of a genome only. Fastas may be one-sequence-per-individual or a concatenated multi-fasta (unaligned) or a mixture of the two.",
+          patterns: ["*.fasta", "*.fa"]
+        }
+        ref_fasta: {
+          description: "A reference assembly (not included in assembly_fastas) to align assembly_fastas against. Typically from NCBI RefSeq or similar.",
+          patterns: ["*.fasta", "*.fa"]
+        }
+    }
+
+    call nextstrain.concatenate {
+        input:
+            infiles     = assembly_fastas,
+            output_name = "all_samples_combined_assembly.fasta"
+    }
+    call nextstrain.mafft_one_chr as mafft {
+        input:
+            sequences = concatenate.combined,
+            ref_fasta = ref_fasta,
+            basename  = "all_samples_aligned.fasta"
+    }
+    call nextstrain.snp_sites {
+        input:
+            msa_fasta = mafft.aligned_sequences
+    }
+    call nextstrain.augur_mask_sites {
+        input:
+            sequences = mafft.aligned_sequences
+    }
+    call nextstrain.draft_augur_tree {
+        input:
+            msa_or_vcf = augur_mask_sites.masked_sequences
+    }
+
+    output {
+        File  combined_assemblies = concatenate.combined
+        File  multiple_alignment  = mafft.aligned_sequences
+        File  unmasked_snps       = snp_sites.snps_vcf
+        File  masked_alignment    = augur_mask_sites.masked_sequences
+        File  ml_tree             = draft_augur_tree.aligned_tree
+    }
+}


### PR DESCRIPTION
- add mafft_iqtree workflow that is entirely metadata free (just sequences)
- add a filter step and add to the beginning of augur_from_msa
- replace augur align with custom task that directly calls `mafft --addfragments --keeplength` and use this instead in augur_from_assemblies and mafft_iqtree (closes #108)