### PR TITLE
set "-o pipefail" for filter_subsample_sequences and mafft_one_chr

### DIFF
--- a/pipes/WDL/tasks/tasks_nextstrain.wdl
+++ b/pipes/WDL/tasks/tasks_nextstrain.wdl
@@ -128,7 +128,7 @@ task filter_subsample_sequences {
     }
     String out_fname = sub(sub(basename(sequences_fasta), ".vcf", ".filtered.vcf"), ".fasta$", ".filtered.fasta")
     command {
-        set -e
+        set -e -o pipefail
         augur version > VERSION
 
         touch wherefile
@@ -265,7 +265,7 @@ task mafft_one_chr {
         Int      cpus = 32
     }
     command {
-        set -e
+        set -e -o pipefail
         touch args.txt
 
         # boolean options


### PR DESCRIPTION
Previously, if the commands along the way in the pipeline fail, the tasks succeed. This adds "-o pipefail" so errors lead to non-zero exits.
This change may be needed elsewhere; only adding to these two tasks for now.