### PR TITLE
bump docker images to reflect update to viral-core 2.1.9

### DIFF
--- a/requirements-modules.txt
+++ b/requirements-modules.txt
@@ -1,7 +1,7 @@
-broadinstitute/viral-core=2.1.8
-broadinstitute/viral-assemble=2.1.8.0
+broadinstitute/viral-core=2.1.9
+broadinstitute/viral-assemble=2.1.9.0
 broadinstitute/viral-classify=2.1.8.0
-broadinstitute/viral-phylo=2.1.8.0
+broadinstitute/viral-phylo=2.1.9.0
 broadinstitute/beast-beagle-cuda=1.10.5pre
 broadinstitute/ncbi-tools=2.10.7.1
 nextstrain/base=build-20200629T201240Z


### PR DESCRIPTION
bump viral-(phylo|core|assemble) to reflect new core image of 2.1.9

viral-classify to be included once it builds (currently timing out on Travis while trying to solve the second env with krakenuniq, diamond, and kaiju)