### PR TITLE
in snp_sites allow toggle to optionally only output columns containing exclusively ACGT

### DIFF
--- a/pipes/WDL/tasks/tasks_nextstrain.wdl
+++ b/pipes/WDL/tasks/tasks_nextstrain.wdl
@@ -373,12 +373,13 @@ task augur_mafft_align {
 task snp_sites {
     input {
         File   msa_fasta
+        Boolean allow_wildcard_bases=true
         String docker = "quay.io/biocontainers/snp-sites:2.5.1--hed695b0_0"
     }
     String out_basename = basename(msa_fasta, ".fasta")
     command {
         snp-sites -V > VERSION
-        snp-sites -v -c -o ~{out_basename}.vcf ~{msa_fasta}
+        snp-sites -v ~{true="" false="-c" allow_wildcard_bases} -o ~{out_basename}.vcf ~{msa_fasta}
     }
     runtime {
         docker: docker


### PR DESCRIPTION
in `snp_sites`, add a toggle (with default now `true`), `allow_wildcard_bases`, to disable the `snp-sites` option (`-c`) of only outputting columns containing exclusively ACGT. This task was previously failing when an alignment had snps only at sites where other sequences had wildcard bases ([IUPAC ambiguity codes](https://droog.gs.washington.edu/parc/images/iupac.html)). This change allows `snp-sites` to succeed by default, albeit with ambiguity codes in the resulting vcf. The ACTG-only constraint can be turned on if `allow_wildcard_bases=false`.