### PR TITLE
bump viral-assemble

### DIFF
--- a/pipes/WDL/tasks/tasks_assembly.wdl
+++ b/pipes/WDL/tasks/tasks_assembly.wdl
@@ -15,7 +15,7 @@ task assemble {
       String   sample_name = basename(basename(reads_unmapped_bam, ".bam"), ".taxfilt")
 
       Int?     machine_mem_gb
-      String   docker="quay.io/broadinstitute/viral-assemble:2.1.12.0"
+      String   docker="quay.io/broadinstitute/viral-assemble:2.1.12.1"
     }
 
     command {
@@ -80,7 +80,7 @@ task scaffold {
       Float?       scaffold_min_pct_contig_aligned
 
       Int?         machine_mem_gb
-      String       docker="quay.io/broadinstitute/viral-assemble:2.1.12.0"
+      String       docker="quay.io/broadinstitute/viral-assemble:2.1.12.1"
 
       # do this in multiple steps in case the input doesn't actually have "assembly1-x" in the name
       String       sample_name = basename(basename(contigs_fasta, ".fasta"), ".assembly1-spades")
@@ -342,7 +342,7 @@ task refine_assembly_with_aligned_reads {
       Int?     min_coverage=3
 
       Int?     machine_mem_gb
-      String   docker="quay.io/broadinstitute/viral-assemble:2.1.12.0"
+      String   docker="quay.io/broadinstitute/viral-assemble:2.1.12.1"
     }
 
     parameter_meta {
@@ -434,7 +434,7 @@ task refine {
       Int?    min_coverage=1
 
       Int?    machine_mem_gb
-      String  docker="quay.io/broadinstitute/viral-assemble:2.1.12.0"
+      String  docker="quay.io/broadinstitute/viral-assemble:2.1.12.1"
 
       String  assembly_basename=basename(basename(assembly_fasta, ".fasta"), ".scaffold")
     }
@@ -504,7 +504,7 @@ task refine_2x_and_plot {
       String? plot_coverage_novoalign_options="-r Random -l 40 -g 40 -x 20 -t 100 -k"
 
       Int?    machine_mem_gb
-      String  docker="quay.io/broadinstitute/viral-assemble:2.1.12.0"
+      String  docker="quay.io/broadinstitute/viral-assemble:2.1.12.1"
 
       # do this in two steps in case the input doesn't actually have "cleaned" in the name
       String  sample_name = basename(basename(reads_unmapped_bam, ".bam"), ".cleaned")

--- a/pipes/WDL/tasks/tasks_reports.wdl
+++ b/pipes/WDL/tasks/tasks_reports.wdl
@@ -436,7 +436,7 @@ task compare_two_genomes {
     File          genome_two
     String        out_basename
 
-    String        docker="quay.io/broadinstitute/viral-assemble:2.1.12.0"
+    String        docker="quay.io/broadinstitute/viral-assemble:2.1.12.1"
   }
 
   command {

--- a/requirements-modules.txt
+++ b/requirements-modules.txt
@@ -1,5 +1,5 @@
 broadinstitute/viral-core=2.1.12
-broadinstitute/viral-assemble=2.1.12.0
+broadinstitute/viral-assemble=2.1.12.1
 broadinstitute/viral-classify=2.1.12.1
 broadinstitute/viral-phylo=2.1.12.0
 broadinstitute/beast-beagle-cuda=1.10.5pre


### PR DESCRIPTION
update viral-assemble from 2.1.12.0 to 2.1.12.1
(fixes behavior of consensus calling when no reads provided)