### PR TITLE
new workflow: subsample_by_metadata_with_focal

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -225,6 +225,11 @@ workflows:
    primaryDescriptorPath: /pipes/WDL/workflows/subsample_by_metadata.wdl
    testParameterFiles:
     - empty.json
+ - name: subsample_by_metadata_with_focal
+   subclass: WDL
+   primaryDescriptorPath: /pipes/WDL/workflows/subsample_by_metadata_with_focal.wdl
+   testParameterFiles:
+    - empty.json
  - name: trimal
    subclass: WDL
    primaryDescriptorPath: /pipes/WDL/workflows/trimal.wdl

--- a/pipes/WDL/tasks/tasks_nextstrain.wdl
+++ b/pipes/WDL/tasks/tasks_nextstrain.wdl
@@ -23,6 +23,29 @@ task concatenate {
     }
 }
 
+task fasta_to_ids {
+    meta {
+        description: "Return the headers only from a fasta file"
+    }
+    input {
+        File sequences_fasta
+    }
+    String basename = basename(sequences_fasta, ".fasta")
+    command {
+        cat "~{sequences_fasta}" | grep \> | cut -c 2- > "~{basename}.txt"
+    }
+    runtime {
+        docker: "ubuntu"
+        memory: "1 GB"
+        cpu:    1
+        disks: "local-disk 375 LOCAL"
+        dx_instance_type: "mem1_ssd1_v2_x2"
+    }
+    output {
+        File ids_txt = "~{basename}.txt"
+    }
+}
+
 task filter_segments {
     input {
         File  all_samples_fasta

--- a/pipes/WDL/tasks/tasks_nextstrain.wdl
+++ b/pipes/WDL/tasks/tasks_nextstrain.wdl
@@ -111,8 +111,8 @@ task filter_subsample_sequences {
         Int?     min_length
         File?    priority
         Int?     subsample_seed
-        String?  exclude_where
-        String?  include_where
+        Array[String]?  exclude_where
+        Array[String]?  include_where
 
         String   docker = "nextstrain/base:build-20200629T201240Z"
     }
@@ -130,7 +130,20 @@ task filter_subsample_sequences {
     command {
         set -e
         augur version > VERSION
-        augur filter \
+
+        touch wherefile
+        VALS="~{write_lines(select_first([exclude_where, []]))}"
+        if [ -n "$(cat $VALS)" ]; then
+            echo "--exclude-where" >> wherefile
+            cat $VALS >> wherefile
+        fi
+        VALS="~{write_lines(select_first([include_where, []]))}"
+        if [ -n "$(cat $VALS)" ]; then
+            echo "--include-where" >> wherefile
+            cat $VALS >> wherefile
+        fi
+
+        cat wherefile | tr '\n' '\0' | xargs -0 -t augur filter \
             --sequences ~{sequences_fasta} \
             --metadata ~{sample_metadata_tsv} \
             ~{"--min-date " + min_date} \
@@ -143,8 +156,6 @@ task filter_subsample_sequences {
             ~{"--sequences-per-group " + sequences_per_group} \
             ~{"--group-by " + group_by} \
             ~{"--subsample-seed " + subsample_seed} \
-            ~{"--exclude-where " + exclude_where} \
-            ~{"--include-where " + include_where} \
             --output "~{out_fname}" | tee STDOUT
         #cat ~{sequences_fasta} | grep \> | wc -l > IN_COUNT
         grep "sequences were dropped during filtering" STDOUT | cut -f 1 -d ' ' > DROP_COUNT

--- a/pipes/WDL/workflows/subsample_by_metadata_with_focal.wdl
+++ b/pipes/WDL/workflows/subsample_by_metadata_with_focal.wdl
@@ -1,0 +1,101 @@
+version 1.0
+
+import "../tasks/tasks_nextstrain.wdl" as nextstrain
+
+workflow subsample_by_metadata_with_focal {
+    meta {
+        description: "Filter and subsample a global sequence set with a bias towards a geographic area of interest."
+    }
+
+    parameter_meta {
+        sample_metadata_tsv: {
+            description: "Tab-separated metadata file that contain binning variables and values. Must contain all samples: output will be filtered to the IDs present in this file.",
+            patterns: ["*.txt", "*.tsv"]
+        }
+        sequences_fasta: {
+            description: "Sequences in fasta format.",
+            patterns: ["*.fasta"]
+        }
+
+        focal_variable: {
+            description: "The dataset will be bifurcated based on this column header."
+        }
+        focal_value: {
+            description: "The dataset will be bifurcated based whether the focal_variable column matches this value or not. Rows that match this value are considered to be part of the 'focal' set of interest, rows that do not are part of the 'global' set."
+        }
+
+        focal_bin_variable: {
+            description: "The focal subset of samples will be evenly subsampled across the discrete values of this column header."
+        }
+        focal_bin_max: {
+            description: "The output will contain no more than this number of focal samples from each discrete value in the focal_bin_variable column."
+        }
+
+        global_bin_variable: {
+            description: "The global subset of samples will be evenly subsampled across the discrete values of this column header."
+        }
+        global_bin_max: {
+            description: "The output will contain no more than this number of global samples from each discrete value in the global_bin_variable column."
+        }
+    }
+
+    input {
+        File    sample_metadata_tsv
+        File    sequences_fasta
+        File?   priorities
+
+        String  focal_variable = "region"
+        String  focal_value = "North America"
+
+        String  focal_bin_variable = "division"
+        Int     focal_bin_max = 50
+
+        String  global_bin_variable = "country"
+        Int     global_bin_max = 50
+    }
+
+    call nextstrain.filter_subsample_sequences as prefilter {
+        input:
+            sequences_fasta = sequences_fasta,
+            sample_metadata_tsv = sample_metadata_tsv
+    }
+
+    call nextstrain.filter_subsample_sequences as subsample_focal {
+        input:
+            sequences_fasta = prefilter.filtered_fasta,
+            sample_metadata_tsv = sample_metadata_tsv,
+            exclude_where = ["${focal_variable}!=${focal_value}"],
+            sequences_per_group = focal_bin_max,
+            group_by = focal_bin_variable,
+            priority = priorities
+    }
+
+    call nextstrain.filter_subsample_sequences as subsample_global {
+        input:
+            sequences_fasta = prefilter.filtered_fasta,
+            sample_metadata_tsv = sample_metadata_tsv,
+            exclude_where = ["${focal_variable}=${focal_value}"],
+            sequences_per_group = global_bin_max,
+            group_by = global_bin_variable,
+            priority = priorities
+    }
+
+    call nextstrain.concatenate as cat_fasta {
+        input:
+            infiles = [
+                subsample_focal.filtered_fasta, subsample_global.filtered_fasta
+            ],
+            output_name = "subsampled.fasta"
+    }
+
+    call nextstrain.fasta_to_ids {
+        input:
+            sequences_fasta = cat_fasta.combined
+    }
+
+    output {
+        File keep_list            = fasta_to_ids.ids_txt
+        File subsampled_sequences = cat_fasta.combined
+        Int  sequences_kept       = subsample_focal.sequences_out + subsample_global.sequences_out
+    }
+}

--- a/pipes/WDL/workflows/subsample_by_metadata_with_focal.wdl
+++ b/pipes/WDL/workflows/subsample_by_metadata_with_focal.wdl
@@ -96,6 +96,8 @@ workflow subsample_by_metadata_with_focal {
     output {
         File keep_list            = fasta_to_ids.ids_txt
         File subsampled_sequences = cat_fasta.combined
+        Int  focal_kept           = subsample_focal.sequences_out
+        Int  global_kept          = subsample_global.sequences_out
         Int  sequences_kept       = subsample_focal.sequences_out + subsample_global.sequences_out
     }
 }


### PR DESCRIPTION
This PR adds a new WDL workflow, `subsample_by_metadata_with_focal`, which provides a functionality I've been doing manually/offline until recently. This subsets an externally provided dataset of sequences to a more manageable sample size with even representation across metadata-defined categories (e.g. geographic). It does so by splitting the external dataset into two categories: one termed *focal* and one termed *global*, and applying different sample count limits (and bin resolutions) to each, before remerging. Current defaults are based on GISAID column headers and use North America as a focal region--but these defaults might be removed in the future to remain data source and user base agnostic.

This workflow can optionally accept a "priorities" matrix so that the random sampling is biased towards the user's genomes of interest. However, a future version of this workflow should just accept the user's genomes of interest instead and compute the priorities matrix for them.

This PR additionally includes adjustments to the `filter_subsample_sequences` WDL task to convert the `include_where` and `exclude_where` input types from `String?` to `Array[String]?`, which better reflects how they would be used, and keeps a cleaner way of describing input values with spaces and special characters, which are better tolerated now.