### PR TITLE
remove recursion limit on find for RunInfo.xml

### DIFF
--- a/pipes/WDL/tasks/tasks_demux.wdl
+++ b/pipes/WDL/tasks/tasks_demux.wdl
@@ -85,7 +85,7 @@ task illumina_demux {
       RUNINFO_FILE="${runinfo}"
     else
       # full RunInfo.xml path
-      RUNINFO_FILE="$(find $FLOWCELL_DIR -type f -maxdepth 3 -name RunInfo.xml | head -n 1)"
+      RUNINFO_FILE="$(find $FLOWCELL_DIR -type f -name RunInfo.xml | head -n 1)"
     fi
     
     # Parse the lane count & run ID from RunInfo.xml file


### PR DESCRIPTION
Currently we look for RunInfo.xml using `find` with `-maxdepth 3`. This gets rid of that parameter and allows it to recurse the entire directory tree if needed.

New tarballs produced by BITS's GP walkup -> cloud service are producing tars that contain the entire directory tree (/seq/illumina_ext/etc...) and you have to traverse much more than three directories in to find the actual BCL directory.