### PR TITLE
add table merging features for metadata

### DIFF
--- a/pipes/WDL/tasks/tasks_assembly.wdl
+++ b/pipes/WDL/tasks/tasks_assembly.wdl
@@ -226,7 +226,7 @@ task align_reads {
     Boolean? skip_mark_dupes=false
 
     Int?     machine_mem_gb
-    String   docker="quay.io/broadinstitute/viral-core:2.1.12"
+    String   docker="quay.io/broadinstitute/viral-core:2.1.13"
 
     String   sample_name = basename(basename(basename(reads_unmapped_bam, ".bam"), ".taxfilt"), ".clean")
   }
@@ -636,7 +636,7 @@ task run_discordance {
       String   out_basename = "run"
       Int      min_coverage=4
 
-      String   docker="quay.io/broadinstitute/viral-core:2.1.12"
+      String   docker="quay.io/broadinstitute/viral-core:2.1.13"
     }
 
     command {

--- a/pipes/WDL/tasks/tasks_demux.wdl
+++ b/pipes/WDL/tasks/tasks_demux.wdl
@@ -6,7 +6,7 @@ task merge_tarballs {
     String        out_filename
 
     Int?          machine_mem_gb
-    String        docker="quay.io/broadinstitute/viral-core:2.1.12"
+    String        docker="quay.io/broadinstitute/viral-core:2.1.13"
   }
 
   command {
@@ -60,7 +60,7 @@ task illumina_demux {
     Boolean? forceGC=true
 
     Int?    machine_mem_gb
-    String  docker="quay.io/broadinstitute/viral-core:2.1.12"
+    String  docker="quay.io/broadinstitute/viral-core:2.1.13"
   }
 
   command {

--- a/pipes/WDL/tasks/tasks_interhost.wdl
+++ b/pipes/WDL/tasks/tasks_interhost.wdl
@@ -142,7 +142,7 @@ task index_ref {
     File?    novocraft_license
 
     Int?     machine_mem_gb
-    String   docker="quay.io/broadinstitute/viral-core:2.1.12"
+    String   docker="quay.io/broadinstitute/viral-core:2.1.13"
   }
 
   command {

--- a/pipes/WDL/tasks/tasks_read_utils.wdl
+++ b/pipes/WDL/tasks/tasks_read_utils.wdl
@@ -11,7 +11,7 @@ task merge_and_reheader_bams {
       File?           reheader_table
       String          out_basename
 
-      String          docker="quay.io/broadinstitute/viral-core:2.1.12"
+      String          docker="quay.io/broadinstitute/viral-core:2.1.13"
     }
 
     command {
@@ -71,7 +71,7 @@ task rmdup_ubam {
     String   method="mvicuna"
 
     Int?     machine_mem_gb
-    String?  docker="quay.io/broadinstitute/viral-core:2.1.12"
+    String?  docker="quay.io/broadinstitute/viral-core:2.1.13"
   }
 
   parameter_meta {
@@ -125,7 +125,7 @@ task downsample_bams {
     Boolean?     deduplicateAfter=false
 
     Int?         machine_mem_gb
-    String       docker="quay.io/broadinstitute/viral-core:2.1.12"
+    String       docker="quay.io/broadinstitute/viral-core:2.1.13"
   }
 
   command {
@@ -184,7 +184,7 @@ task FastqToUBAM {
     String? platform_name
     String? sequencing_center
 
-    String  docker="quay.io/broadinstitute/viral-core:2.1.12"
+    String  docker="quay.io/broadinstitute/viral-core:2.1.13"
   }
   parameter_meta {
     fastq_1: { description: "Unaligned read1 file in fastq format", patterns: ["*.fastq", "*.fastq.gz", "*.fq", "*.fq.gz"] }

--- a/pipes/WDL/tasks/tasks_reports.wdl
+++ b/pipes/WDL/tasks/tasks_reports.wdl
@@ -10,7 +10,7 @@ task plot_coverage {
     Boolean bin_large_plots=false
     String?  binning_summary_statistic="max" # max or min
 
-    String   docker="quay.io/broadinstitute/viral-core:2.1.12"
+    String   docker="quay.io/broadinstitute/viral-core:2.1.13"
   }
   
   command {
@@ -85,7 +85,7 @@ task coverage_report {
     Array[File]  mapped_bam_idx # optional.. speeds it up if you provide it, otherwise we auto-index
     String       out_report_name="coverage_report.txt"
 
-    String       docker="quay.io/broadinstitute/viral-core:2.1.12"
+    String       docker="quay.io/broadinstitute/viral-core:2.1.13"
   }
 
   command {
@@ -115,7 +115,7 @@ task fastqc {
   input {
     File     reads_bam
 
-    String   docker="quay.io/broadinstitute/viral-core:2.1.12"
+    String   docker="quay.io/broadinstitute/viral-core:2.1.13"
   }
 
   String   reads_basename=basename(reads_bam, ".bam")
@@ -148,7 +148,7 @@ task align_and_count {
     Int     topNHits = 3
 
     Int?    machine_mem_gb
-    String  docker="quay.io/broadinstitute/viral-core:2.1.12"
+    String  docker="quay.io/broadinstitute/viral-core:2.1.13"
   }
 
   String  reads_basename=basename(reads_bam, ".bam")
@@ -191,7 +191,7 @@ task align_and_count_summary {
 
     String       output_prefix="count_summary"
 
-    String        docker="quay.io/broadinstitute/viral-core:2.1.12"
+    String        docker="quay.io/broadinstitute/viral-core:2.1.13"
   }
 
   command {
@@ -364,7 +364,7 @@ task tsv_join {
     String         id_col
     String         out_basename
 
-    String         docker="quay.io/broadinstitute/viral-core:2.1.12"
+    String         docker="quay.io/broadinstitute/viral-core:2.1.13"
   }
 
   command {
@@ -391,7 +391,7 @@ task tsv_stack {
   input {
     Array[File]+   input_tsvs
     String         out_basename
-    String         docker="quay.io/broadinstitute/viral-core:2.1.12"
+    String         docker="quay.io/broadinstitute/viral-core:2.1.13"
   }
 
   command {

--- a/pipes/WDL/tasks/tasks_reports.wdl
+++ b/pipes/WDL/tasks/tasks_reports.wdl
@@ -361,32 +361,17 @@ task MultiQC {
 task tsv_join {
   input {
     Array[File]+   input_tsvs
-    Array[String]+ id_columns
-    String         join_type="inner"
+    String         id_col
     String         out_basename
 
     String         docker="quay.io/broadinstitute/viral-core:2.1.12"
   }
 
   command {
-    if [ "${join_type}" = "inner" ]; then
-      JOIN_TYPE=""
-    elif [ "${join_type}" = "outer" ]; then
-      JOIN_TYPE="--${join_type}"
-    elif [ "${join_type}" = "left" ]; then
-      JOIN_TYPE="--${join_type}"
-    elif [ "${join_type}" = "right" ]; then
-      JOIN_TYPE="--${join_type}"
-    else
-      echo "unrecognized join_type ${join_type}"
-      exit 1
-    fi
-    csvjoin -t -y 0 -I \
-      -c ${sep=',' id_columns} \
-      $JOIN_TYPE \
-      ${sep=' ' input_tsvs} \
-      | tr , '\t' \
-      > ${out_basename}.txt
+    file_utils.py tsv_join \
+      ~{sep=' ' input_tsvs} \
+      ~{out_basename}.txt \
+      --join_id ~{id_col}
   }
 
   output {
@@ -394,10 +379,10 @@ task tsv_join {
   }
 
   runtime {
-    memory: "1 GB"
+    memory: "3 GB"
     cpu: 1
     docker: "${docker}"
-    disks: "local-disk 50 HDD"
+    disks: "local-disk 100 HDD"
     dx_instance_type: "mem1_ssd1_v2_x2"
   }
 }

--- a/pipes/WDL/tasks/tasks_taxon_filter.wdl
+++ b/pipes/WDL/tasks/tasks_taxon_filter.wdl
@@ -202,7 +202,7 @@ task merge_one_per_sample {
     Boolean?     rmdup=false
 
     Int?         machine_mem_gb
-    String       docker="quay.io/broadinstitute/viral-core:2.1.12"
+    String       docker="quay.io/broadinstitute/viral-core:2.1.13"
   }
 
   command {

--- a/requirements-modules.txt
+++ b/requirements-modules.txt
@@ -1,4 +1,4 @@
-broadinstitute/viral-core=2.1.12
+broadinstitute/viral-core=2.1.13
 broadinstitute/viral-assemble=2.1.12.1
 broadinstitute/viral-classify=2.1.12.1
 broadinstitute/viral-phylo=2.1.12.0


### PR DESCRIPTION
Adds ability for `augur_from_msa` workflow to take multiple metadata tsv input files. If multiple tsvs are provided, we will perform a left full outer join on them before feeding into the various nextstrain steps that require a single metadata table. Allows for easier / independent maintenance of separate metadata sets.