### PR TITLE
bugfix: filter_classified_bam_to_taxa with empty taxonomic_names

### DIFF
--- a/pipes/WDL/tasks/tasks_metagenomics.wdl
+++ b/pipes/WDL/tasks/tasks_metagenomics.wdl
@@ -695,7 +695,7 @@ task filter_bam_to_taxa {
 
     samtools view -c ${classified_bam} | tee classified_taxonomic_filter_read_count_pre &
 
-    cat taxfilterargs | xargs -d '\n' metagenomics.py filter_bam_to_taxa \
+    cat taxfilterargs | grep . | xargs -d '\n' metagenomics.py filter_bam_to_taxa \
       ${classified_bam} \
       ${classified_reads_txt_gz} \
       "${out_basename}.bam" \


### PR DESCRIPTION
filter_classified_bam_to_taxa lets the user specify taxa either by name (using --taxonomic_names Array[String]) or by ID (using --taxIDs Array[Int]). Default (CI tested) behavior in classify_multi/classify_single is to use --taxonomic_names.

However, when a user leaves --taxonomic_names empty (and uses --taxIDs instead), this workflow fails on Terra and Cromwell. As it turns out, `write_lines([])` (in [this line](https://github.com/broadinstitute/viral-pipelines/blob/v2.1.8.0/pipes/WDL/tasks/tasks_metagenomics.wdl#L682)) appears to write a single newline character to the output file, whereas miniwdl writes an empty file. The former behavior causes an empty arg to be passed to `xargs` which results in a failure for `metagenomics.py` to parse its args.

This PR adds a `grep .` to the pipe to remove empty lines from taxfiltargs. This allows simple test runs of filter_classified_bam_to_taxa to succeed in Cromwell.