### PR TITLE
dockstore 1.9 integration

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,0 @@
-*.pyc
-__pycache__
-tools/conda-cache
-tools/conda-tools

--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -1,0 +1,227 @@
+version: 1.2
+workflows:
+ - name: align_and_count_multiple_report
+   subclass: WDL
+   primaryDescriptorPath: pipes/WDL/workflows/align_and_count_multiple_report.wdl
+   testParameterFiles:
+    - empty.json
+ - name: align_and_count
+   subclass: WDL
+   primaryDescriptorPath: pipes/WDL/workflows/align_and_count.wdl
+   testParameterFiles:
+    - empty.json
+ - name: align_and_plot
+   subclass: WDL
+   primaryDescriptorPath: pipes/WDL/workflows/align_and_plot.wdl
+   testParameterFiles:
+    - test/input/WDL/test_inputs-align_and_plot-local.json
+ - name: assemble_denovo
+   subclass: WDL
+   primaryDescriptorPath: pipes/WDL/workflows/assemble_denovo.wdl
+   testParameterFiles:
+    - test/input/WDL/test_inputs-assemble_denovo-local.json
+ - name: assemble_refbased
+   subclass: WDL
+   primaryDescriptorPath: pipes/WDL/workflows/assemble_refbased.wdl
+   testParameterFiles:
+    - test/input/WDL/test_inputs-assemble_refbased-local.json
+ - name: augur_from_assemblies
+   subclass: WDL
+   primaryDescriptorPath: pipes/WDL/workflows/augur_from_assemblies.wdl
+   testParameterFiles:
+    - test/input/WDL/test_inputs-augur_from_assemblies-local.json
+ - name: augur_from_beast_mcc
+   subclass: WDL
+   primaryDescriptorPath: pipes/WDL/workflows/augur_from_beast_mcc.wdl
+   testParameterFiles:
+    - test/input/WDL/test_inputs-augur_from_beast_mcc-local.json
+ - name: augur_from_msa
+   subclass: WDL
+   primaryDescriptorPath: pipes/WDL/workflows/augur_from_msa.wdl
+   testParameterFiles:
+    - empty.json
+ - name: augur_from_newick
+   subclass: WDL
+   primaryDescriptorPath: pipes/WDL/workflows/augur_from_newick.wdl
+   testParameterFiles:
+    - empty.json
+ - name: bams_multiqc
+   subclass: WDL
+   primaryDescriptorPath: pipes/WDL/workflows/bams_multiqc.wdl
+   testParameterFiles:
+    - empty.json
+ - name: beast_gpu
+   subclass: WDL
+   primaryDescriptorPath: pipes/WDL/workflows/beast_gpu.wdl
+   testParameterFiles:
+    - empty.json
+ - name: classify_kaiju
+   subclass: WDL
+   primaryDescriptorPath: pipes/WDL/workflows/classify_kaiju.wdl
+   testParameterFiles:
+    - empty.json
+ - name: classify_kraken2
+   subclass: WDL
+   primaryDescriptorPath: pipes/WDL/workflows/classify_kraken2.wdl
+   testParameterFiles:
+    - test/input/WDL/test_inputs-classify_kraken2-local.json
+ - name: classify_krakenuniq
+   subclass: WDL
+   primaryDescriptorPath: pipes/WDL/workflows/classify_krakenuniq.wdl
+   testParameterFiles:
+    - empty.json
+ - name: classify_multi
+   subclass: WDL
+   primaryDescriptorPath: pipes/WDL/workflows/classify_multi.wdl
+   testParameterFiles:
+    - empty.json
+ - name: classify_single
+   subclass: WDL
+   primaryDescriptorPath: pipes/WDL/workflows/classify_single.wdl
+   testParameterFiles:
+    - empty.json
+ - name: contigs
+   subclass: WDL
+   primaryDescriptorPath: pipes/WDL/workflows/contigs.wdl
+   testParameterFiles:
+    - empty.json
+ - name: coverage_table
+   subclass: WDL
+   primaryDescriptorPath: pipes/WDL/workflows/coverage_table.wdl
+   testParameterFiles:
+    - empty.json
+ - name: demux_metag
+   subclass: WDL
+   primaryDescriptorPath: pipes/WDL/workflows/demux_metag.wdl
+   testParameterFiles:
+    - empty.json
+ - name: demux_only
+   subclass: WDL
+   primaryDescriptorPath: pipes/WDL/workflows/demux_only.wdl
+   testParameterFiles:
+    - empty.json
+ - name: demux_plus
+   subclass: WDL
+   primaryDescriptorPath: pipes/WDL/workflows/demux_plus.wdl
+   testParameterFiles:
+    - empty.json
+ - name: deplete_only
+   subclass: WDL
+   primaryDescriptorPath: pipes/WDL/workflows/deplete_only.wdl
+   testParameterFiles:
+    - empty.json
+ - name: diff_genome_sets
+   subclass: WDL
+   primaryDescriptorPath: pipes/WDL/workflows/diff_genome_sets.wdl
+   testParameterFiles:
+    - empty.json
+ - name: downsample
+   subclass: WDL
+   primaryDescriptorPath: pipes/WDL/workflows/downsample.wdl
+   testParameterFiles:
+    - empty.json
+ - name: fastq_to_ubam
+   subclass: WDL
+   primaryDescriptorPath: pipes/WDL/workflows/fastq_to_ubam.wdl
+   testParameterFiles:
+    - test/input/WDL/test_inputs-fastq_to_ubam-local.json
+ - name: fetch_annotations
+   subclass: WDL
+   primaryDescriptorPath: pipes/WDL/workflows/fetch_annotations.wdl
+   testParameterFiles:
+    - empty.json
+ - name: fetch_sra_to_bam
+   subclass: WDL
+   primaryDescriptorPath: pipes/WDL/workflows/fetch_sra_to_bam.wdl
+   testParameterFiles:
+    - empty.json
+ - name: filter_classified_bam_to_taxa
+   subclass: WDL
+   primaryDescriptorPath: pipes/WDL/workflows/filter_classified_bam_to_taxa.wdl
+   testParameterFiles:
+    - empty.json
+ - name: filter_sequences
+   subclass: WDL
+   primaryDescriptorPath: pipes/WDL/workflows/filter_sequences.wdl
+   testParameterFiles:
+    - empty.json
+ - name: genbank
+   subclass: WDL
+   primaryDescriptorPath: pipes/WDL/workflows/genbank.wdl
+   testParameterFiles:
+    - test/input/WDL/test_inputs-genbank-local.json
+ - name: isnvs_merge_to_vcf
+   subclass: WDL
+   primaryDescriptorPath: pipes/WDL/workflows/isnvs_merge_to_vcf.wdl
+   testParameterFiles:
+    - empty.json
+ - name: isnvs_one_sample
+   subclass: WDL
+   primaryDescriptorPath: pipes/WDL/workflows/isnvs_one_sample.wdl
+   testParameterFiles:
+    - empty.json
+ - name: kraken2_build
+   subclass: WDL
+   primaryDescriptorPath: pipes/WDL/workflows/kraken2_build.wdl
+   testParameterFiles:
+    - empty.json
+ - name: mafft_and_snp
+   subclass: WDL
+   primaryDescriptorPath: pipes/WDL/workflows/mafft_and_snp.wdl
+   testParameterFiles:
+    - empty.json
+ - name: mafft_and_trim
+   subclass: WDL
+   primaryDescriptorPath: pipes/WDL/workflows/mafft_and_trim.wdl
+   testParameterFiles:
+    - empty.json
+ - name: mafft
+   subclass: WDL
+   primaryDescriptorPath: pipes/WDL/workflows/mafft.wdl
+   testParameterFiles:
+    - empty.json
+ - name: merge_bams
+   subclass: WDL
+   primaryDescriptorPath: pipes/WDL/workflows/merge_bams.wdl
+   testParameterFiles:
+    - empty.json
+ - name: merge_metagenomics
+   subclass: WDL
+   primaryDescriptorPath: pipes/WDL/workflows/merge_metagenomics.wdl
+   testParameterFiles:
+    - empty.json
+ - name: merge_tar_chunks
+   subclass: WDL
+   primaryDescriptorPath: pipes/WDL/workflows/merge_tar_chunks.wdl
+   testParameterFiles:
+    - empty.json
+ - name: merge_vcfs_and_annotate
+   subclass: WDL
+   primaryDescriptorPath: pipes/WDL/workflows/merge_vcfs_and_annotate.wdl
+   testParameterFiles:
+    - empty.json
+ - name: merge_vcfs
+   subclass: WDL
+   primaryDescriptorPath: pipes/WDL/workflows/merge_vcfs.wdl
+   testParameterFiles:
+    - empty.json
+ - name: multiqc_only
+   subclass: WDL
+   primaryDescriptorPath: pipes/WDL/workflows/multiqc_only.wdl
+   testParameterFiles:
+    - empty.json
+ - name: scaffold_and_refine
+   subclass: WDL
+   primaryDescriptorPath: pipes/WDL/workflows/scaffold_and_refine.wdl
+   testParameterFiles:
+    - empty.json
+ - name: subsample_by_metadata
+   subclass: WDL
+   primaryDescriptorPath: pipes/WDL/workflows/subsample_by_metadata.wdl
+   testParameterFiles:
+    - empty.json
+ - name: trimal
+   subclass: WDL
+   primaryDescriptorPath: pipes/WDL/workflows/trimal.wdl
+   testParameterFiles:
+    - empty.json

