### PR TITLE
increase vm sizes for mafft and snp_sites

### DIFF
--- a/pipes/WDL/tasks/tasks_nextstrain.wdl
+++ b/pipes/WDL/tasks/tasks_nextstrain.wdl
@@ -386,11 +386,11 @@ task snp_sites {
     }
     runtime {
         docker: docker
-        memory: "7 GB"
+        memory: "31 GB"
         cpu :   2
         disks:  "local-disk 100 HDD"
         preemptible: 0
-        dx_instance_type: "mem1_ssd1_v2_x4"
+        dx_instance_type: "mem3_ssd1_v2_x4"
     }
     output {
         File   snps_vcf = "~{out_basename}.vcf"

--- a/pipes/WDL/tasks/tasks_nextstrain.wdl
+++ b/pipes/WDL/tasks/tasks_nextstrain.wdl
@@ -386,11 +386,11 @@ task snp_sites {
     }
     runtime {
         docker: docker
-        memory: "1 GB"
-        cpu :   1
-        disks:  "local-disk 50 HDD"
+        memory: "7 GB"
+        cpu :   2
+        disks:  "local-disk 100 HDD"
         preemptible: 0
-        dx_instance_type: "mem1_ssd1_v2_x2"
+        dx_instance_type: "mem1_ssd1_v2_x4"
     }
     output {
         File   snps_vcf = "~{out_basename}.vcf"

--- a/pipes/WDL/tasks/tasks_nextstrain.wdl
+++ b/pipes/WDL/tasks/tasks_nextstrain.wdl
@@ -314,7 +314,7 @@ task mafft_one_chr {
         docker: docker
         memory: mem_size + " GB"
         cpu :   cpus
-        disks:  "local-disk 100 HDD"
+        disks:  "local-disk 375 LOCAL"
         preemptible: 0
         dx_instance_type: "mem1_ssd1_v2_x36"
     }


### PR DESCRIPTION
- bump disk size on `mafft_one_chr` task from 100GB to 375GB (was running out of space on large alignments)
- bump RAM (and CPU and disk) on `snp_sites` task (was running out of mem on large alignments)