### PR TITLE
bugfix: filter_bam_to_taxa

### DIFF
--- a/pipes/WDL/tasks/tasks_metagenomics.wdl
+++ b/pipes/WDL/tasks/tasks_metagenomics.wdl
@@ -682,14 +682,19 @@ task filter_bam_to_taxa {
     TAXNAMELIST="${write_lines(select_first([taxonomic_names, []]))}"
     if [ -n "$(cat $TAXNAMELIST)" ]; then
       echo "--taxNames" >> taxfilterargs
+      cat $TAXNAMELIST >> taxfilterargs
+      echo "" >> taxfilterargs # cromwell write_lines lacks a final newline, so add one manually
     fi
-    cat $TAXNAMELIST >> taxfilterargs
 
     TAXIDLIST="${write_lines(select_first([taxonomic_ids, []]))}"
     if [ -n "$(cat $TAXIDLIST)" ]; then
       echo "--taxIDs" >> taxfilterargs
+      cat $TAXIDLIST >> taxfilterargs
+      echo "" >> taxfilterargs # cromwell write_lines lacks a final newline, so add one manually
     fi
-    cat $TAXIDLIST >> taxfilterargs
+
+    echo "taxfilterargs:"
+    cat taxfilterargs
 
     metagenomics.py --version | tee VERSION
 


### PR DESCRIPTION
In `task filter_bam_to_taxa`, a bug exists when specifying a list of taxon names or ids. Terra/Cromwell's implementation of the WDL `write_lines` command appears to write the `Array` elements to a text file where the last line of the text file lacks a newline character. This fix adds an additional newline character to the newline-delimited "taxfilterargs" file that we use as input to `xargs` when invoking `metagenomics.py filter_bam_to_taxa`. There is already a defensive `grep` before the `xargs` that filters out empty lines (for other implementations where `write_lines` behaves more as expected).