--- a/pipes/WDL/tasks/tasks_assembly.wdl
+++ b/pipes/WDL/tasks/tasks_assembly.wdl
@@ -16,7 +16,7 @@ task assemble {
       String   sample_name = basename(basename(reads_unmapped_bam, ".bam"), ".taxfilt")
 
       Int?     machine_mem_gb
-      String   docker="quay.io/broadinstitute/viral-assemble"
+      String   docker="quay.io/broadinstitute/viral-assemble:2.1.4.0"
     }
 
     command {
@@ -114,7 +114,7 @@ task scaffold {
       Float?       scaffold_min_pct_contig_aligned
 
       Int?         machine_mem_gb
-      String       docker="quay.io/broadinstitute/viral-assemble"
+      String       docker="quay.io/broadinstitute/viral-assemble:2.1.4.0"
 
       # do this in multiple steps in case the input doesn't actually have "assembly1-x" in the name
       String       sample_name = basename(basename(basename(contigs_fasta, ".fasta"), ".assembly1-trinity"), ".assembly1-spades")
@@ -201,7 +201,7 @@ task ivar_trim {
       Int?    min_quality=1
 
       Int?    machine_mem_gb
-      String  docker="andersenlabapps/ivar"
+      String  docker="andersenlabapps/ivar:1.2.2"
     }
 
     String  bam_basename=basename(aligned_bam, ".bam")
@@ -259,7 +259,7 @@ task align_reads {
     String?  aligner_options
     Boolean? skip_mark_dupes=false
 
-    String   docker="quay.io/broadinstitute/viral-core"
+    String   docker="quay.io/broadinstitute/viral-core:2.1.8"
 
     String   sample_name = basename(basename(basename(reads_unmapped_bam, ".bam"), ".taxfilt"), ".clean")
   }
@@ -373,7 +373,7 @@ task refine_assembly_with_aligned_reads {
       Int?     min_coverage=3
 
       Int?     machine_mem_gb
-      String   docker="quay.io/broadinstitute/viral-assemble"
+      String   docker="quay.io/broadinstitute/viral-assemble:2.1.4.0"
     }
 
     parameter_meta {
@@ -465,7 +465,7 @@ task refine {
       Int?    min_coverage=1
 
       Int?    machine_mem_gb
-      String  docker="quay.io/broadinstitute/viral-assemble"
+      String  docker="quay.io/broadinstitute/viral-assemble:2.1.4.0"
 
       String  assembly_basename=basename(basename(assembly_fasta, ".fasta"), ".scaffold")
     }
@@ -535,7 +535,7 @@ task refine_2x_and_plot {
       String? plot_coverage_novoalign_options="-r Random -l 40 -g 40 -x 20 -t 100 -k"
 
       Int?    machine_mem_gb
-      String  docker="quay.io/broadinstitute/viral-assemble"
+      String  docker="quay.io/broadinstitute/viral-assemble:2.1.4.0"
 
       # do this in two steps in case the input doesn't actually have "cleaned" in the name
       String  sample_name = basename(basename(reads_unmapped_bam, ".bam"), ".cleaned")
@@ -667,7 +667,7 @@ task run_discordance {
       String   out_basename = "run"
       Int      min_coverage=4
 
-      String   docker="quay.io/broadinstitute/viral-core"
+      String   docker="quay.io/broadinstitute/viral-core:2.1.8"
     }
 
     command {

--- a/pipes/WDL/tasks/tasks_demux.wdl
+++ b/pipes/WDL/tasks/tasks_demux.wdl
@@ -6,7 +6,7 @@ task merge_tarballs {
     String        out_filename
 
     Int?          machine_mem_gb
-    String        docker="quay.io/broadinstitute/viral-core"
+    String        docker="quay.io/broadinstitute/viral-core:2.1.8"
   }
 
   command {
@@ -60,7 +60,7 @@ task illumina_demux {
     Boolean? forceGC=true
 
     Int?    machine_mem_gb
-    String  docker="quay.io/broadinstitute/viral-core"
+    String  docker="quay.io/broadinstitute/viral-core:2.1.8"
   }
 
   command {

--- a/pipes/WDL/tasks/tasks_interhost.wdl
+++ b/pipes/WDL/tasks/tasks_interhost.wdl
@@ -9,7 +9,7 @@ task multi_align_mafft_ref {
     Float?         mafft_gapOpeningPenalty
 
     Int?           machine_mem_gb
-    String         docker="quay.io/broadinstitute/viral-phylo"
+    String         docker="quay.io/broadinstitute/viral-phylo:2.1.4.0"
   }
 
   String           fasta_basename = basename(reference_fasta, '.fasta')
@@ -53,7 +53,7 @@ task multi_align_mafft {
     Float?         mafft_gapOpeningPenalty
 
     Int?           machine_mem_gb
-    String         docker="quay.io/broadinstitute/viral-phylo"
+    String         docker="quay.io/broadinstitute/viral-phylo:2.1.4.0"
   }
 
   command {
@@ -90,7 +90,7 @@ task beast {
   input {
     File     beauti_xml
 
-    String   docker="quay.io/broadinstitute/beast-beagle-cuda"
+    String   docker="quay.io/broadinstitute/beast-beagle-cuda:1.10.5pre"
   }
 
   # TO DO: parameterize gpuType and gpuCount
@@ -137,7 +137,7 @@ task index_ref {
     File?    novocraft_license
 
     Int?     machine_mem_gb
-    String   docker="quay.io/broadinstitute/viral-core"
+    String   docker="quay.io/broadinstitute/viral-core:2.1.8"
   }
 
   command {
@@ -247,7 +247,7 @@ task merge_vcfs_gatk {
     File        ref_fasta
 
     Int?     machine_mem_gb
-    String   docker="quay.io/broadinstitute/viral-phylo"
+    String   docker="quay.io/broadinstitute/viral-phylo:2.1.4.0"
 
     String   output_prefix = "merged"
   }

--- a/pipes/WDL/tasks/tasks_intrahost.wdl
+++ b/pipes/WDL/tasks/tasks_intrahost.wdl
@@ -10,7 +10,7 @@ task isnvs_per_sample {
     Int?    maxBias
 
     Int?    machine_mem_gb
-    String  docker="quay.io/broadinstitute/viral-phylo"
+    String  docker="quay.io/broadinstitute/viral-phylo:2.1.4.0"
 
     String  sample_name = basename(basename(basename(mapped_bam, ".bam"), ".all"), ".mapped")
   }
@@ -51,7 +51,7 @@ task isnvs_vcf {
     Boolean        naiveFilter=false
 
     Int?           machine_mem_gb
-    String         docker="quay.io/broadinstitute/viral-phylo"
+    String         docker="quay.io/broadinstitute/viral-phylo:2.1.4.0"
   }
 
   parameter_meta {
@@ -124,7 +124,7 @@ task annotate_vcf_snpeff {
     String?        emailAddress
 
     Int?           machine_mem_gb
-    String         docker="quay.io/broadinstitute/viral-phylo"
+    String         docker="quay.io/broadinstitute/viral-phylo:2.1.4.0"
 
     String         output_basename = basename(basename(in_vcf, ".gz"), ".vcf")
   }

--- a/pipes/WDL/tasks/tasks_metagenomics.wdl
+++ b/pipes/WDL/tasks/tasks_metagenomics.wdl
@@ -11,7 +11,7 @@ task krakenuniq {
     File        krona_taxonomy_db_tgz  # taxonomy.tab
 
     Int?        machine_mem_gb
-    String      docker="quay.io/broadinstitute/viral-classify"
+    String      docker="quay.io/broadinstitute/viral-classify:2.1.4.0"
   }
 
   parameter_meta {
@@ -136,7 +136,7 @@ task build_krakenuniq_db {
     Int?        zstd_compression_level
 
     Int?        machine_mem_gb
-    String      docker="quay.io/broadinstitute/viral-classify"
+    String      docker="quay.io/broadinstitute/viral-classify:2.1.4.0"
   }
 
   command {
@@ -202,7 +202,7 @@ task kraken2 {
     Int?     min_base_qual
 
     Int?     machine_mem_gb
-    String   docker="quay.io/broadinstitute/viral-classify"
+    String   docker="quay.io/broadinstitute/viral-classify:2.1.4.0"
   }
 
   parameter_meta {
@@ -334,7 +334,7 @@ task build_kraken2_db {
     Int?        zstd_compression_level
 
     Int?        machine_mem_gb
-    String      docker="quay.io/broadinstitute/viral-classify"
+    String      docker="quay.io/broadinstitute/viral-classify:2.1.4.0"
   }
 
   parameter_meta {
@@ -472,7 +472,7 @@ task blastx {
     File     krona_taxonomy_db_tgz
 
     Int?     machine_mem_gb
-    String   docker="quay.io/broadinstitute/viral-classify"
+    String   docker="quay.io/broadinstitute/viral-classify:2.1.4.0"
   }
 
   parameter_meta {
@@ -559,7 +559,7 @@ task krona {
     Int?     magnitude_column
 
     Int?     machine_mem_gb
-    String   docker="quay.io/broadinstitute/viral-classify"
+    String   docker="quay.io/broadinstitute/viral-classify:2.1.4.0"
   }
 
   command {
@@ -658,7 +658,7 @@ task filter_bam_to_taxa {
     String         out_filename_suffix = "filtered"
 
     Int?           machine_mem_gb
-    String         docker="quay.io/broadinstitute/viral-classify"
+    String         docker="quay.io/broadinstitute/viral-classify:2.1.4.0"
   }
 
   String out_basename = basename(classified_bam, ".bam") + "." + out_filename_suffix
@@ -738,7 +738,7 @@ task kaiju {
     File     krona_taxonomy_db_tgz  # taxonomy/taxonomy.tab
 
     Int?     machine_mem_gb
-    String   docker="quay.io/broadinstitute/viral-classify"
+    String   docker="quay.io/broadinstitute/viral-classify:2.1.4.0"
   }
 
   String   input_basename = basename(reads_unmapped_bam, ".bam")

--- a/pipes/WDL/tasks/tasks_ncbi.wdl
+++ b/pipes/WDL/tasks/tasks_ncbi.wdl
@@ -25,7 +25,7 @@ task download_fasta {
     Array[String]+ accessions
     String         emailAddress
 
-    String         docker="quay.io/broadinstitute/viral-phylo"
+    String         docker="quay.io/broadinstitute/viral-phylo:2.1.4.0"
   }
 
   command {
@@ -56,7 +56,7 @@ task download_annotations {
     String         emailAddress
     String         combined_out_prefix
 
-    String         docker="quay.io/broadinstitute/viral-phylo"
+    String         docker="quay.io/broadinstitute/viral-phylo:2.1.4.0"
   }
 
   command {
@@ -100,7 +100,7 @@ task annot_transfer {
     File         reference_fasta
     Array[File]+ reference_feature_table
 
-    String  docker="quay.io/broadinstitute/viral-phylo"
+    String  docker="quay.io/broadinstitute/viral-phylo:2.1.4.0"
   }
 
   parameter_meta {
@@ -153,7 +153,7 @@ task align_and_annot_transfer_single {
     Array[File]+ reference_fastas
     Array[File]+ reference_feature_tables
 
-    String  docker="quay.io/broadinstitute/viral-phylo"
+    String  docker="quay.io/broadinstitute/viral-phylo:2.1.4.0"
   }
 
   parameter_meta {
@@ -208,7 +208,7 @@ task biosample_to_genbank {
     Int   num_segments=1
     Int   taxid
 
-    String  docker="quay.io/broadinstitute/viral-phylo"
+    String  docker="quay.io/broadinstitute/viral-phylo:2.1.4.0"
   }
   String base = basename(biosample_attributes, ".txt")
   command {
@@ -254,7 +254,7 @@ task prepare_genbank {
     String?      assembly_method_version
 
     Int?         machine_mem_gb
-    String       docker="quay.io/broadinstitute/viral-phylo"
+    String       docker="quay.io/broadinstitute/viral-phylo:2.1.4.0"
   }
 
   parameter_meta {

--- a/pipes/WDL/tasks/tasks_ncbi_tools.wdl
+++ b/pipes/WDL/tasks/tasks_ncbi_tools.wdl
@@ -6,7 +6,7 @@ task Fetch_SRA_to_BAM {
         String  SRA_ID
 
         Int?    machine_mem_gb
-        String  docker = "quay.io/broadinstitute/ncbi-tools"
+        String  docker = "quay.io/broadinstitute/ncbi-tools:2.10.7.1"
     }
 
     command {

--- a/pipes/WDL/tasks/tasks_nextstrain.wdl
+++ b/pipes/WDL/tasks/tasks_nextstrain.wdl
@@ -91,7 +91,7 @@ task filter_subsample_sequences {
         String?  exclude_where
         String?  include_where
 
-        String   docker = "nextstrain/base"
+        String   docker = "nextstrain/base:build-20200629T201240Z"
     }
     parameter_meta {
         sequences_fasta: {
@@ -157,7 +157,7 @@ task filter_sequences_to_list {
         File          sequences
         Array[File]?  keep_list
 
-        String   docker = "nextstrain/base"
+        String   docker = "nextstrain/base:build-20200629T201240Z"
     }
     parameter_meta {
         sequences: {
@@ -223,7 +223,7 @@ task mafft_one_chr {
         Boolean  remove_reference = false
         Boolean  keep_length = true
 
-        String   docker = "quay.io/broadinstitute/viral-phylo"
+        String   docker = "quay.io/broadinstitute/viral-phylo:2.1.4.0"
     }
     command {
         set -e
@@ -292,7 +292,7 @@ task augur_mafft_align {
         Boolean  fill_gaps = true
         Boolean  remove_reference = true
 
-        String   docker = "nextstrain/base"
+        String   docker = "nextstrain/base:build-20200629T201240Z"
     }
     command {
         set -e
@@ -358,7 +358,7 @@ task augur_mask_sites {
         File     sequences
         File?    mask_bed
 
-        String   docker = "nextstrain/base"
+        String   docker = "nextstrain/base:build-20200629T201240Z"
     }
     parameter_meta {
         sequences: {
@@ -412,7 +412,7 @@ task draft_augur_tree {
         File?    vcf_reference
         String?  tree_builder_args
 
-        String   docker = "nextstrain/base"
+        String   docker = "nextstrain/base:build-20200629T201240Z"
     }
     parameter_meta {
         msa_or_vcf: {
@@ -478,7 +478,7 @@ task refine_augur_tree {
         String?  divergence_units
         File?    vcf_reference
 
-        String   docker = "nextstrain/base"
+        String   docker = "nextstrain/base:build-20200629T201240Z"
     }
     parameter_meta {
         msa_or_vcf: {
@@ -547,7 +547,7 @@ task ancestral_traits {
         File?          weights
         Float?         sampling_bias_correction
 
-        String   docker = "nextstrain/base"
+        String   docker = "nextstrain/base:build-20200629T201240Z"
     }
     String out_basename = basename(tree, '.nwk')
     command {
@@ -597,7 +597,7 @@ task ancestral_tree {
         File?    vcf_reference
         File?    output_vcf
 
-        String   docker = "nextstrain/base"
+        String   docker = "nextstrain/base:build-20200629T201240Z"
     }
     parameter_meta {
         msa_or_vcf: {
@@ -655,7 +655,7 @@ task translate_augur_tree {
         File?  vcf_reference_output
         File?  vcf_reference
 
-        String docker = "nextstrain/base"
+        String docker = "nextstrain/base:build-20200629T201240Z"
     }
     String out_basename = basename(tree, '.nwk')
     command {
@@ -696,7 +696,7 @@ task assign_clades_to_nodes {
         File ref_fasta
         File clades_tsv
 
-        String docker = "nextstrain/base"
+        String docker = "nextstrain/base:build-20200629T201240Z"
     }
     String out_basename = basename(basename(tree_nwk, ".nwk"), "_timetree")
     command {
@@ -738,7 +738,7 @@ task augur_import_beast {
         String? tip_date_delimiter
 
         Int?    machine_mem_gb
-        String  docker = "nextstrain/base"
+        String  docker = "nextstrain/base:build-20200629T201240Z"
     }
     String tree_basename = basename(beast_mcc_tree, ".tree")
     command {
@@ -792,7 +792,7 @@ task export_auspice_json {
         Array[String]? maintainers
         String?        title
 
-        String docker = "nextstrain/base"
+        String docker = "nextstrain/base:build-20200629T201240Z"
     }
     String out_basename = basename(basename(tree, ".nwk"), "_timetree")
     command {

--- a/pipes/WDL/tasks/tasks_read_utils.wdl
+++ b/pipes/WDL/tasks/tasks_read_utils.wdl
@@ -11,7 +11,7 @@ task merge_and_reheader_bams {
       File?           reheader_table
       String          out_basename
 
-      String          docker="quay.io/broadinstitute/viral-core"
+      String          docker="quay.io/broadinstitute/viral-core:2.1.8"
     }
 
     command {
@@ -71,7 +71,7 @@ task rmdup_ubam {
     String   method="mvicuna"
 
     Int?     machine_mem_gb
-    String?  docker="quay.io/broadinstitute/viral-core"
+    String?  docker="quay.io/broadinstitute/viral-core:2.1.8"
   }
 
   parameter_meta {
@@ -125,7 +125,7 @@ task downsample_bams {
     Boolean?     deduplicateAfter=false
 
     Int?         machine_mem_gb
-    String       docker="quay.io/broadinstitute/viral-core"
+    String       docker="quay.io/broadinstitute/viral-core:2.1.8"
   }
 
   command {
@@ -184,7 +184,7 @@ task FastqToUBAM {
     String? platform_name
     String? sequencing_center
 
-    String  docker="quay.io/broadinstitute/viral-core"
+    String  docker="quay.io/broadinstitute/viral-core:2.1.8"
   }
   parameter_meta {
     fastq_1: { description: "Unaligned read1 file in fastq format", patterns: ["*.fastq", "*.fastq.gz", "*.fq", "*.fq.gz"] }

--- a/pipes/WDL/tasks/tasks_reports.wdl
+++ b/pipes/WDL/tasks/tasks_reports.wdl
@@ -10,7 +10,7 @@ task plot_coverage {
     Boolean? bin_large_plots=false
     String?  binning_summary_statistic="max" # max or min
 
-    String   docker="quay.io/broadinstitute/viral-core"
+    String   docker="quay.io/broadinstitute/viral-core:2.1.8"
   }
   
   command {
@@ -85,7 +85,7 @@ task coverage_report {
     Array[File]  mapped_bam_idx # optional.. speeds it up if you provide it, otherwise we auto-index
     String       out_report_name="coverage_report.txt"
 
-    String       docker="quay.io/broadinstitute/viral-core"
+    String       docker="quay.io/broadinstitute/viral-core:2.1.8"
   }
 
   command {
@@ -115,7 +115,7 @@ task fastqc {
   input {
     File     reads_bam
 
-    String   docker="quay.io/broadinstitute/viral-core"
+    String   docker="quay.io/broadinstitute/viral-core:2.1.8"
   }
 
   String   reads_basename=basename(reads_bam, ".bam")
@@ -148,7 +148,7 @@ task align_and_count {
     Int?    topNHits = 3
 
     Int?    machine_mem_gb
-    String  docker="quay.io/broadinstitute/viral-core"
+    String  docker="quay.io/broadinstitute/viral-core:2.1.8"
   }
 
   String  reads_basename=basename(reads_bam, ".bam")
@@ -191,7 +191,7 @@ task align_and_count_summary {
 
     String?       output_prefix="count_summary"
 
-    String        docker="quay.io/broadinstitute/viral-core"
+    String        docker="quay.io/broadinstitute/viral-core:2.1.8"
   }
 
   command {
@@ -222,7 +222,7 @@ task aggregate_metagenomics_reports {
     String       aggregate_taxlevel_focus                 = "species"
     Int?         aggregate_top_N_hits                     = 5
 
-    String       docker="quay.io/broadinstitute/viral-classify"
+    String       docker="quay.io/broadinstitute/viral-classify:2.1.4.0"
   }
 
   parameter_meta {
@@ -365,7 +365,7 @@ task tsv_join {
     String         join_type="inner"
     String         out_basename
 
-    String         docker="quay.io/broadinstitute/viral-core"
+    String         docker="quay.io/broadinstitute/viral-core:2.1.8"
   }
 
   command {
@@ -406,7 +406,7 @@ task tsv_stack {
   input {
     Array[File]+   input_tsvs
     String         out_basename
-    String         docker="quay.io/broadinstitute/viral-core"
+    String         docker="quay.io/broadinstitute/viral-core:2.1.8"
   }
 
   command {
@@ -436,7 +436,7 @@ task compare_two_genomes {
     File          genome_two
     String        out_basename
 
-    String        docker="quay.io/broadinstitute/viral-assemble"
+    String        docker="quay.io/broadinstitute/viral-assemble:2.1.4.0"
   }
 
   command {

--- a/pipes/WDL/tasks/tasks_taxon_filter.wdl
+++ b/pipes/WDL/tasks/tasks_taxon_filter.wdl
@@ -14,7 +14,7 @@ task deplete_taxa {
 
     Int?         cpu=8
     Int?         machine_mem_gb
-    String       docker="quay.io/broadinstitute/viral-classify"
+    String       docker="quay.io/broadinstitute/viral-classify:2.1.4.0"
   }
 
   parameter_meta {
@@ -110,7 +110,7 @@ task filter_to_taxon {
     String?  neg_control_prefixes_space_separated = "neg water NTC"
 
     Int?     machine_mem_gb
-    String   docker="quay.io/broadinstitute/viral-classify"
+    String   docker="quay.io/broadinstitute/viral-classify:2.1.4.0"
   }
 
   # do this in two steps in case the input doesn't actually have "cleaned" in the name
@@ -166,7 +166,7 @@ task build_lastal_db {
     File    sequences_fasta
 
     Int?    machine_mem_gb
-    String  docker="quay.io/broadinstitute/viral-classify"
+    String  docker="quay.io/broadinstitute/viral-classify:2.1.4.0"
   }
 
   String  db_name = basename(sequences_fasta, ".fasta")
@@ -202,7 +202,7 @@ task merge_one_per_sample {
     Boolean?     rmdup=false
 
     Int?         machine_mem_gb
-    String       docker="quay.io/broadinstitute/viral-core"
+    String       docker="quay.io/broadinstitute/viral-core:2.1.8"
   }
 
   command {

--- a/travis/version-wdl-runtimes.sh
+++ b/travis/version-wdl-runtimes.sh
@@ -1,10 +1,19 @@
 #!/bin/bash
 # requires $MODULE_VERSIONS to be set to point to a text file with equal-sign-separated values
-set -e -o pipefail
+set -e
 
+# here is the older script that actually used sed to replace version strings
+#while IFS='=' read module version; do
+#	OLD_TAG=$module
+#	NEW_TAG="$module:$version"
+#	echo Replacing $OLD_TAG with $NEW_TAG in all task WDL files
+#	sed -i -- "s|$OLD_TAG|$NEW_TAG|g" pipes/WDL/tasks/*.wdl
+#done < $MODULE_VERSIONS
+
+# this is the newer script that simply validates existing version strings
 while IFS='=' read module version; do
 	OLD_TAG=$module
 	NEW_TAG="$module:$version"
-	echo Replacing $OLD_TAG with $NEW_TAG in all task WDL files
-	sed -i -- "s|$OLD_TAG|$NEW_TAG|g" pipes/WDL/tasks/*.wdl
+	echo Validating that $OLD_TAG is $NEW_TAG in all task WDL files
+    ! grep $OLD_TAG pipes/WDL/tasks/*.wdl | grep -v $NEW_TAG
 done < $MODULE_VERSIONS


### PR DESCRIPTION
Update to use github apps integration for Dockstore.
- adds a top level .dockstore.yml file using their new 1.9 api format
- hardcode docker version strings instead of replacing during travis build
- update version-wdl-runtimes.sh to perform validation checks during travis (instead of actually encoding them)