### PR TITLE
vphaser isnv calling in assemble_refbased

### DIFF
--- a/pipes/WDL/tasks/tasks_intrahost.wdl
+++ b/pipes/WDL/tasks/tasks_intrahost.wdl
@@ -17,10 +17,11 @@ task isnvs_per_sample {
 
   command {
     intrahost.py --version | tee VERSION
+    echo ${sample_name} | tee SAMPLE_NAME
     intrahost.py vphaser_one_sample \
         ${mapped_bam} \
         ${assembly_fasta} \
-        vphaser2.${sample_name}.txt.gz \
+        ${sample_name}.vphaser2.txt.gz \
         ${'--vphaserNumThreads' + threads} \
         --removeDoublyMappedReads \
         ${'--minReadsEach' + minReadsPerStrand} \
@@ -28,7 +29,8 @@ task isnvs_per_sample {
   }
 
   output {
-    File   isnvsFile        = "vphaser2.${sample_name}.txt.gz"
+    File   isnvsFile        = "${sample_name}.vphaser2.txt.gz"
+    String sample_name      = read_string("SAMPLE_NAME")
     String viralngs_version = read_string("VERSION")
   }
   runtime {
@@ -49,6 +51,7 @@ task isnvs_vcf {
     Array[String]? sampleNames
     String?        emailAddress
     Boolean        naiveFilter=false
+    Boolean        outputAllPositions=true
 
     Int?           machine_mem_gb
     String         docker="quay.io/broadinstitute/viral-phylo:2.1.4.0"
@@ -87,6 +90,7 @@ task isnvs_vcf {
         --alignments ${sep=' ' perSegmentMultiAlignments} \
         --strip_chr_version \
         ${true="--naive_filter" false="" naiveFilter} \
+        ${true="--output_all_positions" false="" outputAllPositions} \
         --parse_accession
         
     interhost.py snpEff \

--- a/pipes/WDL/tasks/tasks_intrahost.wdl
+++ b/pipes/WDL/tasks/tasks_intrahost.wdl
@@ -30,7 +30,7 @@ task isnvs_per_sample {
 
   output {
     File   isnvsFile        = "${sample_name}.vphaser2.txt.gz"
-    String sample_name      = read_string("SAMPLE_NAME")
+    String sample_name_out  = read_string("SAMPLE_NAME")
     String viralngs_version = read_string("VERSION")
   }
   runtime {

--- a/pipes/WDL/workflows/assemble_refbased.wdl
+++ b/pipes/WDL/workflows/assemble_refbased.wdl
@@ -125,7 +125,7 @@ workflow assemble_refbased {
     call interhost.multi_align_mafft_ref as mafft {
         input:
             reference_fasta  = reference_fasta,
-            assemblies_fasta = select_all([call_consensus.refined_assembly_fasta,[]])
+            assemblies_fasta = [call_consensus.refined_assembly_fasta]
     }
 
     call intrahost.isnvs_vcf as write_isnv_vcf {

--- a/pipes/WDL/workflows/assemble_refbased.wdl
+++ b/pipes/WDL/workflows/assemble_refbased.wdl
@@ -130,7 +130,7 @@ workflow assemble_refbased {
 
     call intrahost.isnvs_vcf as write_isnv_vcf {
         input:
-            vphaser2Calls             = select_all([call_isnvs.isnvsFile,[]]),
+            vphaser2Calls             = [call_isnvs.isnvsFile],
             perSegmentMultiAlignments = mafft.alignments_by_chr,
             reference_fasta           = reference_fasta,
             sampleNames               = select_all([call_isnvs.sample_name_out,[]])

--- a/pipes/WDL/workflows/assemble_refbased.wdl
+++ b/pipes/WDL/workflows/assemble_refbased.wdl
@@ -124,16 +124,16 @@ workflow assemble_refbased {
 
     call interhost.multi_align_mafft_ref as mafft {
         input:
-            reference_fasta = reference_fasta,
-            assemblies_fasta = call_consensus.refined_assembly_fasta
+            reference_fasta  = reference_fasta,
+            assemblies_fasta = select_all([call_consensus.refined_assembly_fasta,[]])
     }
 
     call intrahost.isnvs_vcf as write_isnv_vcf {
         input:
-            vphaser2Calls             = call_isnvs.isnvsFile,
+            vphaser2Calls             = select_all([call_isnvs.isnvsFile,[]]),
             perSegmentMultiAlignments = mafft.alignments_by_chr,
             reference_fasta           = reference_fasta,
-            sampleNames               = call_isnvs.sample_name_out
+            sampleNames               = select_all([call_isnvs.sample_name_out,[]])
     }
 
     scatter(reads_unmapped_bam in reads_unmapped_bams) {

--- a/pipes/WDL/workflows/assemble_refbased.wdl
+++ b/pipes/WDL/workflows/assemble_refbased.wdl
@@ -1,7 +1,8 @@
 version 1.0
 
 import "../tasks/tasks_assembly.wdl" as assembly
-import "../tasks/tasks_intrahost.wdl" as assembly
+import "../tasks/tasks_intrahost.wdl" as intrahost
+import "../tasks/tasks_interhost.wdl" as interhost
 import "../tasks/tasks_reports.wdl" as reports
 import "../tasks/tasks_read_utils.wdl" as read_utils
 

--- a/pipes/WDL/workflows/assemble_refbased.wdl
+++ b/pipes/WDL/workflows/assemble_refbased.wdl
@@ -133,7 +133,7 @@ workflow assemble_refbased {
             vphaser2Calls             = [call_isnvs.isnvsFile],
             perSegmentMultiAlignments = mafft.alignments_by_chr,
             reference_fasta           = reference_fasta,
-            sampleNames               = select_all([call_isnvs.sample_name_out,[]])
+            sampleNames               = [call_isnvs.sample_name_out]
     }
 
     scatter(reads_unmapped_bam in reads_unmapped_bams) {

--- a/pipes/WDL/workflows/assemble_refbased.wdl
+++ b/pipes/WDL/workflows/assemble_refbased.wdl
@@ -122,18 +122,13 @@ workflow assemble_refbased {
             assembly_fasta = call_consensus.refined_assembly_fasta
     }
 
-    call interhost.multi_align_mafft_ref as mafft {
-        input:
-            reference_fasta  = reference_fasta,
-            assemblies_fasta = [call_consensus.refined_assembly_fasta]
-    }
-
     call intrahost.isnvs_vcf as write_isnv_vcf {
         input:
             vphaser2Calls             = [call_isnvs.isnvsFile],
-            perSegmentMultiAlignments = mafft.alignments_by_chr,
+            perSegmentMultiAlignments = [call_consensus.refined_assembly_fasta],
             reference_fasta           = reference_fasta,
-            sampleNames               = [call_isnvs.sample_name_out]
+            sampleNames               = [call_isnvs.sample_name_out],
+            append_reference_to_input = true
     }
 
     scatter(reads_unmapped_bam in reads_unmapped_bams) {

--- a/pipes/WDL/workflows/assemble_refbased.wdl
+++ b/pipes/WDL/workflows/assemble_refbased.wdl
@@ -132,7 +132,7 @@ workflow assemble_refbased {
             vphaser2Calls             = call_isnvs.isnvsFile,
             perSegmentMultiAlignments = mafft.alignments_by_chr,
             reference_fasta           = reference_fasta,
-            sampleNames               = call_isnvs.sample_name
+            sampleNames               = call_isnvs.sample_name_out
     }
 
     scatter(reads_unmapped_bam in reads_unmapped_bams) {


### PR DESCRIPTION
call iSNVs via vPhaser2 within assemble_refbased.wdl. iSNV calling should be scheduled to occur in parallel with align-to-self
--output_all_positions=true in tasks_intrahost::isnvs_vcf; also change vphaser output filename to be prefixed with the sample_name rather than "vphaser2"

depends on merge of this PR upstream and release of docker image: broadinstitute/viral-phylo#27