### PR TITLE
streamline NCBI submissions

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -215,6 +215,11 @@ workflows:
    primaryDescriptorPath: /pipes/WDL/workflows/multiqc_only.wdl
    testParameterFiles:
     - empty.json
+ - name: sarscov2_genbank
+   subclass: WDL
+   primaryDescriptorPath: /pipes/WDL/workflows/sarscov2_genbank.wdl
+   testParameterFiles:
+    - empty.json
  - name: sarscov2_lineages
    subclass: WDL
    primaryDescriptorPath: /pipes/WDL/workflows/sarscov2_lineages.wdl

--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -215,6 +215,11 @@ workflows:
    primaryDescriptorPath: /pipes/WDL/workflows/multiqc_only.wdl
    testParameterFiles:
     - empty.json
+ - name: sarscov2_illumina_full
+   subclass: WDL
+   primaryDescriptorPath: /pipes/WDL/workflows/sarscov2_illumina_full.wdl
+   testParameterFiles:
+    - empty.json
  - name: sarscov2_genbank
    subclass: WDL
    primaryDescriptorPath: /pipes/WDL/workflows/sarscov2_genbank.wdl

--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -105,6 +105,11 @@ workflows:
    primaryDescriptorPath: /pipes/WDL/workflows/demux_only.wdl
    testParameterFiles:
     - empty.json
+ - name: demux_deplete
+   subclass: WDL
+   primaryDescriptorPath: /pipes/WDL/workflows/demux_deplete.wdl
+   testParameterFiles:
+    - empty.json
  - name: demux_plus
    subclass: WDL
    primaryDescriptorPath: /pipes/WDL/workflows/demux_plus.wdl
@@ -213,11 +218,6 @@ workflows:
  - name: multiqc_only
    subclass: WDL
    primaryDescriptorPath: /pipes/WDL/workflows/multiqc_only.wdl
-   testParameterFiles:
-    - empty.json
- - name: sarscov2_illumina_full
-   subclass: WDL
-   primaryDescriptorPath: /pipes/WDL/workflows/sarscov2_illumina_full.wdl
    testParameterFiles:
     - empty.json
  - name: sarscov2_genbank

--- a/pipes/WDL/tasks/tasks_assembly.wdl
+++ b/pipes/WDL/tasks/tasks_assembly.wdl
@@ -226,7 +226,7 @@ task align_reads {
     Boolean? skip_mark_dupes=false
 
     Int?     machine_mem_gb
-    String   docker="quay.io/broadinstitute/viral-core:2.1.13"
+    String   docker="quay.io/broadinstitute/viral-core:2.1.14"
 
     String   sample_name = basename(basename(basename(reads_unmapped_bam, ".bam"), ".taxfilt"), ".clean")
   }
@@ -636,7 +636,7 @@ task run_discordance {
       String   out_basename = "run"
       Int      min_coverage=4
 
-      String   docker="quay.io/broadinstitute/viral-core:2.1.13"
+      String   docker="quay.io/broadinstitute/viral-core:2.1.14"
     }
 
     command {

--- a/pipes/WDL/tasks/tasks_demux.wdl
+++ b/pipes/WDL/tasks/tasks_demux.wdl
@@ -6,7 +6,7 @@ task merge_tarballs {
     String        out_filename
 
     Int?          machine_mem_gb
-    String        docker="quay.io/broadinstitute/viral-core:2.1.13"
+    String        docker="quay.io/broadinstitute/viral-core:2.1.14"
   }
 
   command {
@@ -60,7 +60,7 @@ task illumina_demux {
     Boolean? forceGC=true
 
     Int?    machine_mem_gb
-    String  docker="quay.io/broadinstitute/viral-core:2.1.13"
+    String  docker="quay.io/broadinstitute/viral-core:2.1.14"
   }
 
   command {

--- a/pipes/WDL/tasks/tasks_interhost.wdl
+++ b/pipes/WDL/tasks/tasks_interhost.wdl
@@ -9,7 +9,7 @@ task multi_align_mafft_ref {
     Float?         mafft_gapOpeningPenalty
 
     Int?           machine_mem_gb
-    String         docker="quay.io/broadinstitute/viral-phylo:2.1.13.0"
+    String         docker="quay.io/broadinstitute/viral-phylo:2.1.13.1"
   }
 
   String           fasta_basename = basename(reference_fasta, '.fasta')
@@ -53,7 +53,7 @@ task multi_align_mafft {
     Float?         mafft_gapOpeningPenalty
 
     Int?           machine_mem_gb
-    String         docker="quay.io/broadinstitute/viral-phylo:2.1.13.0"
+    String         docker="quay.io/broadinstitute/viral-phylo:2.1.13.1"
   }
 
   command {
@@ -252,7 +252,7 @@ task merge_vcfs_gatk {
     File        ref_fasta
 
     Int?     machine_mem_gb
-    String   docker="quay.io/broadinstitute/viral-phylo:2.1.13.0"
+    String   docker="quay.io/broadinstitute/viral-phylo:2.1.13.1"
 
     String   output_prefix = "merged"
   }

--- a/pipes/WDL/tasks/tasks_interhost.wdl
+++ b/pipes/WDL/tasks/tasks_interhost.wdl
@@ -9,7 +9,7 @@ task multi_align_mafft_ref {
     Float?         mafft_gapOpeningPenalty
 
     Int?           machine_mem_gb
-    String         docker="quay.io/broadinstitute/viral-phylo:2.1.13.1"
+    String         docker="quay.io/broadinstitute/viral-phylo:2.1.13.2"
   }
 
   String           fasta_basename = basename(reference_fasta, '.fasta')
@@ -53,7 +53,7 @@ task multi_align_mafft {
     Float?         mafft_gapOpeningPenalty
 
     Int?           machine_mem_gb
-    String         docker="quay.io/broadinstitute/viral-phylo:2.1.13.1"
+    String         docker="quay.io/broadinstitute/viral-phylo:2.1.13.2"
   }
 
   command {
@@ -252,7 +252,7 @@ task merge_vcfs_gatk {
     File        ref_fasta
 
     Int?     machine_mem_gb
-    String   docker="quay.io/broadinstitute/viral-phylo:2.1.13.1"
+    String   docker="quay.io/broadinstitute/viral-phylo:2.1.13.2"
 
     String   output_prefix = "merged"
   }

--- a/pipes/WDL/tasks/tasks_interhost.wdl
+++ b/pipes/WDL/tasks/tasks_interhost.wdl
@@ -142,7 +142,7 @@ task index_ref {
     File?    novocraft_license
 
     Int?     machine_mem_gb
-    String   docker="quay.io/broadinstitute/viral-core:2.1.13"
+    String   docker="quay.io/broadinstitute/viral-core:2.1.14"
   }
 
   command {

--- a/pipes/WDL/tasks/tasks_interhost.wdl
+++ b/pipes/WDL/tasks/tasks_interhost.wdl
@@ -9,7 +9,7 @@ task multi_align_mafft_ref {
     Float?         mafft_gapOpeningPenalty
 
     Int?           machine_mem_gb
-    String         docker="quay.io/broadinstitute/viral-phylo:2.1.12.0"
+    String         docker="quay.io/broadinstitute/viral-phylo:2.1.13.0"
   }
 
   String           fasta_basename = basename(reference_fasta, '.fasta')
@@ -53,7 +53,7 @@ task multi_align_mafft {
     Float?         mafft_gapOpeningPenalty
 
     Int?           machine_mem_gb
-    String         docker="quay.io/broadinstitute/viral-phylo:2.1.12.0"
+    String         docker="quay.io/broadinstitute/viral-phylo:2.1.13.0"
   }
 
   command {
@@ -252,7 +252,7 @@ task merge_vcfs_gatk {
     File        ref_fasta
 
     Int?     machine_mem_gb
-    String   docker="quay.io/broadinstitute/viral-phylo:2.1.12.0"
+    String   docker="quay.io/broadinstitute/viral-phylo:2.1.13.0"
 
     String   output_prefix = "merged"
   }

--- a/pipes/WDL/tasks/tasks_intrahost.wdl
+++ b/pipes/WDL/tasks/tasks_intrahost.wdl
@@ -11,7 +11,7 @@ task isnvs_per_sample {
     Boolean removeDoublyMappedReads=true
 
     Int?    machine_mem_gb
-    String  docker="quay.io/broadinstitute/viral-phylo:2.1.13.0"
+    String  docker="quay.io/broadinstitute/viral-phylo:2.1.13.1"
 
     String  sample_name = basename(basename(basename(mapped_bam, ".bam"), ".all"), ".mapped")
   }
@@ -52,7 +52,7 @@ task isnvs_vcf {
     Boolean        naiveFilter=false
 
     Int?           machine_mem_gb
-    String         docker="quay.io/broadinstitute/viral-phylo:2.1.13.0"
+    String         docker="quay.io/broadinstitute/viral-phylo:2.1.13.1"
   }
 
   parameter_meta {
@@ -125,7 +125,7 @@ task annotate_vcf_snpeff {
     String?        emailAddress
 
     Int?           machine_mem_gb
-    String         docker="quay.io/broadinstitute/viral-phylo:2.1.13.0"
+    String         docker="quay.io/broadinstitute/viral-phylo:2.1.13.1"
 
     String         output_basename = basename(basename(in_vcf, ".gz"), ".vcf")
   }

--- a/pipes/WDL/tasks/tasks_intrahost.wdl
+++ b/pipes/WDL/tasks/tasks_intrahost.wdl
@@ -11,7 +11,7 @@ task isnvs_per_sample {
     Boolean removeDoublyMappedReads=true
 
     Int?    machine_mem_gb
-    String  docker="quay.io/broadinstitute/viral-phylo:2.1.12.0"
+    String  docker="quay.io/broadinstitute/viral-phylo:2.1.13.0"
 
     String  sample_name = basename(basename(basename(mapped_bam, ".bam"), ".all"), ".mapped")
   }
@@ -52,7 +52,7 @@ task isnvs_vcf {
     Boolean        naiveFilter=false
 
     Int?           machine_mem_gb
-    String         docker="quay.io/broadinstitute/viral-phylo:2.1.12.0"
+    String         docker="quay.io/broadinstitute/viral-phylo:2.1.13.0"
   }
 
   parameter_meta {
@@ -125,7 +125,7 @@ task annotate_vcf_snpeff {
     String?        emailAddress
 
     Int?           machine_mem_gb
-    String         docker="quay.io/broadinstitute/viral-phylo:2.1.12.0"
+    String         docker="quay.io/broadinstitute/viral-phylo:2.1.13.0"
 
     String         output_basename = basename(basename(in_vcf, ".gz"), ".vcf")
   }

--- a/pipes/WDL/tasks/tasks_intrahost.wdl
+++ b/pipes/WDL/tasks/tasks_intrahost.wdl
@@ -11,7 +11,7 @@ task isnvs_per_sample {
     Boolean removeDoublyMappedReads=true
 
     Int?    machine_mem_gb
-    String  docker="quay.io/broadinstitute/viral-phylo:2.1.13.1"
+    String  docker="quay.io/broadinstitute/viral-phylo:2.1.13.2"
 
     String  sample_name = basename(basename(basename(mapped_bam, ".bam"), ".all"), ".mapped")
   }
@@ -52,7 +52,7 @@ task isnvs_vcf {
     Boolean        naiveFilter=false
 
     Int?           machine_mem_gb
-    String         docker="quay.io/broadinstitute/viral-phylo:2.1.13.1"
+    String         docker="quay.io/broadinstitute/viral-phylo:2.1.13.2"
   }
 
   parameter_meta {
@@ -125,7 +125,7 @@ task annotate_vcf_snpeff {
     String?        emailAddress
 
     Int?           machine_mem_gb
-    String         docker="quay.io/broadinstitute/viral-phylo:2.1.13.1"
+    String         docker="quay.io/broadinstitute/viral-phylo:2.1.13.2"
 
     String         output_basename = basename(basename(in_vcf, ".gz"), ".vcf")
   }

--- a/pipes/WDL/tasks/tasks_ncbi.wdl
+++ b/pipes/WDL/tasks/tasks_ncbi.wdl
@@ -248,7 +248,7 @@ task structured_comments {
   }
 }
 
-task rename_fasta {
+task rename_fasta_header {
   input {
     File    genome_fasta
     String  new_name

--- a/pipes/WDL/tasks/tasks_ncbi.wdl
+++ b/pipes/WDL/tasks/tasks_ncbi.wdl
@@ -563,14 +563,14 @@ task vadr {
       ~{vadr_opts} \
       --mxsize $RAM_MB \
       "~{genome_fasta}" \
-      ~{out_base}
+      "~{out_base}"
 
     # package everything for output
-    tar -C ~{out_base} -czvf ~{out_base}.vadr.tar.gz .
+    tar -C "~{out_base}" -czvf "~{out_base}.vadr.tar.gz" .
 
     # prep alerts into a tsv file for parsing
-    cat ~{out_base}/~{out_base}.vadr.alt.list| cut -f 2 | tail -n +2 > ~{out_base}.vadr.alerts.tsv
-    wc -l ~{out_base}.vadr.alerts.tsv > NUM_ALERTS
+    cat "~{out_base}/~{out_base}.vadr.alt.list" | cut -f 2 | tail -n +2 > "~{out_base}.vadr.alerts.tsv"
+    cat "~{out_base}.vadr.alerts.tsv" | wc -l > NUM_ALERTS
   >>>
   output {
     File feature_tbl  = "~{out_base}/~{out_base}.vadr.pass.tbl"

--- a/pipes/WDL/tasks/tasks_ncbi.wdl
+++ b/pipes/WDL/tasks/tasks_ncbi.wdl
@@ -544,11 +544,11 @@ task package_genbank_ftp_submission {
 
 task vadr {
   meta {
-    description: "Runs NCBI's Viral Annotation DefineR for annotation and QC."
+    description: "Runs NCBI's Viral Annotation DefineR for annotation and QC. See https://github.com/ncbi/vadr/wiki/Coronavirus-annotation"
   }
   input {
     File   genome_fasta
-    String vadr_opts="-r -s --nomisc --lowsimterm 2 --mkey NC_045512 --fstlowthr 0.0 --alt_fail lowscore,fsthicnf,fstlocnf"
+    String vadr_opts="-s -r --nomisc --mkey NC_045512 --lowsim5term 2 --lowsim3term 2 --fstlowthr 0.0 --alt_fail lowscore,fsthicnf,fstlocnf"
 
     String  docker="staphb/vadr:1.1.2"
   }

--- a/pipes/WDL/tasks/tasks_ncbi.wdl
+++ b/pipes/WDL/tasks/tasks_ncbi.wdl
@@ -351,12 +351,13 @@ task sra_meta_prep {
     for bam in bam_uris:
       # filename must be <libraryname>.<flowcell>.<lane>.cleaned.bam
       assert bam.endswith('.cleaned.bam'), "filename does not end in .cleaned.bam: {}".format(bam)
-      bam_parts = os.path.basename(bam).split('.')
-      assert len(bam_parts) >= 5, "filename does not conform to <libraryname>.<flowcell>.<lane>.cleaned.bam -- {}".format(bam)
+      bam_base = os.path.basename(bam)
+      bam_parts = bam_base.split('.')
+      assert len(bam_parts) >= 5, "filename does not conform to <libraryname>.<flowcell>.<lane>.cleaned.bam -- {}".format(bam_base)
       lib = '.'.join(bam_parts[:-4])
       lib_to_bams.setdefault(lib, [])
-      lib_to_bams[lib].append(bam)
-      print("debug: registering lib={} bam={}".format(lib, bam))
+      lib_to_bams[lib].append(bam_base)
+      print("debug: registering lib={} bam={}".format(lib, bam_base))
     with open('~{biosample_map}', 'rt') as inf:
       for row in csv.DictReader(inf, delimiter='\t'):
         sample_to_biosample[row['sample_name']] = row['accession']
@@ -381,7 +382,7 @@ task sra_meta_prep {
               'library_strategy': row.get('library_strategy',''),
               'library_source': row.get('library_source',''),
               'library_selection': row.get('library_selection',''),
-              'library_layout': '${true="paired" false="single" paired}',
+              'library_layout': '~{true="paired" false="single" paired}',
               'platform': '~{platform}',
               'instrument_model': '~{instrument_model}',
               'design_description': row.get('design_description',''),

--- a/pipes/WDL/tasks/tasks_ncbi.wdl
+++ b/pipes/WDL/tasks/tasks_ncbi.wdl
@@ -212,29 +212,29 @@ task structured_comments {
     set -e
 
     python3 << CODE
-      import util.file
+    import util.file
 
-      samples_to_filter_to = set()
-      if "~{default='' filter_to_ids}":
-          with open("~{default='' filter_to_ids}", 'rt') as inf:
-              samples_to_filter_to = set(line.strip() for line in inf)
+    samples_to_filter_to = set()
+    if "~{default='' filter_to_ids}":
+        with open("~{default='' filter_to_ids}", 'rt') as inf:
+            samples_to_filter_to = set(line.strip() for line in inf)
 
-      out_headers_total = ('SeqID', 'StructuredCommentPrefix', 'Assembly Method', 'Coverage', 'Sequencing Technology', 'StructuredCommentSuffix')
-      with open("~{out_base}.cmt", 'wt') as outf:
-          outf.write('\t'.join(out_headers_total)+'\n')
+    out_headers_total = ('SeqID', 'StructuredCommentPrefix', 'Assembly Method', 'Coverage', 'Sequencing Technology', 'StructuredCommentSuffix')
+    with open("~{out_base}.cmt", 'wt') as outf:
+        outf.write('\t'.join(out_headers_total)+'\n')
 
-          for row in util.file.read_tabfile_dict(in_table):
-              outrow = dict((h, row.get(header_key_map.get(h,h), '')) for h in out_headers)
+        for row in util.file.read_tabfile_dict(in_table):
+            outrow = dict((h, row.get(header_key_map.get(h,h), '')) for h in out_headers)
 
-              if samples_to_filter_to:
-                if row['SeqID'] not in samples_to_filter_to:
-                    continue
+            if samples_to_filter_to:
+              if row['SeqID'] not in samples_to_filter_to:
+                  continue
 
-              if outrow['Coverage']:
-                outrow['Coverage'] = "{}x".format(round(float(outrow['Coverage'])))
-              outrow['StructuredCommentPrefix'] = 'Assembly-Data'
-              outrow['StructuredCommentSuffix'] = 'Assembly-Data'
-              outf.write('\t'.join(outrow[h] for h in out_headers)+'\n')
+            if outrow['Coverage']:
+              outrow['Coverage'] = "{}x".format(round(float(outrow['Coverage'])))
+            outrow['StructuredCommentPrefix'] = 'Assembly-Data'
+            outrow['StructuredCommentSuffix'] = 'Assembly-Data'
+            outf.write('\t'.join(outrow[h] for h in out_headers)+'\n')
     CODE
   >>>
   output {

--- a/pipes/WDL/tasks/tasks_ncbi.wdl
+++ b/pipes/WDL/tasks/tasks_ncbi.wdl
@@ -258,7 +258,7 @@ task rename_fasta {
   command {
     set -e
     file_utils.py rename_fasta_sequences \
-      "~{genome_fasta}.fasta" "~{new_name}.fasta" "~{new_name}"
+      "~{genome_fasta}" "~{new_name}.fasta" "~{new_name}"
   }
   output {
     File renamed_fasta = "~{new_name}.fasta"

--- a/pipes/WDL/tasks/tasks_ncbi.wdl
+++ b/pipes/WDL/tasks/tasks_ncbi.wdl
@@ -364,7 +364,7 @@ task sra_meta_prep {
 
     # set up SRA metadata table
     outrows = []
-    out_headers = ('biosample_accession', 'library_ID', 'title', 'library_strategy', 'library_source', 'library_selection', 'library_layout', 'platform', 'instrument_model', 'design_description', 'filetype', 'filename')
+    out_headers = ('biosample_accession', 'library_ID', 'title', 'library_strategy', 'library_source', 'library_selection', 'library_layout', 'platform', 'instrument_model', 'design_description', 'filetype', 'assembly', 'filename')
 
     # iterate through library_metadata entries and produce an output row for each entry
     for libfile in library_metadata:
@@ -387,6 +387,7 @@ task sra_meta_prep {
               'instrument_model': '~{instrument_model}',
               'design_description': row.get('design_description',''),
               'filetype': 'bam',
+              'assembly': 'unaligned',
               'files': lib_to_bams[lib],
             })
     assert outrows, "failed to prepare any metadata -- output is empty!"

--- a/pipes/WDL/tasks/tasks_ncbi.wdl
+++ b/pipes/WDL/tasks/tasks_ncbi.wdl
@@ -223,7 +223,7 @@ task structured_comments {
     with open("~{out_base}.cmt", 'wt') as outf:
         outf.write('\t'.join(out_headers_total)+'\n')
 
-        for row in util.file.read_tabfile_dict(in_table):
+        for row in util.file.read_tabfile_dict("~{assembly_stats_tsv}"):
             outrow = dict((h, row.get(header_key_map.get(h,h), '')) for h in out_headers)
 
             if samples_to_filter_to:

--- a/pipes/WDL/tasks/tasks_ncbi.wdl
+++ b/pipes/WDL/tasks/tasks_ncbi.wdl
@@ -253,15 +253,17 @@ task rename_fasta {
     File    genome_fasta
     String  new_name
 
+    String  out_basename = basename(genome_fasta, ".fasta")
+
     String  docker="quay.io/broadinstitute/viral-core:2.1.13"
   }
   command {
     set -e
     file_utils.py rename_fasta_sequences \
-      "~{genome_fasta}" "~{new_name}.fasta" "~{new_name}"
+      "~{genome_fasta}" "~{out_basename}.fasta" "~{new_name}"
   }
   output {
-    File renamed_fasta = "~{new_name}.fasta"
+    File renamed_fasta = "~{out_basename}.fasta"
   }
   runtime {
     docker: "~{docker}"

--- a/pipes/WDL/tasks/tasks_ncbi.wdl
+++ b/pipes/WDL/tasks/tasks_ncbi.wdl
@@ -205,7 +205,7 @@ task structured_comments {
 
     File?   filter_to_ids
 
-    String  docker="quay.io/broadinstitute/viral-core:2.1.13"
+    String  docker="quay.io/broadinstitute/viral-core:2.1.14"
   }
   String out_base = basename(assembly_stats_tsv, '.txt')
   command <<<
@@ -255,7 +255,7 @@ task rename_fasta_header {
 
     String  out_basename = basename(genome_fasta, ".fasta")
 
-    String  docker="quay.io/broadinstitute/viral-core:2.1.13"
+    String  docker="quay.io/broadinstitute/viral-core:2.1.14"
   }
   command {
     set -e

--- a/pipes/WDL/tasks/tasks_ncbi.wdl
+++ b/pipes/WDL/tasks/tasks_ncbi.wdl
@@ -353,7 +353,6 @@ task sra_meta_prep {
       assert bam.endswith('.cleaned.bam'), "filename does not end in .cleaned.bam: {}".format(bam)
       bam_parts = os.path.basename(bam).split('.')
       assert len(bam_parts) >= 5, "filename does not conform to <libraryname>.<flowcell>.<lane>.cleaned.bam -- {}".format(bam)
-      lib = util.file.sanitize_id_for_sam_rname('.'.join(bam_parts[:-4]))
       lib_to_bams.setdefault(lib, [])
       lib_to_bams[lib].append(bam)
       print("debug: registering lib={} bam={}".format(lib, bam))
@@ -369,7 +368,7 @@ task sra_meta_prep {
     for libfile in library_metadata:
       with open(libfile, 'rt') as inf:
         for row in csv.DictReader(inf, delimiter='\t'):
-          lib = "{}.l{}".format(row['sample'], row['library_id_per_sample'])
+          lib = util.file.sanitize_id_for_sam_rname("{}.l{}".format(row['sample'], row['library_id_per_sample']))
           biosample = sample_to_biosample.get(row['sample'],'')
           bams = lib_to_bams.get(lib,[])
           print("debug: sample={} lib={} biosample={}, bams={}".format(row['sample'], lib, biosample, bams))

--- a/pipes/WDL/tasks/tasks_ncbi.wdl
+++ b/pipes/WDL/tasks/tasks_ncbi.wdl
@@ -405,6 +405,7 @@ task package_genbank_ftp_submission {
     # make the submission xml file
     SUB_NAME="~{submission_name}"
     ACCT_NAME="~{account_name}"
+    SPUID="~{submission_uid}"
     cat << EOF > submission.xml
     <?xml version="1.0"?>
     <Submission>
@@ -416,12 +417,12 @@ task package_genbank_ftp_submission {
       </Description>
       <Action>
         <AddFiles target_db="GenBank">
-          <File file_path="~{submission_uid}.zip">
+          <File file_path="$SPUID.zip">
             <DataType>genbank-submission-package</DataType>
           </File>
           <Attribute name="wizard">BankIt_SARSCoV2_api</Attribute>
           <Identifier>
-            <SPUID spuid_namespace="~{spuid_namespace}">~{submission_uid}</SPUID>
+            <SPUID spuid_namespace="~{spuid_namespace}">$SPUID</SPUID>
           </Identifier>
         </AddFiles>
       </Action>

--- a/pipes/WDL/tasks/tasks_ncbi.wdl
+++ b/pipes/WDL/tasks/tasks_ncbi.wdl
@@ -199,6 +199,29 @@ task align_and_annot_transfer_single {
   }
 }
 
+task rename_fasta {
+  input {
+    File    genome_fasta
+    String  new_name
+
+    String  docker="quay.io/broadinstitute/viral-core:2.1.13"
+  }
+  command {
+    set -e
+    file_utils.py rename_fasta_sequences \
+      "~{genome_fasta}.fasta" "~{new_name}.fasta" "~{new_name}"
+  }
+  output {
+    File renamed_fasta = "~{new_name}.fasta"
+  }
+  runtime {
+    docker: "~{docker}"
+    memory: "1 GB"
+    cpu: 1
+    dx_instance_type: "mem1_ssd1_v2_x2"
+  }
+}
+
 task biosample_to_genbank {
   meta {
     description: "Prepares two input metadata files for Genbank submission based on a BioSample registration attributes table (attributes.tsv) since all of the necessary values are there. This produces both a Genbank Source Modifier Table and a BioSample ID map file that can be fed into the prepare_genbank task."

--- a/pipes/WDL/tasks/tasks_ncbi.wdl
+++ b/pipes/WDL/tasks/tasks_ncbi.wdl
@@ -271,6 +271,29 @@ task rename_fasta {
   }
 }
 
+task lookup_table_by_filename {
+  input {
+    String  id
+    File    mapping_tsv
+    Int     return_col=2
+
+    String  docker="ubuntu"
+  }
+  command {
+    set -e -o pipefail
+    grep ^"~{id}" ~{mapping_tsv} | cut -f ~{return_col} > OUTVAL
+  }
+  output {
+    String value = read_string("OUTVAL")
+  }
+  runtime {
+    docker: "~{docker}"
+    memory: "1 GB"
+    cpu: 1
+    dx_instance_type: "mem1_ssd1_v2_x2"
+  }
+}
+
 task biosample_to_genbank {
   meta {
     description: "Prepares two input metadata files for Genbank submission based on a BioSample registration attributes table (attributes.tsv) since all of the necessary values are there. This produces both a Genbank Source Modifier Table and a BioSample ID map file that can be fed into the prepare_genbank task."

--- a/pipes/WDL/tasks/tasks_ncbi.wdl
+++ b/pipes/WDL/tasks/tasks_ncbi.wdl
@@ -353,6 +353,7 @@ task sra_meta_prep {
       assert bam.endswith('.cleaned.bam'), "filename does not end in .cleaned.bam: {}".format(bam)
       bam_parts = os.path.basename(bam).split('.')
       assert len(bam_parts) >= 5, "filename does not conform to <libraryname>.<flowcell>.<lane>.cleaned.bam -- {}".format(bam)
+      lib = '.'.join(bam_parts[:-4])
       lib_to_bams.setdefault(lib, [])
       lib_to_bams[lib].append(bam)
       print("debug: registering lib={} bam={}".format(lib, bam))

--- a/pipes/WDL/tasks/tasks_ncbi.wdl
+++ b/pipes/WDL/tasks/tasks_ncbi.wdl
@@ -25,7 +25,7 @@ task download_fasta {
     Array[String]+ accessions
     String         emailAddress
 
-    String         docker="quay.io/broadinstitute/viral-phylo:2.1.13.0"
+    String         docker="quay.io/broadinstitute/viral-phylo:2.1.13.1"
   }
 
   command {
@@ -56,7 +56,7 @@ task download_annotations {
     String         emailAddress
     String         combined_out_prefix
 
-    String         docker="quay.io/broadinstitute/viral-phylo:2.1.13.0"
+    String         docker="quay.io/broadinstitute/viral-phylo:2.1.13.1"
   }
 
   command {
@@ -100,7 +100,7 @@ task annot_transfer {
     File         reference_fasta
     Array[File]+ reference_feature_table
 
-    String  docker="quay.io/broadinstitute/viral-phylo:2.1.13.0"
+    String  docker="quay.io/broadinstitute/viral-phylo:2.1.13.1"
   }
 
   parameter_meta {
@@ -153,7 +153,7 @@ task align_and_annot_transfer_single {
     Array[File]+ reference_fastas
     Array[File]+ reference_feature_tables
 
-    String  docker="quay.io/broadinstitute/viral-phylo:2.1.13.0"
+    String  docker="quay.io/broadinstitute/viral-phylo:2.1.13.1"
   }
 
   parameter_meta {
@@ -210,7 +210,7 @@ task biosample_to_genbank {
 
     File? filter_to_ids
 
-    String  docker="quay.io/broadinstitute/viral-phylo:2.1.13.0"
+    String  docker="quay.io/broadinstitute/viral-phylo:2.1.13.1"
   }
   String base = basename(biosample_attributes, ".txt")
   command {
@@ -258,7 +258,7 @@ task prepare_genbank {
     String?      assembly_method_version
 
     Int?         machine_mem_gb
-    String       docker="quay.io/broadinstitute/viral-phylo:2.1.13.0"
+    String       docker="quay.io/broadinstitute/viral-phylo:2.1.13.1"
   }
 
   parameter_meta {

--- a/pipes/WDL/tasks/tasks_ncbi.wdl
+++ b/pipes/WDL/tasks/tasks_ncbi.wdl
@@ -496,7 +496,7 @@ task package_genbank_ftp_submission {
     cp "~{structured_comment_table}" comment.cmt
     cp "~{source_modifier_table}" source.src
     cp "~{author_template_sbt}" template.sbt
-    zip "~{submission_uid}.zip" sequences.fsa comment.cmt source.src template.sbt
+    zip "~{submission_uid}.zip" sequence.fsa comment.cmt source.src template.sbt
 
     # make the submission xml file
     SUB_NAME="~{submission_name}"
@@ -569,11 +569,12 @@ task vadr {
     tar -C ~{out_base} -czvf ~{out_base}.vadr.tar.gz .
 
     # prep alerts into a tsv file for parsing
-    cat ~{out_base}/~{out_base}.vadr.alt.list| tail -n +2 | cut -f 2- > ~{out_base}.vadr.alerts.tsv
+    cat ~{out_base}/~{out_base}.vadr.alt.list| cut -f 2 | tail -n +2 > ~{out_base}.vadr.alerts.tsv
+    wc -l ~{out_base}.vadr.alerts.tsv > NUM_ALERTS
   >>>
   output {
     File feature_tbl  = "~{out_base}/~{out_base}.vadr.pass.tbl"
-    Int  num_alerts = length(read_lines("~{out_base}.vadr.alerts.tsv"))
+    Int  num_alerts = read_int("NUM_ALERTS")
     File alerts_list = "~{out_base}/~{out_base}.vadr.alt.list"
     Array[Array[String]] alerts = read_tsv("~{out_base}.vadr.alerts.tsv")
     File outputs_tgz = "~{out_base}.vadr.tar.gz"

--- a/pipes/WDL/tasks/tasks_ncbi.wdl
+++ b/pipes/WDL/tasks/tasks_ncbi.wdl
@@ -550,7 +550,7 @@ task vadr {
     File   genome_fasta
     String vadr_opts="-r -s --nomisc --lowsimterm 2 --mkey NC_045512 --fstlowthr 0.0 --alt_fail lowscore,fsthicnf,fstlocnf"
 
-    String  docker="staphb/vadr:1.1"
+    String  docker="staphb/vadr:1.1.2"
   }
   String out_base = basename(genome_fasta, '.fasta')
   command <<<

--- a/pipes/WDL/tasks/tasks_ncbi.wdl
+++ b/pipes/WDL/tasks/tasks_ncbi.wdl
@@ -354,6 +354,7 @@ task sra_meta_prep {
       lib = '.'.join(bam_parts[:-4])
       lib_to_bams.setdefault(lib, [])
       lib_to_bams[lib].append(bam)
+      print("debug: registering lib={} bam={}".format(lib, bam))
     with open('~{biosample_map}', 'rt') as inf:
       for row in csv.DictReader(inf, delimiter='\t'):
         sample_to_biosample[row['sample_name']] = row['accession']
@@ -385,6 +386,7 @@ task sra_meta_prep {
               'filetype': 'bam',
               'files': lib_to_bams[lib],
             })
+    assert outrows, "failed to prepare any metadata -- output is empty!"
 
     # find library with the most files and add col headers
     n_cols = max(len(row['files']) for row in outrows)

--- a/pipes/WDL/tasks/tasks_ncbi.wdl
+++ b/pipes/WDL/tasks/tasks_ncbi.wdl
@@ -455,7 +455,7 @@ task vadr {
 
     String  docker="staphb/vadr:1.1"
   }
-  String out_base = basename(genome_fasta, 'fasta')
+  String out_base = basename(genome_fasta, '.fasta')
   command <<<
     set -e
 

--- a/pipes/WDL/tasks/tasks_ncbi.wdl
+++ b/pipes/WDL/tasks/tasks_ncbi.wdl
@@ -224,7 +224,7 @@ task structured_comments {
         outf.write('\t'.join(out_headers)+'\n')
 
         for row in util.file.read_tabfile_dict("~{assembly_stats_tsv}"):
-            outrow = dict((h, row.get(header_key_map.get(h,h), '')) for h in out_headers)
+            outrow = dict((h, row.get(h, '')) for h in out_headers)
 
             if samples_to_filter_to:
               if row['SeqID'] not in samples_to_filter_to:

--- a/pipes/WDL/tasks/tasks_ncbi.wdl
+++ b/pipes/WDL/tasks/tasks_ncbi.wdl
@@ -219,9 +219,9 @@ task structured_comments {
         with open("~{default='' filter_to_ids}", 'rt') as inf:
             samples_to_filter_to = set(line.strip() for line in inf)
 
-    out_headers_total = ('SeqID', 'StructuredCommentPrefix', 'Assembly Method', 'Coverage', 'Sequencing Technology', 'StructuredCommentSuffix')
+    out_headers = ('SeqID', 'StructuredCommentPrefix', 'Assembly Method', 'Coverage', 'Sequencing Technology', 'StructuredCommentSuffix')
     with open("~{out_base}.cmt", 'wt') as outf:
-        outf.write('\t'.join(out_headers_total)+'\n')
+        outf.write('\t'.join(out_headers)+'\n')
 
         for row in util.file.read_tabfile_dict("~{assembly_stats_tsv}"):
             outrow = dict((h, row.get(header_key_map.get(h,h), '')) for h in out_headers)

--- a/pipes/WDL/tasks/tasks_ncbi.wdl
+++ b/pipes/WDL/tasks/tasks_ncbi.wdl
@@ -25,7 +25,7 @@ task download_fasta {
     Array[String]+ accessions
     String         emailAddress
 
-    String         docker="quay.io/broadinstitute/viral-phylo:2.1.13.1"
+    String         docker="quay.io/broadinstitute/viral-phylo:2.1.13.2"
   }
 
   command {
@@ -56,7 +56,7 @@ task download_annotations {
     String         emailAddress
     String         combined_out_prefix
 
-    String         docker="quay.io/broadinstitute/viral-phylo:2.1.13.1"
+    String         docker="quay.io/broadinstitute/viral-phylo:2.1.13.2"
   }
 
   command {
@@ -100,7 +100,7 @@ task annot_transfer {
     File         reference_fasta
     Array[File]+ reference_feature_table
 
-    String  docker="quay.io/broadinstitute/viral-phylo:2.1.13.1"
+    String  docker="quay.io/broadinstitute/viral-phylo:2.1.13.2"
   }
 
   parameter_meta {
@@ -153,7 +153,7 @@ task align_and_annot_transfer_single {
     Array[File]+ reference_fastas
     Array[File]+ reference_feature_tables
 
-    String  docker="quay.io/broadinstitute/viral-phylo:2.1.13.1"
+    String  docker="quay.io/broadinstitute/viral-phylo:2.1.13.2"
   }
 
   parameter_meta {
@@ -307,7 +307,7 @@ task biosample_to_genbank {
 
     File? filter_to_ids
 
-    String  docker="quay.io/broadinstitute/viral-phylo:2.1.13.1"
+    String  docker="quay.io/broadinstitute/viral-phylo:2.1.13.2"
   }
   String base = basename(biosample_attributes, ".txt")
   command {
@@ -321,6 +321,7 @@ task biosample_to_genbank {
         "${base}".biosample.map.txt \
         ${'--filter_to_samples ' + filter_to_ids} \
         --biosample_in_smt \
+        --iso_dates \
         --loglevel DEBUG
   }
   output {
@@ -355,7 +356,7 @@ task prepare_genbank {
     String?      assembly_method_version
 
     Int?         machine_mem_gb
-    String       docker="quay.io/broadinstitute/viral-phylo:2.1.13.1"
+    String       docker="quay.io/broadinstitute/viral-phylo:2.1.13.2"
   }
 
   parameter_meta {

--- a/pipes/WDL/tasks/tasks_ncbi.wdl
+++ b/pipes/WDL/tasks/tasks_ncbi.wdl
@@ -367,9 +367,10 @@ task sra_meta_prep {
       with open(libfile, 'rt') as inf:
         for row in csv.DictReader(inf, delimiter='\t'):
           lib = "{}.l{}".format(row['sample'], row['library_id_per_sample'])
-          print("debug: sample={} lib={}".format(row['sample'], lib))
-          if row['sample'] in sample_to_biosample and lib in lib_to_bams:
-            print("debug: passed")
+          biosample = sample_to_biosample.get(row['sample'],'')
+          bams = lib_to_bams.get(lib,[])
+          print("debug: sample={} lib={} biosample={}, bams={}".format(row['sample'], lib, biosample, bams))
+          if biosample and bams:
             outrows.append({
               'biosample_accession': sample_to_biosample[row['sample']],
               'library_ID': lib,

--- a/pipes/WDL/tasks/tasks_ncbi.wdl
+++ b/pipes/WDL/tasks/tasks_ncbi.wdl
@@ -369,7 +369,7 @@ task sra_meta_prep {
     for libfile in library_metadata:
       with open(libfile, 'rt') as inf:
         for row in csv.DictReader(inf, delimiter='\t'):
-          lib = util.file.sanitize_id_for_sam_rname("{}.l{}".format(row['sample'], row['library_id_per_sample']))
+          lib = util.file.string_to_file_name("{}.l{}".format(row['sample'], row['library_id_per_sample']))
           biosample = sample_to_biosample.get(row['sample'],'')
           bams = lib_to_bams.get(lib,[])
           print("debug: sample={} lib={} biosample={}, bams={}".format(row['sample'], lib, biosample, bams))

--- a/pipes/WDL/tasks/tasks_nextstrain.wdl
+++ b/pipes/WDL/tasks/tasks_nextstrain.wdl
@@ -613,7 +613,7 @@ task refine_augur_tree {
         Int?     gen_per_year
         Float?   clock_rate
         Float?   clock_std_dev
-        Boolean  keep_root = false
+        Boolean  keep_root = true
         String?  root
         Boolean? covariance
         Boolean  keep_polytomies = false
@@ -623,7 +623,7 @@ task refine_augur_tree {
         String?  branch_length_inference
         String?  coalescent
         Int?     clock_filter_iqd = 4
-        String?  divergence_units
+        String?  divergence_units = "mutations"
         File?    vcf_reference
 
         String   docker = "nextstrain/base:build-20201214T004216Z"

--- a/pipes/WDL/tasks/tasks_nextstrain.wdl
+++ b/pipes/WDL/tasks/tasks_nextstrain.wdl
@@ -170,7 +170,7 @@ task filter_subsample_sequences {
     }
     runtime {
         docker: docker
-        memory: "3 GB"
+        memory: "15 GB"
         cpu :   4
         disks:  "local-disk 100 HDD"
         dx_instance_type: "mem1_ssd1_v2_x4"

--- a/pipes/WDL/tasks/tasks_nextstrain.wdl
+++ b/pipes/WDL/tasks/tasks_nextstrain.wdl
@@ -413,7 +413,7 @@ task mafft_one_chr {
         Boolean  memsavetree = false
 
         String   docker = "quay.io/broadinstitute/viral-phylo:2.1.13.2"
-        Int      mem_size = 80
+        Int      mem_size = 250
         Int      cpus = 32
     }
     command {
@@ -473,7 +473,7 @@ task mafft_one_chr {
         cpu :   cpus
         disks:  "local-disk 375 LOCAL"
         preemptible: 0
-        dx_instance_type: "mem1_ssd1_v2_x36"
+        dx_instance_type: "mem3_ssd1_v2_x36"
     }
     output {
         File   aligned_sequences = "~{basename}_aligned.fasta"

--- a/pipes/WDL/tasks/tasks_nextstrain.wdl
+++ b/pipes/WDL/tasks/tasks_nextstrain.wdl
@@ -285,7 +285,7 @@ task mafft_one_chr {
         Boolean  large = false
         Boolean  memsavetree = false
 
-        String   docker = "quay.io/broadinstitute/viral-phylo:2.1.13.1"
+        String   docker = "quay.io/broadinstitute/viral-phylo:2.1.13.2"
         Int      mem_size = 60
         Int      cpus = 32
     }

--- a/pipes/WDL/tasks/tasks_nextstrain.wdl
+++ b/pipes/WDL/tasks/tasks_nextstrain.wdl
@@ -285,7 +285,7 @@ task mafft_one_chr {
         Boolean  large = false
         Boolean  memsavetree = false
 
-        String   docker = "quay.io/broadinstitute/viral-phylo:2.1.13.0"
+        String   docker = "quay.io/broadinstitute/viral-phylo:2.1.13.1"
         Int      mem_size = 60
         Int      cpus = 32
     }

--- a/pipes/WDL/tasks/tasks_nextstrain.wdl
+++ b/pipes/WDL/tasks/tasks_nextstrain.wdl
@@ -282,16 +282,12 @@ task filter_sequences_by_length {
     import util.file
     n_total = 0
     n_kept = 0
-    do_not_count = set(('N','n','-','.',' '))
     with util.file.open_or_gzopen('~{sequences_fasta}', 'rt') as inf:
         with util.file.open_or_gzopen('~{out_fname}', 'wt') as outf:
             for seq in Bio.SeqIO.parse(inf, 'fasta'):
                 n_total += 1
-                n_unambig = 0
-                for base in seq.seq:
-                    if base not in do_not_count:
-                        n_unambig += 1
-                if n_unambig >= ~{min_non_N}:
+                ungapseq = seq.seq.ungap().upper()
+                if (len(ungapseq) - ungapseq.count('N')) >= ~{min_non_N}:
                     n_kept += 1
                     Bio.SeqIO.write(seq, outf, 'fasta')
     n_dropped = n_total-n_kept

--- a/pipes/WDL/tasks/tasks_nextstrain.wdl
+++ b/pipes/WDL/tasks/tasks_nextstrain.wdl
@@ -30,7 +30,7 @@ task gzcat {
     input {
         Array[File] infiles
         String      output_name
-        String      docker="quay.io/broadinstitute/viral-core:2.1.13"
+        String      docker="quay.io/broadinstitute/viral-core:2.1.14"
     }
     command <<<
         python3 <<CODE
@@ -63,7 +63,7 @@ task derived_cols {
         String?       lab_highlight_loc
         Array[File]   table_map=[]
 
-        String        docker="quay.io/broadinstitute/viral-core:2.1.13"
+        String        docker="quay.io/broadinstitute/viral-core:2.1.14"
     }
     String basename = basename(basename(metadata_tsv, ".txt"), ".tsv")
     command {
@@ -264,7 +264,7 @@ task filter_sequences_by_length {
         File    sequences_fasta
         Int     min_non_N = 1
 
-        String  docker="quay.io/broadinstitute/viral-core:2.1.13"
+        String  docker="quay.io/broadinstitute/viral-core:2.1.14"
     }
     parameter_meta {
         sequences_fasta: {

--- a/pipes/WDL/tasks/tasks_nextstrain.wdl
+++ b/pipes/WDL/tasks/tasks_nextstrain.wdl
@@ -364,8 +364,8 @@ task mafft_one_chr {
         # decompress sequences if necessary
         GENOMES="~{sequences}"
         if [[ $GENOMES == *.gz ]]; then
-            gzip -d $GENOMES
-            GENOMES=$(basename $GENOMES .gz)
+            gzip -dc $GENOMES > uncompressed.fasta
+            GENOMES="uncompressed.fasta"
         fi
 
         touch args.txt

--- a/pipes/WDL/tasks/tasks_nextstrain.wdl
+++ b/pipes/WDL/tasks/tasks_nextstrain.wdl
@@ -35,9 +35,9 @@ task gzcat {
     command <<<
         python3 <<CODE
         import util.file
-        with util.file.open_or_gzopen("~{output_name}", 'w') as outf:
+        with util.file.open_or_gzopen("~{output_name}", 'wt') as outf:
             for infname in "~{sep=' ' infiles}".split(' '):
-                with util.file.open_or_gzopen(infname, 'r') as inf:
+                with util.file.open_or_gzopen(infname, 'rt') as inf:
                     for line in inf:
                         outf.write(line)
         CODE

--- a/pipes/WDL/tasks/tasks_nextstrain.wdl
+++ b/pipes/WDL/tasks/tasks_nextstrain.wdl
@@ -285,7 +285,7 @@ task mafft_one_chr {
         Boolean  large = false
         Boolean  memsavetree = false
 
-        String   docker = "quay.io/broadinstitute/viral-phylo:2.1.12.0"
+        String   docker = "quay.io/broadinstitute/viral-phylo:2.1.13.0"
         Int      mem_size = 60
         Int      cpus = 32
     }

--- a/pipes/WDL/tasks/tasks_nextstrain.wdl
+++ b/pipes/WDL/tasks/tasks_nextstrain.wdl
@@ -355,7 +355,7 @@ task mafft_one_chr {
         Boolean  memsavetree = false
 
         String   docker = "quay.io/broadinstitute/viral-phylo:2.1.13.2"
-        Int      mem_size = 60
+        Int      mem_size = 80
         Int      cpus = 32
     }
     command {

--- a/pipes/WDL/tasks/tasks_read_utils.wdl
+++ b/pipes/WDL/tasks/tasks_read_utils.wdl
@@ -11,7 +11,7 @@ task merge_and_reheader_bams {
       File?           reheader_table
       String          out_basename
 
-      String          docker="quay.io/broadinstitute/viral-core:2.1.13"
+      String          docker="quay.io/broadinstitute/viral-core:2.1.14"
     }
 
     command {
@@ -71,7 +71,7 @@ task rmdup_ubam {
     String   method="mvicuna"
 
     Int?     machine_mem_gb
-    String?  docker="quay.io/broadinstitute/viral-core:2.1.13"
+    String?  docker="quay.io/broadinstitute/viral-core:2.1.14"
   }
 
   parameter_meta {
@@ -125,7 +125,7 @@ task downsample_bams {
     Boolean?     deduplicateAfter=false
 
     Int?         machine_mem_gb
-    String       docker="quay.io/broadinstitute/viral-core:2.1.13"
+    String       docker="quay.io/broadinstitute/viral-core:2.1.14"
   }
 
   command {
@@ -184,7 +184,7 @@ task FastqToUBAM {
     String? platform_name
     String? sequencing_center
 
-    String  docker="quay.io/broadinstitute/viral-core:2.1.13"
+    String  docker="quay.io/broadinstitute/viral-core:2.1.14"
   }
   parameter_meta {
     fastq_1: { description: "Unaligned read1 file in fastq format", patterns: ["*.fastq", "*.fastq.gz", "*.fq", "*.fq.gz"] }

--- a/pipes/WDL/tasks/tasks_read_utils.wdl
+++ b/pipes/WDL/tasks/tasks_read_utils.wdl
@@ -32,7 +32,7 @@ task group_bams_by_sample {
     CODE
   >>>
   output {
-    Array[Array[String]] grouped_bam_filepaths = read_tsv('grouped_bams')
+    Array[Array[String]+] grouped_bam_filepaths = read_tsv('grouped_bams')
     Array[String]        sample_names = read_lines('sample_names')
   }
   runtime {

--- a/pipes/WDL/tasks/tasks_reports.wdl
+++ b/pipes/WDL/tasks/tasks_reports.wdl
@@ -117,12 +117,13 @@ task assembly_bases {
 
     input {
       File     fasta
-      String   docker="quay.io/broadinstitute/viral-baseimage:0.1.19"
+      String   docker="ubuntu"
     }
 
     command {
-        grep -v '^>' refined.fasta | tr -d '\n' | wc -c | tee assembly_length
-        grep -v '^>' refined.fasta | tr -d '\nNn' | wc -c | tee assembly_length_unambiguous
+        set -e
+        grep -v '^>' "~{fasta}" | tr -d '\n' | wc -c | tee assembly_length
+        grep -v '^>' "~{fasta}" | tr -d '\nNn' | wc -c | tee assembly_length_unambiguous
     }
 
     output {

--- a/pipes/WDL/tasks/tasks_reports.wdl
+++ b/pipes/WDL/tasks/tasks_reports.wdl
@@ -10,7 +10,7 @@ task plot_coverage {
     Boolean bin_large_plots=false
     String?  binning_summary_statistic="max" # max or min
 
-    String   docker="quay.io/broadinstitute/viral-core:2.1.13"
+    String   docker="quay.io/broadinstitute/viral-core:2.1.14"
   }
   
   command {
@@ -85,7 +85,7 @@ task coverage_report {
     Array[File]  mapped_bam_idx # optional.. speeds it up if you provide it, otherwise we auto-index
     String       out_report_name="coverage_report.txt"
 
-    String       docker="quay.io/broadinstitute/viral-core:2.1.13"
+    String       docker="quay.io/broadinstitute/viral-core:2.1.14"
   }
 
   command {
@@ -144,7 +144,7 @@ task fastqc {
   input {
     File     reads_bam
 
-    String   docker="quay.io/broadinstitute/viral-core:2.1.13"
+    String   docker="quay.io/broadinstitute/viral-core:2.1.14"
   }
 
   String   reads_basename=basename(reads_bam, ".bam")
@@ -177,7 +177,7 @@ task align_and_count {
     Int     topNHits = 3
 
     Int?    machine_mem_gb
-    String  docker="quay.io/broadinstitute/viral-core:2.1.13"
+    String  docker="quay.io/broadinstitute/viral-core:2.1.14"
   }
 
   String  reads_basename=basename(reads_bam, ".bam")
@@ -220,7 +220,7 @@ task align_and_count_summary {
 
     String       output_prefix="count_summary"
 
-    String        docker="quay.io/broadinstitute/viral-core:2.1.13"
+    String        docker="quay.io/broadinstitute/viral-core:2.1.14"
   }
 
   command {
@@ -393,7 +393,7 @@ task tsv_join {
     String         id_col
     String         out_basename
 
-    String         docker="quay.io/broadinstitute/viral-core:2.1.13"
+    String         docker="quay.io/broadinstitute/viral-core:2.1.14"
   }
 
   command {
@@ -420,7 +420,7 @@ task tsv_stack {
   input {
     Array[File]+   input_tsvs
     String         out_basename
-    String         docker="quay.io/broadinstitute/viral-core:2.1.13"
+    String         docker="quay.io/broadinstitute/viral-core:2.1.14"
   }
 
   command {

--- a/pipes/WDL/tasks/tasks_reports.wdl
+++ b/pipes/WDL/tasks/tasks_reports.wdl
@@ -110,6 +110,34 @@ task coverage_report {
   }
 }
 
+task assembly_bases {
+    meta {
+      description: "Count bases in a fasta file."
+    }
+
+    input {
+      File     fasta
+      String   docker="quay.io/broadinstitute/viral-baseimage:0.1.19"
+    }
+
+    command {
+        grep -v '^>' refined.fasta | tr -d '\n' | wc -c | tee assembly_length
+        grep -v '^>' refined.fasta | tr -d '\nNn' | wc -c | tee assembly_length_unambiguous
+    }
+
+    output {
+        Int    assembly_length              = read_int("assembly_length")
+        Int    assembly_length_unambiguous  = read_int("assembly_length_unambiguous")
+    }
+
+    runtime {
+        docker: "${docker}"
+        memory: "1 GB"
+        cpu: 1
+        disks: "local-disk 50 HDD"
+        dx_instance_type: "mem1_ssd1_v2_x2"
+    }
+}
 
 task fastqc {
   input {

--- a/pipes/WDL/tasks/tasks_sarscov2.wdl
+++ b/pipes/WDL/tasks/tasks_sarscov2.wdl
@@ -39,7 +39,7 @@ task nextclade_one_sample {
         grep ^aaDeletions transposed.tsv | cut -f 2 | grep -v aaDeletions > NEXTCLADE_AADELS
     }
     runtime {
-        docker: "neherlab/nextclade:0.10.0"
+        docker: "neherlab/nextclade:0.11.1"
         memory: "3 GB"
         cpu:    2
         disks: "local-disk 50 HDD"
@@ -85,7 +85,7 @@ task nextclade_many_samples {
             --output-tree "~{basename}".nextclade.auspice.json
     }
     runtime {
-        docker: "neherlab/nextclade:0.10.0"
+        docker: "neherlab/nextclade:0.11.1"
         memory: "14 GB"
         cpu:    16
         disks: "local-disk 100 HDD"
@@ -136,7 +136,7 @@ task pangolin_one_sample {
         grep ^lineage transposed.tsv | cut -f 2 | grep -v lineage > PANGOLIN_CLADE
     }
     runtime {
-        docker: "staphb/pangolin:2.1.1"
+        docker: "staphb/pangolin:2.1.6"
         memory: "3 GB"
         cpu:    2
         disks: "local-disk 50 HDD"

--- a/pipes/WDL/tasks/tasks_taxon_filter.wdl
+++ b/pipes/WDL/tasks/tasks_taxon_filter.wdl
@@ -202,7 +202,7 @@ task merge_one_per_sample {
     Boolean?     rmdup=false
 
     Int?         machine_mem_gb
-    String       docker="quay.io/broadinstitute/viral-core:2.1.13"
+    String       docker="quay.io/broadinstitute/viral-core:2.1.14"
   }
 
   command {

--- a/pipes/WDL/workflows/augur_from_assemblies.wdl
+++ b/pipes/WDL/workflows/augur_from_assemblies.wdl
@@ -78,7 +78,7 @@ workflow augur_from_assemblies {
     call nextstrain.gzcat {
         input:
             infiles     = assembly_fastas,
-            output_name = "all_samples_combined_assembly.fasta.gz"
+            output_name = "all_samples_combined_assembly.fasta"
     }
     call nextstrain.mafft_one_chr as mafft {
         input:

--- a/pipes/WDL/workflows/augur_from_assemblies.wdl
+++ b/pipes/WDL/workflows/augur_from_assemblies.wdl
@@ -3,7 +3,7 @@ version 1.0
 import "mafft_and_snp.wdl"
 import "subsample_by_metadata_with_focal.wdl"
 import "augur_from_msa.wdl"
-
+import "../tasks/tasks_nextstrain.wdl" as nextstrain
 
 workflow augur_from_assemblies {
     meta {
@@ -28,7 +28,7 @@ workflow augur_from_assemblies {
             ref_fasta = ref_fasta
     }
 
-    call subsample_by_metadata_with_focal.subsample_by_metadata_with_focal {
+    call subsample_by_metadata_with_focal.subsample_by_metadata_with_focal as subsample {
         input:
             sequences_fasta = mafft_and_snp.multiple_alignment
     }
@@ -36,26 +36,35 @@ workflow augur_from_assemblies {
     call augur_from_msa.augur_from_msa {
         input:
             msa_or_vcf = mafft_and_snp.multiple_alignment,
-            sample_metadata = [subsample_by_metadata_with_focal.metadata_merged],
+            sample_metadata = [subsample.metadata_merged],
             ref_fasta = ref_fasta,
-            keep_list = [subsample_by_metadata_with_focal.keep_list]
+            keep_list = [subsample.keep_list]
+    }
+
+    # re-export because it's quick and it exposes all the optional inputs
+    call nextstrain.export_auspice_json {
+        input:
+            tree            = augur_from_msa.time_tree,
+            sample_metadata = subsample.metadata_merged,
+            node_data_jsons = augur_from_msa.node_data_jsons
     }
 
     output {
-        File  combined_assemblies  = mafft_and_snp.combined_assemblies
-        File  multiple_alignment   = mafft_and_snp.multiple_alignment
-        File  unmasked_snps        = mafft_and_snp.unmasked_snps
+      File  combined_assemblies   = mafft_and_snp.combined_assemblies
+      File  multiple_alignment    = mafft_and_snp.multiple_alignment
+      File  unmasked_snps         = mafft_and_snp.unmasked_snps
 
-        File  metadata_merged      = subsample_by_metadata_with_focal.metadata_merged
-        File  keep_list            = subsample_by_metadata_with_focal.keep_list
-        File  subsampled_sequences = subsample_by_metadata_with_focal.subsampled_sequences
-        Int   focal_kept           = subsample_by_metadata_with_focal.focal_kept
-        Int   global_kept          = subsample_by_metadata_with_focal.global_kept
-        Int   sequences_kept       = subsample_by_metadata_with_focal.sequences_kept
+      File  metadata_merged       = subsample.metadata_merged
+      File  keep_list             = subsample.keep_list
+      File  subsampled_sequences  = subsample.subsampled_sequences
+      Int   focal_kept            = subsample.focal_kept
+      Int   global_kept           = subsample.global_kept
+      Int   sequences_kept        = subsample.sequences_kept
 
-        File  masked_alignment     = augur_from_msa.masked_alignment
-        File  ml_tree              = augur_from_msa.ml_tree
-        File  time_tree            = augur_from_msa.time_tree
-        File  auspice_input_json   = augur_from_msa.auspice_input_json
+      File  masked_alignment      = augur_from_msa.masked_alignment
+      File  ml_tree               = augur_from_msa.ml_tree
+      File  time_tree             = augur_from_msa.time_tree
+      Array[File] node_data_jsons = augur_from_msa.node_data_jsons
+      File  auspice_input_json    = export_auspice_json.virus_json
     }
 }

--- a/pipes/WDL/workflows/augur_from_assemblies.wdl
+++ b/pipes/WDL/workflows/augur_from_assemblies.wdl
@@ -1,9 +1,9 @@
 version 1.0
 
 import "mafft_and_snp.wdl"
-import "subsample_by_metadata_with_focal.wdl"
-import "augur_from_msa.wdl"
+
 import "../tasks/tasks_nextstrain.wdl" as nextstrain
+import "../tasks/tasks_reports.wdl" as reports
 
 workflow augur_from_assemblies {
     meta {
@@ -14,7 +14,19 @@ workflow augur_from_assemblies {
 
     input {
         File            ref_fasta
-        File            auspice_config
+        Array[File]+    sample_metadata_tsvs
+
+        String          focal_variable = "region"
+        String          focal_value = "North America"
+
+        String          focal_bin_variable = "division"
+        Int             focal_bin_max = 50
+
+        String          global_bin_variable = "country"
+        Int             global_bin_max = 50
+
+        File?           clades_tsv
+        Array[String]?  ancestral_traits_to_infer
     }
 
     parameter_meta {
@@ -22,9 +34,38 @@ workflow augur_from_assemblies {
           description: "A reference assembly (not included in assembly_fastas) to align assembly_fastas against. Typically from NCBI RefSeq or similar.",
           patterns: ["*.fasta", "*.fa"]
         }
-        auspice_config: {
-          description: "A file specifying options to customize the auspice export; see: https://nextstrain.github.io/auspice/customise-client/introduction",
-          patterns: ["*.json", "*.txt"]
+        sample_metadata_tsvs: {
+            description: "Tab-separated metadata file that contain binning variables and values. Must contain all samples: output will be filtered to the IDs present in this file.",
+            patterns: ["*.txt", "*.tsv"]
+        }
+
+        focal_variable: {
+            description: "The dataset will be bifurcated based on this column header."
+        }
+        focal_value: {
+            description: "The dataset will be bifurcated based whether the focal_variable column matches this value or not. Rows that match this value are considered to be part of the 'focal' set of interest, rows that do not are part of the 'global' set."
+        }
+
+        focal_bin_variable: {
+            description: "The focal subset of samples will be evenly subsampled across the discrete values of this column header."
+        }
+        focal_bin_max: {
+            description: "The output will contain no more than this number of focal samples from each discrete value in the focal_bin_variable column."
+        }
+
+        global_bin_variable: {
+            description: "The global subset of samples will be evenly subsampled across the discrete values of this column header."
+        }
+        global_bin_max: {
+            description: "The output will contain no more than this number of global samples from each discrete value in the global_bin_variable column."
+        }
+
+        ancestral_traits_to_infer: {
+          description: "A list of metadata traits to use for ancestral node inference (see https://nextstrain-augur.readthedocs.io/en/stable/usage/cli/traits.html). Multiple traits may be specified; must correspond exactly to column headers in metadata file. Omitting these values will skip ancestral trait inference, and ancestral nodes will not have estimated values for metadata."
+        }
+        clades_tsv: {
+          description: "A TSV file containing clade mutation positions in four columns: [clade  gene    site    alt]; see: https://nextstrain.org/docs/tutorials/defining-clades",
+          patterns: ["*.tsv", "*.txt"]
         }
     }
 
@@ -34,27 +75,116 @@ workflow augur_from_assemblies {
             run_iqtree = false
     }
 
-    call subsample_by_metadata_with_focal.subsample_by_metadata_with_focal as subsample {
-        input:
-            sequences_fasta = mafft_and_snp.multiple_alignment
+
+    #### subsample_by_metadata_with_focal
+
+    if(length(sample_metadata_tsvs)>1) {
+        call reports.tsv_join {
+            input:
+                input_tsvs = sample_metadata_tsvs,
+                id_col = 'strain',
+                out_basename = "metadata-merged"
+        }
     }
 
-    call augur_from_msa.augur_from_msa {
+    call nextstrain.derived_cols {
         input:
-            msa_or_vcf = mafft_and_snp.multiple_alignment,
-            sample_metadata = [subsample.metadata_merged],
-            ref_fasta = ref_fasta,
-            keep_list = [subsample.keep_list],
-            auspice_config = auspice_config
+            metadata_tsv = select_first(flatten([[tsv_join.out_tsv], sample_metadata_tsvs]))
     }
 
-    # re-export because it's quick and it exposes all the optional inputs
+    call nextstrain.filter_subsample_sequences as prefilter {
+        input:
+            sequences_fasta = mafft_and_snp.multiple_alignment,
+            sample_metadata_tsv = derived_cols.derived_metadata
+    }
+
+    call nextstrain.filter_subsample_sequences as subsample_focal {
+        input:
+            sequences_fasta = prefilter.filtered_fasta,
+            sample_metadata_tsv = derived_cols.derived_metadata,
+            exclude_where = ["${focal_variable}!=${focal_value}"],
+            sequences_per_group = focal_bin_max,
+            group_by = focal_bin_variable
+    }
+
+    call nextstrain.filter_subsample_sequences as subsample_global {
+        input:
+            sequences_fasta = prefilter.filtered_fasta,
+            sample_metadata_tsv = derived_cols.derived_metadata,
+            exclude_where = ["${focal_variable}=${focal_value}"],
+            sequences_per_group = global_bin_max,
+            group_by = global_bin_variable
+    }
+
+    call nextstrain.concatenate as cat_fasta {
+        input:
+            infiles = [
+                subsample_focal.filtered_fasta, subsample_global.filtered_fasta
+            ],
+            output_name = "subsampled.fasta"
+    }
+
+    call nextstrain.fasta_to_ids {
+        input:
+            sequences_fasta = cat_fasta.combined
+    }
+
+
+    #### augur_from_msa
+
+    call nextstrain.augur_mask_sites {
+        input:
+            sequences = cat_fasta.combined
+    }
+    call nextstrain.draft_augur_tree {
+        input:
+            msa_or_vcf = augur_mask_sites.masked_sequences
+    }
+
+    call nextstrain.refine_augur_tree {
+        input:
+            raw_tree    = draft_augur_tree.aligned_tree,
+            msa_or_vcf  = augur_mask_sites.masked_sequences,
+            metadata    = derived_cols.derived_metadata
+    }
+    if(defined(ancestral_traits_to_infer) && length(select_first([ancestral_traits_to_infer,[]]))>0) {
+        call nextstrain.ancestral_traits {
+            input:
+                tree           = refine_augur_tree.tree_refined,
+                metadata       = derived_cols.derived_metadata,
+                columns        = select_first([ancestral_traits_to_infer,[]])
+        }
+    }
+    call nextstrain.ancestral_tree {
+        input:
+            tree        = refine_augur_tree.tree_refined,
+            msa_or_vcf  = augur_mask_sites.masked_sequences
+    }
+    call nextstrain.translate_augur_tree {
+        input:
+            tree        = refine_augur_tree.tree_refined,
+            nt_muts     = ancestral_tree.nt_muts_json
+    }
+    if(defined(clades_tsv)) {
+        call nextstrain.assign_clades_to_nodes {
+            input:
+                tree_nwk     = refine_augur_tree.tree_refined,
+                nt_muts_json = ancestral_tree.nt_muts_json,
+                aa_muts_json = translate_augur_tree.aa_muts_json,
+                ref_fasta    = ref_fasta,
+                clades_tsv   = select_first([clades_tsv])
+        }
+    }
     call nextstrain.export_auspice_json {
         input:
-            tree            = augur_from_msa.time_tree,
-            sample_metadata = subsample.metadata_merged,
-            node_data_jsons = augur_from_msa.node_data_jsons,
-            auspice_config  = auspice_config
+            tree            = refine_augur_tree.tree_refined,
+            sample_metadata = derived_cols.derived_metadata,
+            node_data_jsons = select_all([
+                                refine_augur_tree.branch_lengths,
+                                ancestral_traits.node_data_json,
+                                ancestral_tree.nt_muts_json,
+                                translate_augur_tree.aa_muts_json,
+                                assign_clades_to_nodes.node_clade_data_json])
     }
 
     output {
@@ -62,17 +192,22 @@ workflow augur_from_assemblies {
       File  multiple_alignment    = mafft_and_snp.multiple_alignment
       File  unmasked_snps         = mafft_and_snp.unmasked_snps
 
-      File  metadata_merged       = subsample.metadata_merged
-      File  keep_list             = subsample.keep_list
-      File  subsampled_sequences  = subsample.subsampled_sequences
-      Int   focal_kept            = subsample.focal_kept
-      Int   global_kept           = subsample.global_kept
-      Int   sequences_kept        = subsample.sequences_kept
+      File  metadata_merged       = derived_cols.derived_metadata
+      File  keep_list             = fasta_to_ids.ids_txt
+      File  subsampled_sequences  = cat_fasta.combined
+      Int   focal_kept            = subsample_focal.sequences_out
+      Int   global_kept           = subsample_global.sequences_out
+      Int   sequences_kept        = subsample_focal.sequences_out + subsample_global.sequences_out
 
-      File  masked_alignment      = augur_from_msa.masked_alignment
-      File  ml_tree               = augur_from_msa.ml_tree
-      File  time_tree             = augur_from_msa.time_tree
-      Array[File] node_data_jsons = augur_from_msa.node_data_jsons
+      File  masked_alignment      = augur_mask_sites.masked_sequences
+      File  ml_tree               = draft_augur_tree.aligned_tree
+      File  time_tree             = refine_augur_tree.tree_refined
+      Array[File] node_data_jsons = select_all([
+                    refine_augur_tree.branch_lengths,
+                    ancestral_traits.node_data_json,
+                    ancestral_tree.nt_muts_json,
+                    translate_augur_tree.aa_muts_json,
+                    assign_clades_to_nodes.node_clade_data_json])
       File  auspice_input_json    = export_auspice_json.virus_json
     }
 }

--- a/pipes/WDL/workflows/augur_from_assemblies.wdl
+++ b/pipes/WDL/workflows/augur_from_assemblies.wdl
@@ -1,6 +1,9 @@
 version 1.0
 
-import "../tasks/tasks_nextstrain.wdl" as nextstrain
+import "mafft_and_snp.wdl"
+import "subsample_by_metadata_with_focal.wdl"
+import "augur_from_msa.wdl"
+
 
 workflow augur_from_assemblies {
     meta {
@@ -10,132 +13,49 @@ workflow augur_from_assemblies {
     }
 
     input {
-        Array[File]     assembly_fastas
-        File            sample_metadata
-        String          virus
         File            ref_fasta
-        File            genbank_gb
-        File            auspice_config
-        File?           clades_tsv
-        Array[String]?  ancestral_traits_to_infer
     }
 
     parameter_meta {
-        assembly_fastas: {
-          description: "Set of assembled genomes to align and build trees. These must represent a single chromosome/segment of a genome only. Fastas may be one-sequence-per-individual or a concatenated multi-fasta (unaligned) or a mixture of the two. Fasta header records need to be pipe-delimited (|) for each metadata value.",
-          patterns: ["*.fasta", "*.fa"]
-        }
-        sample_metadata: {
-          description: "Metadata in tab-separated text format. See https://nextstrain-augur.readthedocs.io/en/stable/faq/metadata.html for details.",
-          patterns: ["*.txt", "*.tsv"]
-        }
-        virus: {
-          description: "A filename-friendly string that is used as a base for output file names."
-        }
         ref_fasta: {
           description: "A reference assembly (not included in assembly_fastas) to align assembly_fastas against. Typically from NCBI RefSeq or similar.",
           patterns: ["*.fasta", "*.fa"]
         }
-        genbank_gb: {
-          description: "A 'genbank' formatted gene annotation file that is used to calculate coding consequences of observed mutations. Must correspond to the same coordinate space as ref_fasta. Typically downloaded from the same NCBI accession number as ref_fasta.",
-          patterns: ["*.gb", "*.gbf"]
-        }
-        ancestral_traits_to_infer: {
-          description: "A list of metadata traits to use for ancestral node inference (see https://nextstrain-augur.readthedocs.io/en/stable/usage/cli/traits.html). Multiple traits may be specified; must correspond exactly to column headers in metadata file. Omitting these values will skip ancestral trait inference, and ancestral nodes will not have estimated values for metadata."
-        }
-        auspice_config: {
-          description: "A file specifying options to customize the auspice export; see: https://nextstrain.github.io/auspice/customise-client/introduction",
-          patterns: ["*.json", "*.txt"]
-        }
-        clades_tsv: {
-          description: "A TSV file containing clade mutation positions in four columns: [clade  gene    site    alt]; see: https://nextstrain.org/docs/tutorials/defining-clades",
-          patterns: ["*.tsv", "*.txt"]
-        }
     }
 
-    call nextstrain.concatenate {
+    call mafft_and_snp.mafft_and_snp {
         input:
-            infiles     = assembly_fastas,
-            output_name = "all_samples_combined_assembly.fasta"
+            ref_fasta = ref_fasta
     }
-    call nextstrain.filter_subsample_sequences {
-            input:
-                sequences_fasta     = concatenate.combined,
-                sample_metadata_tsv = sample_metadata
-    }
-    call nextstrain.mafft_one_chr as mafft {
+
+    call subsample_by_metadata_with_focal.subsample_by_metadata_with_focal {
         input:
-            sequences = filter_subsample_sequences.filtered_fasta,
+            sequences_fasta = mafft_and_snp.multiple_alignment
+    }
+
+    call augur_from_msa.augur_from_msa {
+        input:
+            msa_or_vcf = mafft_and_snp.multiple_alignment,
+            sample_metadata = [subsample_by_metadata_with_focal.metadata_merged],
             ref_fasta = ref_fasta,
-            basename  = virus
-    }
-    call nextstrain.snp_sites {
-        input:
-            msa_fasta = mafft.aligned_sequences
-    }
-    call nextstrain.augur_mask_sites {
-        input:
-            sequences = mafft.aligned_sequences
-    }
-    call nextstrain.draft_augur_tree {
-        input:
-            msa_or_vcf = augur_mask_sites.masked_sequences
-    }
-    call nextstrain.refine_augur_tree {
-        input:
-            raw_tree    = draft_augur_tree.aligned_tree,
-            msa_or_vcf  = augur_mask_sites.masked_sequences,
-            metadata    = sample_metadata
-    }
-    if(defined(ancestral_traits_to_infer) && length(select_first([ancestral_traits_to_infer,[]]))>0) {
-        call nextstrain.ancestral_traits {
-            input:
-                tree           = refine_augur_tree.tree_refined,
-                metadata       = sample_metadata,
-                columns        = select_first([ancestral_traits_to_infer,[]])
-        }
-    }
-    call nextstrain.ancestral_tree {
-        input:
-            tree        = refine_augur_tree.tree_refined,
-            msa_or_vcf  = augur_mask_sites.masked_sequences
-    }
-    call nextstrain.translate_augur_tree {
-        input:
-            tree        = refine_augur_tree.tree_refined,
-            nt_muts     = ancestral_tree.nt_muts_json,
-            genbank_gb  = genbank_gb
-    }
-    if(defined(clades_tsv)) {
-        call nextstrain.assign_clades_to_nodes {
-            input:
-                tree_nwk     = refine_augur_tree.tree_refined,
-                nt_muts_json = ancestral_tree.nt_muts_json,
-                aa_muts_json = translate_augur_tree.aa_muts_json,
-                ref_fasta    = ref_fasta,
-                clades_tsv   = select_first([clades_tsv])
-        }
-    }
-    call nextstrain.export_auspice_json {
-        input:
-            tree            = refine_augur_tree.tree_refined,
-            sample_metadata = sample_metadata,
-            node_data_jsons = select_all([
-                                refine_augur_tree.branch_lengths,
-                                ancestral_traits.node_data_json,
-                                ancestral_tree.nt_muts_json,
-                                translate_augur_tree.aa_muts_json,
-                                assign_clades_to_nodes.node_clade_data_json]),
-            auspice_config  = auspice_config
+            keep_list = [subsample_by_metadata_with_focal.keep_list]
     }
 
     output {
-        File  combined_assemblies = concatenate.combined
-        File  multiple_alignment  = mafft.aligned_sequences
-        File  unmasked_snps       = snp_sites.snps_vcf
-        File  masked_alignment    = augur_mask_sites.masked_sequences
-        File  ml_tree             = draft_augur_tree.aligned_tree
-        File  time_tree           = refine_augur_tree.tree_refined
-        File  auspice_input_json  = export_auspice_json.virus_json
+        File  combined_assemblies  = mafft_and_snp.combined_assemblies
+        File  multiple_alignment   = mafft_and_snp.multiple_alignment
+        File  unmasked_snps        = mafft_and_snp.unmasked_snps
+
+        File  metadata_merged      = subsample_by_metadata_with_focal.metadata_merged
+        File  keep_list            = subsample_by_metadata_with_focal.keep_list
+        File  subsampled_sequences = subsample_by_metadata_with_focal.subsampled_sequences
+        Int   focal_kept           = subsample_by_metadata_with_focal.focal_kept
+        Int   global_kept          = subsample_by_metadata_with_focal.global_kept
+        Int   sequences_kept       = subsample_by_metadata_with_focal.sequences_kept
+
+        File  masked_alignment     = augur_from_msa.masked_alignment
+        File  ml_tree              = augur_from_msa.ml_tree
+        File  time_tree            = augur_from_msa.time_tree
+        File  auspice_input_json   = augur_from_msa.auspice_input_json
     }
 }

--- a/pipes/WDL/workflows/augur_from_msa.wdl
+++ b/pipes/WDL/workflows/augur_from_msa.wdl
@@ -19,6 +19,7 @@ workflow augur_from_msa {
         File?           clades_tsv
         Array[String]?  ancestral_traits_to_infer
         Array[File]?    keep_list
+        File?           mask_bed
     }
 
     parameter_meta {
@@ -50,8 +51,12 @@ workflow augur_from_msa {
           patterns: ["*.tsv", "*.txt"]
         }
         keep_list: {
-          description: "Lists of strain ids to filter inputs down to.",
+          description: "Optional lists of strain ids to filter inputs down to.",
           patterns: ["*.txt", "*.tsv"]
+        }
+        mask_bed: {
+          description: "Optional list of sites to mask when building trees.",
+          patterns: ["*.bed"]
         }
     }
 
@@ -62,7 +67,8 @@ workflow augur_from_msa {
     }
     call nextstrain.augur_mask_sites {
         input:
-            sequences = filter_sequences_to_list.filtered_fasta
+            sequences = filter_sequences_to_list.filtered_fasta,
+            mask_bed  = mask_bed
     }
     call nextstrain.draft_augur_tree {
         input:
@@ -128,6 +134,12 @@ workflow augur_from_msa {
         File  masked_alignment    = augur_mask_sites.masked_sequences
         File  ml_tree             = draft_augur_tree.aligned_tree
         File  time_tree           = refine_augur_tree.tree_refined
+        Array[File] node_data_jsons     = select_all([
+                    refine_augur_tree.branch_lengths,
+                    ancestral_traits.node_data_json,
+                    ancestral_tree.nt_muts_json,
+                    translate_augur_tree.aa_muts_json,
+                    assign_clades_to_nodes.node_clade_data_json])
         File  auspice_input_json  = export_auspice_json.virus_json
     }
 }

--- a/pipes/WDL/workflows/augur_from_msa.wdl
+++ b/pipes/WDL/workflows/augur_from_msa.wdl
@@ -18,6 +18,7 @@ workflow augur_from_msa {
         File            auspice_config
         File?           clades_tsv
         Array[String]?  ancestral_traits_to_infer
+        Array[File]?    keep_list
     }
 
     parameter_meta {
@@ -48,11 +49,16 @@ workflow augur_from_msa {
           description: "A TSV file containing clade mutation positions in four columns: [clade  gene    site    alt]; see: https://nextstrain.org/docs/tutorials/defining-clades",
           patterns: ["*.tsv", "*.txt"]
         }
+        keep_list: {
+          description: "Lists of strain ids to filter inputs down to.",
+          patterns: ["*.txt", "*.tsv"]
+        }
     }
 
     call nextstrain.filter_sequences_to_list {
         input:
-            sequences = msa_or_vcf
+            sequences = msa_or_vcf,
+            keep_list = keep_list
     }
     call nextstrain.augur_mask_sites {
         input:

--- a/pipes/WDL/workflows/demux_deplete.wdl
+++ b/pipes/WDL/workflows/demux_deplete.wdl
@@ -1,0 +1,84 @@
+version 1.0
+
+import "../tasks/tasks_demux.wdl" as demux
+import "../tasks/tasks_read_utils.wdl" as read_utils
+import "../tasks/tasks_taxon_filter.wdl" as taxon_filter
+import "../tasks/tasks_reports.wdl" as reports
+
+workflow demux_plus {
+    meta {
+        description: "Picard-based demultiplexing and basecalling from a tarball of a raw BCL directory, followed by QC metrics and depletion. Intended for automatic triggering post upload on DNAnexus."
+        author: "Broad Viral Genomics"
+        email:  "viral-ngs@broadinstitute.org"
+    }
+
+    input {
+        File         flowcell_tgz
+        Array[File]+ samplesheets
+
+        File spikein_db
+        Array[File]? bmtaggerDbs  # .tar.gz, .tgz, .tar.bz2, .tar.lz4, .fasta, or .fasta.gz
+        Array[File]? blastDbs  # .tar.gz, .tgz, .tar.bz2, .tar.lz4, .fasta, or .fasta.gz
+        Array[File]? bwaDbs
+    }
+
+    scatter(lane_sheet in zip(range(length(samplesheets)), samplesheets)) {
+        call demux.illumina_demux as illumina_demux {
+            input:
+                flowcell_tgz = flowcell_tgz,
+                lane = lane_sheet.left,
+                samplesheet = lane_sheet.right
+        }
+
+    }
+
+    scatter(raw_reads in flatten(illumina_demux.raw_reads_unaligned_bams)) {
+        call reports.align_and_count as spikein {
+            input:
+                reads_bam = raw_reads,
+                ref_db = spikein_db
+        }
+        call taxon_filter.deplete_taxa as deplete {
+            input:
+                raw_reads_unmapped_bam = raw_reads,
+                bmtaggerDbs = bmtaggerDbs,
+                blastDbs = blastDbs,
+                bwaDbs = bwaDbs
+        }
+    }
+
+    call reports.MultiQC as multiqc_raw {
+        input:
+            input_files = flatten(illumina_demux.raw_reads_fastqc_zip),
+            file_name   = "multiqc-raw.html"
+    }
+
+    call reports.MultiQC as multiqc_cleaned {
+        input:
+            input_files = deplete.cleaned_fastqc_zip,
+            file_name   = "multiqc-cleaned.html"
+    }
+
+    call reports.align_and_count_summary as spike_summary {
+        input:
+            counts_txt = spikein.report
+    }
+
+    output {
+        Array[File] raw_reads_unaligned_bams     = flatten(illumina_demux.raw_reads_unaligned_bams)
+        Array[File] cleaned_reads_unaligned_bams = deplete.cleaned_bam
+
+        Array[Int]  read_counts_raw = deplete.depletion_read_count_pre
+        Array[Int]  read_counts_depleted = deplete.depletion_read_count_post
+
+        Array[File] demux_metrics            = illumina_demux.metrics
+        Array[File] demux_commonBarcodes     = illumina_demux.commonBarcodes
+        Array[File] demux_outlierBarcodes    = illumina_demux.outlierBarcodes
+
+        File        multiqc_report_raw     = multiqc_raw.multiqc_report
+        File        multiqc_report_cleaned = multiqc_cleaned.multiqc_report
+        File        spikein_counts         = spike_summary.count_summary
+
+        String      demux_viral_core_version          = illumina_demux.viralngs_version[0]
+    }
+}

--- a/pipes/WDL/workflows/demux_deplete.wdl
+++ b/pipes/WDL/workflows/demux_deplete.wdl
@@ -28,7 +28,7 @@ workflow demux_deplete {
         call demux.illumina_demux as illumina_demux {
             input:
                 flowcell_tgz = flowcell_tgz,
-                lane = lane_sheet.left,
+                lane = lane_sheet.left + 1,
                 samplesheet = lane_sheet.right
         }
     }

--- a/pipes/WDL/workflows/demux_deplete.wdl
+++ b/pipes/WDL/workflows/demux_deplete.wdl
@@ -4,17 +4,18 @@ import "../tasks/tasks_demux.wdl" as demux
 import "../tasks/tasks_read_utils.wdl" as read_utils
 import "../tasks/tasks_taxon_filter.wdl" as taxon_filter
 import "../tasks/tasks_reports.wdl" as reports
+import "../tasks/tasks_ncbi.wdl" as ncbi
 
-workflow demux_plus {
+workflow demux_deplete {
     meta {
-        description: "Picard-based demultiplexing and basecalling from a tarball of a raw BCL directory, followed by QC metrics and depletion. Intended for automatic triggering post upload on DNAnexus."
+        description: "Picard-based demultiplexing and basecalling from a tarball of a raw BCL directory, followed by QC metrics, depletion, and SRA submission prep."
         author: "Broad Viral Genomics"
         email:  "viral-ngs@broadinstitute.org"
     }
 
     input {
         File         flowcell_tgz
-        Array[File]+ samplesheets
+        Array[File]+ samplesheets  ## must be in lane order!
 
         File spikein_db
         Array[File]? bmtaggerDbs  # .tar.gz, .tgz, .tar.bz2, .tar.lz4, .fasta, or .fasta.gz
@@ -22,6 +23,7 @@ workflow demux_plus {
         Array[File]? bwaDbs
     }
 
+    #### demux each lane
     scatter(lane_sheet in zip(range(length(samplesheets)), samplesheets)) {
         call demux.illumina_demux as illumina_demux {
             input:
@@ -29,9 +31,9 @@ workflow demux_plus {
                 lane = lane_sheet.left,
                 samplesheet = lane_sheet.right
         }
-
     }
 
+    #### human depletion & spike-in counting for all files
     scatter(raw_reads in flatten(illumina_demux.raw_reads_unaligned_bams)) {
         call reports.align_and_count as spikein {
             input:
@@ -47,18 +49,24 @@ workflow demux_plus {
         }
     }
 
+    #### SRA submission prep
+    call ncbi.sra_meta_prep {
+        input:
+            cleaned_bam_filepaths = deplete.cleaned_bam,
+            out_name = "sra_metadata-~{basename(flowcell_tgz, '.tar.gz')}.tsv"
+    }
+
+    #### summary stats
     call reports.MultiQC as multiqc_raw {
         input:
             input_files = flatten(illumina_demux.raw_reads_fastqc_zip),
             file_name   = "multiqc-raw.html"
     }
-
     call reports.MultiQC as multiqc_cleaned {
         input:
             input_files = deplete.cleaned_fastqc_zip,
             file_name   = "multiqc-cleaned.html"
     }
-
     call reports.align_and_count_summary as spike_summary {
         input:
             counts_txt = spikein.report
@@ -66,19 +74,21 @@ workflow demux_plus {
 
     output {
         Array[File] raw_reads_unaligned_bams     = flatten(illumina_demux.raw_reads_unaligned_bams)
-        Array[File] cleaned_reads_unaligned_bams = deplete.cleaned_bam
-
         Array[Int]  read_counts_raw = deplete.depletion_read_count_pre
+
+        Array[File] cleaned_reads_unaligned_bams = deplete.cleaned_bam
         Array[Int]  read_counts_depleted = deplete.depletion_read_count_post
 
-        Array[File] demux_metrics            = illumina_demux.metrics
-        Array[File] demux_commonBarcodes     = illumina_demux.commonBarcodes
-        Array[File] demux_outlierBarcodes    = illumina_demux.outlierBarcodes
+        File        sra_metadata          = sra_meta_prep.sra_metadata
+
+        Array[File] demux_metrics         = illumina_demux.metrics
+        Array[File] demux_commonBarcodes  = illumina_demux.commonBarcodes
+        Array[File] demux_outlierBarcodes = illumina_demux.outlierBarcodes
 
         File        multiqc_report_raw     = multiqc_raw.multiqc_report
         File        multiqc_report_cleaned = multiqc_cleaned.multiqc_report
         File        spikein_counts         = spike_summary.count_summary
 
-        String      demux_viral_core_version          = illumina_demux.viralngs_version[0]
+        String      demux_viral_core_version = illumina_demux.viralngs_version[0]
     }
 }

--- a/pipes/WDL/workflows/mafft_and_snp.wdl
+++ b/pipes/WDL/workflows/mafft_and_snp.wdl
@@ -17,23 +17,23 @@ workflow mafft_and_snp {
 
     parameter_meta {
         assembly_fastas: {
-          description: "Set of assembled genomes to align and build trees. These must represent a single chromosome/segment of a genome only. Fastas may be one-sequence-per-individual or a concatenated multi-fasta (unaligned) or a mixture of the two.",
-          patterns: ["*.fasta", "*.fa"]
+          description: "Set of assembled genomes to align and build trees. These must represent a single chromosome/segment of a genome only. Fastas may be one-sequence-per-individual or a concatenated multi-fasta (unaligned) or a mixture of the two. They may be compressed (gz, bz2, zst, lz4), uncompressed, or a mixture.",
+          patterns: ["*.fasta", "*.fa", "*.fasta.gz", "*.fasta.zst"]
         }
         ref_fasta: {
-          description: "A reference assembly (not included in assembly_fastas) to align assembly_fastas against. Typically from NCBI RefSeq or similar.",
+          description: "A reference assembly (not included in assembly_fastas) to align assembly_fastas against. Typically from NCBI RefSeq or similar. Uncompressed.",
           patterns: ["*.fasta", "*.fa"]
         }
     }
 
-    call nextstrain.concatenate {
+    call nextstrain.gzcat {
         input:
             infiles     = assembly_fastas,
-            output_name = "all_samples_combined_assembly.fasta"
+            output_name = "all_samples_combined_assembly.fasta.gz"
     }
     call nextstrain.mafft_one_chr as mafft {
         input:
-            sequences = concatenate.combined,
+            sequences = gzcat.combined,
             ref_fasta = ref_fasta,
             basename  = "all_samples_aligned.fasta"
     }
@@ -49,7 +49,7 @@ workflow mafft_and_snp {
     }
 
     output {
-        File  combined_assemblies = concatenate.combined
+        File  combined_assemblies = gzcat.combined
         File  multiple_alignment  = mafft.aligned_sequences
         File  unmasked_snps       = snp_sites.snps_vcf
         File? ml_tree             = draft_augur_tree.aligned_tree

--- a/pipes/WDL/workflows/sarscov2_genbank.wdl
+++ b/pipes/WDL/workflows/sarscov2_genbank.wdl
@@ -45,19 +45,13 @@ workflow sarscov2_genbank {
 
     scatter(assembly in assemblies_fasta) {
         if(defined(fasta_rename_map)) {
-          #call ncbi.lookup_table_by_filename {
-          #  input:
-          #    id = basename(assembly, ".fasta"),
-          #    mapping_tsv = select_first([fasta_rename_map])
-          #}
-          call ncbi.rename_fasta {
+          call ncbi.rename_fasta_header {
             input:
               genome_fasta = assembly,
               new_name = read_map(select_first([fasta_rename_map]))[basename(assembly, ".fasta")]
-              #new_name = lookup_table_by_filename.value
           }
         }
-        File renamed_assembly = select_first([rename_fasta.renamed_fasta, assembly])
+        File renamed_assembly = select_first([rename_fasta_header.renamed_fasta, assembly])
         call reports.assembly_bases {
           input:
             fasta = renamed_assembly

--- a/pipes/WDL/workflows/sarscov2_genbank.wdl
+++ b/pipes/WDL/workflows/sarscov2_genbank.wdl
@@ -45,13 +45,18 @@ workflow sarscov2_genbank {
 
     scatter(assembly in assemblies_fasta) {
         if(defined(fasta_rename_map)) {
-          call ncbi.rename_fasta_with_map {
+          call ncbi.lookup_table_by_filename {
             input:
-              fasta = assembly,
-              id_map = fasta_rename_map
+              id = basename(assembly),
+              mapping_tsv = select_first([fasta_rename_map])
+          }
+          call ncbi.rename_fasta {
+            input:
+              genome_fasta = assembly,
+              new_name = lookup_table_by_filename.value
           }
         }
-        File renamed_assembly = select_first([rename_fasta_with_map.renamed_fasta, assembly])
+        File renamed_assembly = select_first([rename_fasta.renamed_fasta, assembly])
         call reports.assembly_bases {
           input:
             fasta = renamed_assembly

--- a/pipes/WDL/workflows/sarscov2_genbank.wdl
+++ b/pipes/WDL/workflows/sarscov2_genbank.wdl
@@ -45,15 +45,16 @@ workflow sarscov2_genbank {
 
     scatter(assembly in assemblies_fasta) {
         if(defined(fasta_rename_map)) {
-          call ncbi.lookup_table_by_filename {
-            input:
-              id = basename(assembly, ".fasta"),
-              mapping_tsv = select_first([fasta_rename_map])
-          }
+          #call ncbi.lookup_table_by_filename {
+          #  input:
+          #    id = basename(assembly, ".fasta"),
+          #    mapping_tsv = select_first([fasta_rename_map])
+          #}
           call ncbi.rename_fasta {
             input:
               genome_fasta = assembly,
-              new_name = lookup_table_by_filename.value
+              new_name = read_map(select_first([fasta_rename_map]))[basename(assembly, ".fasta")]
+              #new_name = lookup_table_by_filename.value
           }
         }
         File renamed_assembly = select_first([rename_fasta.renamed_fasta, assembly])

--- a/pipes/WDL/workflows/sarscov2_genbank.wdl
+++ b/pipes/WDL/workflows/sarscov2_genbank.wdl
@@ -2,11 +2,12 @@ version 1.0
 
 import "../tasks/tasks_ncbi.wdl" as ncbi
 import "../tasks/tasks_nextstrain.wdl" as nextstrain
+import "../tasks/tasks_reports.wdl" as reports
 
-workflow genbank {
+workflow sarscov2_genbank {
 
     meta {
-        description: "Prepare assemblies for Genbank submission. This includes annotation by simple coordinate transfer from Genbank annotations and a multiple alignment. See https://viral-pipelines.readthedocs.io/en/latest/ncbi_submission.html for details."
+        description: "Prepare SARS-CoV-2 assemblies for Genbank submission. This includes QC checks with NCBI's VADR tool and filters out genomes that do not pass its tests."
         author: "Broad Viral Genomics"
         email:  "viral-ngs@broadinstitute.org"
     }
@@ -16,22 +17,17 @@ workflow genbank {
 
         File          authors_sbt
         File          biosample_attributes
-        File          structured_comment_table
-        Int           taxid=2697049
+        File          assembly_stats_tsv
+        File?         fasta_rename_map
+
+        Int           taxid = 2697049
+        Int           min_genome_bases = 20000
     }
 
     parameter_meta {
         assemblies_fasta: {
           description: "Genomes to prepare for Genbank submission. One file per genome: all segments/chromosomes included in one file. All fasta files must contain exactly the same number of sequences as reference_fasta (which must equal the number of files in reference_annot_tbl).",
           patterns: ["*.fasta"]
-        }
-        reference_fastas: {
-          description: "Reference genome, each segment/chromosome in a separate fasta file, in the exact same count and order as the segments/chromosomes described in genome_fasta. Headers must be Genbank accessions.",
-          patterns: ["*.fasta"]
-        }
-        reference_feature_tables: {
-          description: "NCBI Genbank feature table, each segment/chromosome in a separate TBL file, in the exact same count and order as the segments/chromosomes described in genome_fasta and reference_fastas. Accession numbers in the TBL files must correspond exactly to those in reference_fasta.",
-          patterns: ["*.tbl"]
         }
         authors_sbt: {
           description: "A genbank submission template file (SBT) with the author list, created at https://submit.ncbi.nlm.nih.gov/genbank/template/submission/",
@@ -41,31 +37,37 @@ workflow genbank {
           description: "A post-submission attributes file from NCBI BioSample, which is available at https://submit.ncbi.nlm.nih.gov/subs/ and clicking on 'Download attributes file with BioSample accessions'.",
           patterns: ["*.txt", "*.tsv"]
         }
-        structured_comment_table: {
-          description: "A six column tab text file with one row per sequence and the following header columns: SeqID, StructuredCommentPrefix, Assembly Method, Coverage        Sequencing Technology, StructuredCommentSuffix",
-          patterns: ["*.txt", "*.tsv"],
-          category: "common"
+        assembly_stats_tsv: {
+          description: "A four column tab text file with one row per sequence and the following header columns: SeqID, Assembly Method, Coverage, Sequencing Technology",
+          patterns: ["*.txt", "*.tsv"]
         }
-        sequencingTech: {
-          description: "The type of sequencer used to generate reads. NCBI has a controlled vocabulary for this value which can be found here: https://submit.ncbi.nlm.nih.gov/structcomment/nongenomes/",
-          category: "common"
-        }
-
     }
 
     scatter(assembly in assemblies_fasta) {
-        call ncbi.vadr {
+        if(defined(fasta_rename_map)) {
+          call ncbi.rename_fasta_with_map {
             input:
-                genome_fasta = assembly
+              fasta = assembly,
+              id_map = fasta_rename_map
+          }
         }
-        if (vadr.num_alerts==0) {
-          File good_assembly = assembly
+        File renamed_assembly = select_first([rename_fasta_with_map.renamed_fasta, assembly])
+        call reports.assembly_bases {
+          input:
+            fasta = renamed_assembly
+        }
+        call ncbi.vadr {
+          input:
+            genome_fasta = renamed_assembly
+        }
+        if ( (vadr.num_alerts==0) && (assembly_bases.assembly_length_unambiguous >= min_genome_bases) ) {
+          File passing_assemblies = renamed_assembly
         }
     }
 
     call nextstrain.concatenate {
       input:
-        infiles = select_all(good_assembly),
+        infiles = select_all(passing_assemblies),
         output_name = "assemblies.fasta"
     }
     call nextstrain.fasta_to_ids {
@@ -81,12 +83,18 @@ workflow genbank {
         filter_to_ids = fasta_to_ids.ids_txt
     }
 
+    call ncbi.structured_comments {
+      input:
+        assembly_stats_tsv = assembly_stats_tsv,
+        filter_to_ids = fasta_to_ids.ids_txt
+    }
+
     call ncbi.package_genbank_ftp_submission {
       input:
         sequences_fasta = concatenate.combined,
         source_modifier_table = biosample_to_genbank.genbank_source_modifier_table,
         author_template_sbt = authors_sbt,
-        structured_comment_table = structured_comment_table
+        structured_comment_table = structured_comments.structured_comment_table
     }
 
     output {
@@ -94,7 +102,7 @@ workflow genbank {
         File submission_xml    = package_genbank_ftp_submission.submission_xml
         File submit_ready   = package_genbank_ftp_submission.submit_ready
 
-        Int  num_successful = length(select_all(good_assembly))
+        Int  num_successful = length(select_all(passing_assemblies))
         Int  num_input = length(assemblies_fasta)
 
         Array[File] vadr_outputs = vadr.outputs_tgz

--- a/pipes/WDL/workflows/sarscov2_genbank.wdl
+++ b/pipes/WDL/workflows/sarscov2_genbank.wdl
@@ -1,0 +1,106 @@
+version 1.0
+
+import "../tasks/tasks_ncbi.wdl" as ncbi
+import "../tasks/tasks_nextstrain.wdl" as nextstrain
+
+workflow genbank {
+
+    meta {
+        description: "Prepare assemblies for Genbank submission. This includes annotation by simple coordinate transfer from Genbank annotations and a multiple alignment. See https://viral-pipelines.readthedocs.io/en/latest/ncbi_submission.html for details."
+        author: "Broad Viral Genomics"
+        email:  "viral-ngs@broadinstitute.org"
+    }
+
+    input {
+        Array[File]+  assemblies_fasta
+
+        File          authors_sbt
+        File          biosample_attributes
+        File          structured_comment_table
+        Int           taxid=2697049
+    }
+
+    parameter_meta {
+        assemblies_fasta: {
+          description: "Genomes to prepare for Genbank submission. One file per genome: all segments/chromosomes included in one file. All fasta files must contain exactly the same number of sequences as reference_fasta (which must equal the number of files in reference_annot_tbl).",
+          patterns: ["*.fasta"]
+        }
+        reference_fastas: {
+          description: "Reference genome, each segment/chromosome in a separate fasta file, in the exact same count and order as the segments/chromosomes described in genome_fasta. Headers must be Genbank accessions.",
+          patterns: ["*.fasta"]
+        }
+        reference_feature_tables: {
+          description: "NCBI Genbank feature table, each segment/chromosome in a separate TBL file, in the exact same count and order as the segments/chromosomes described in genome_fasta and reference_fastas. Accession numbers in the TBL files must correspond exactly to those in reference_fasta.",
+          patterns: ["*.tbl"]
+        }
+        authors_sbt: {
+          description: "A genbank submission template file (SBT) with the author list, created at https://submit.ncbi.nlm.nih.gov/genbank/template/submission/",
+          patterns: ["*.sbt"]
+        }
+        biosample_attributes: {
+          description: "A post-submission attributes file from NCBI BioSample, which is available at https://submit.ncbi.nlm.nih.gov/subs/ and clicking on 'Download attributes file with BioSample accessions'.",
+          patterns: ["*.txt", "*.tsv"]
+        }
+        structured_comment_table: {
+          description: "A six column tab text file with one row per sequence and the following header columns: SeqID, StructuredCommentPrefix, Assembly Method, Coverage        Sequencing Technology, StructuredCommentSuffix",
+          patterns: ["*.txt", "*.tsv"],
+          category: "common"
+        }
+        sequencingTech: {
+          description: "The type of sequencer used to generate reads. NCBI has a controlled vocabulary for this value which can be found here: https://submit.ncbi.nlm.nih.gov/structcomment/nongenomes/",
+          category: "common"
+        }
+
+    }
+
+    scatter(assembly in assemblies_fasta) {
+        call ncbi.vadr {
+            input:
+                genome_fasta = assembly
+        }
+        if (vadr.num_alerts==0) {
+          File good_assembly = assembly
+        }
+    }
+
+    call nextstrain.concatenate {
+      input:
+        infiles = select_all(good_assembly),
+        output_name = "assemblies.fasta"
+    }
+    call nextstrain.fasta_to_ids {
+      input:
+        sequences_fasta = concatenate.combined
+    }
+
+    call ncbi.biosample_to_genbank {
+      input:
+        biosample_attributes = biosample_attributes,
+        num_segments = 1,
+        taxid = taxid,
+        filter_to_ids = fasta_to_ids.ids_txt
+    }
+
+    call ncbi.package_genbank_ftp_submission {
+      input:
+        sequences_fasta = concatenate.combined,
+        source_modifier_table = biosample_to_genbank.genbank_source_modifier_table,
+        author_template_sbt = authors_sbt,
+        structured_comment_table = structured_comment_table
+    }
+
+    output {
+        File submission_zip = package_genbank_ftp_submission.submission_zip
+        File submission_xml    = package_genbank_ftp_submission.submission_xml
+        File submit_ready   = package_genbank_ftp_submission.submit_ready
+
+        Int  num_successful = length(select_all(good_assembly))
+        Int  num_input = length(assemblies_fasta)
+
+        Array[File] vadr_outputs = vadr.outputs_tgz
+
+        File biosample_map = biosample_to_genbank.biosample_map
+        File genbank_source_table = biosample_to_genbank.genbank_source_modifier_table
+    }
+
+}

--- a/pipes/WDL/workflows/sarscov2_genbank.wdl
+++ b/pipes/WDL/workflows/sarscov2_genbank.wdl
@@ -47,7 +47,7 @@ workflow sarscov2_genbank {
         if(defined(fasta_rename_map)) {
           call ncbi.lookup_table_by_filename {
             input:
-              id = basename(assembly),
+              id = basename(assembly, ".fasta"),
               mapping_tsv = select_first([fasta_rename_map])
           }
           call ncbi.rename_fasta {

--- a/pipes/WDL/workflows/sarscov2_genbank.wdl
+++ b/pipes/WDL/workflows/sarscov2_genbank.wdl
@@ -45,10 +45,11 @@ workflow sarscov2_genbank {
 
     scatter(assembly in assemblies_fasta) {
         if(defined(fasta_rename_map)) {
+          String fasta_basename = basename(assembly, ".fasta")
           call ncbi.rename_fasta_header {
             input:
               genome_fasta = assembly,
-              new_name = read_map(select_first([fasta_rename_map]))[basename(assembly, ".fasta")]
+              new_name = read_map(select_first([fasta_rename_map]))[fasta_basename]
           }
         }
         File renamed_assembly = select_first([rename_fasta_header.renamed_fasta, assembly])

--- a/pipes/WDL/workflows/sarscov2_illumina_full.wdl
+++ b/pipes/WDL/workflows/sarscov2_illumina_full.wdl
@@ -1,0 +1,164 @@
+version 1.0
+
+import "../tasks/tasks_metagenomics.wdl" as metagenomics
+import "../tasks/tasks_read_utils.wdl" as read_utils
+import "../tasks/tasks_taxon_filter.wdl" as taxon_filter
+import "../tasks/tasks_assembly.wdl" as assembly
+import "../tasks/tasks_reports.wdl" as reports
+import "../tasks/tasks_ncbi.wdl" as ncbi
+import "../tasks/tasks_sarscov2.wdl" as sarscov2
+
+import "assemble_refbased.wdl"
+import "sarscov2_lineages.wdl"
+import "sarscov2_genbank.wdl"
+import "../tasks/tasks_demux.wdl" as demux
+
+workflow sarscov2_illumina_full {
+    meta {
+        description: "Full SARS-CoV-2 analysis workflow starting from raw Illumina flowcell (tar.gz) and metadata and performing assembly, spike-in analysis, qc, lineage assignment, and packaging for data release."
+        author: "Broad Viral Genomics"
+        email:  "viral-ngs@broadinstitute.org"
+    }
+
+    parameter_meta {
+        reference_fasta: {
+            description: "Reference genome to align reads to.",
+            patterns: ["*.fasta"]
+        }
+        ampseq_trim_coords_bed: {
+            description: "amplicon primers to trim in reference coordinate space (0-based BED format)",
+            patterns: ["*.bed"]
+        }
+
+        authors_sbt: {
+          description: "A genbank submission template file (SBT) with the author list, created at https://submit.ncbi.nlm.nih.gov/genbank/template/submission/",
+          patterns: ["*.sbt"]
+        }
+        biosample_attributes: {
+          description: "A post-submission attributes file from NCBI BioSample, which is available at https://submit.ncbi.nlm.nih.gov/subs/ and clicking on 'Download attributes file with BioSample accessions'.",
+          patterns: ["*.txt", "*.tsv"]
+        }
+
+    }
+
+    input {
+        File         flowcell_tgz
+        Array[File]+ samplesheets  ## must be in lane order!
+
+        File          reference_fasta
+        File          ampseq_trim_coords_bed
+
+        File          authors_sbt
+        File          biosample_attributes
+        File?         fasta_rename_map
+
+        Int           taxid = 2697049
+        Int           min_genome_bases = 20000
+
+        File          spikein_db
+        File          trim_clip_db
+        Array[File]?  bmtaggerDbs  # .tar.gz, .tgz, .tar.bz2, .tar.lz4, .fasta, or .fasta.gz
+        Array[File]?  blastDbs  # .tar.gz, .tgz, .tar.bz2, .tar.lz4, .fasta, or .fasta.gz
+        Array[File]?  bwaDbs
+    }
+
+    #### demux each lane
+    scatter(lane_sheet in zip(range(length(samplesheets)), samplesheets)) {
+        call demux.illumina_demux as illumina_demux {
+            input:
+                flowcell_tgz = flowcell_tgz,
+                lane = lane_sheet.left + 1,
+                samplesheet = lane_sheet.right
+        }
+    }
+
+    #### human depletion & spike-in counting for all files
+    scatter(raw_reads in flatten(illumina_demux.raw_reads_unaligned_bams)) {
+        call reports.align_and_count as spikein {
+            input:
+                reads_bam = raw_reads,
+                ref_db = spikein_db
+        }
+        call taxon_filter.deplete_taxa as deplete {
+            input:
+                raw_reads_unmapped_bam = raw_reads,
+                bmtaggerDbs = bmtaggerDbs,
+                blastDbs = blastDbs,
+                bwaDbs = bwaDbs
+        }
+    }
+
+    #### SRA submission prep
+    call ncbi.sra_meta_prep {
+        input:
+            cleaned_bam_filepaths = deplete.cleaned_bam,
+            out_name = "sra_metadata-~{basename(flowcell_tgz, '.tar.gz')}.tsv"
+    }
+
+    #### summary stats
+    call reports.MultiQC as multiqc_raw {
+        input:
+            input_files = flatten(illumina_demux.raw_reads_fastqc_zip),
+            file_name   = "multiqc-raw.html"
+    }
+    call reports.MultiQC as multiqc_cleaned {
+        input:
+            input_files = deplete.cleaned_fastqc_zip,
+            file_name   = "multiqc-cleaned.html"
+    }
+    call reports.align_and_count_summary as spike_summary {
+        input:
+            counts_txt = spikein.report
+    }
+
+    ### assembly and analyses per biosample
+    call read_utils.group_bams_by_sample {
+        input:
+            bam_filepaths = deplete.cleaned_bam
+    }
+    scatter(name_reads in zip(group_bams_by_sample.sample_names, group_bams_by_sample.grouped_bam_filepaths)) {
+        call assemble_refbased.assemble_refbased {
+            input:
+                reads_unmapped_bams = [name_reads.right],
+                reference_fasta = reference_fasta,
+                sample_name = name_reads.left
+                # lookup skip_mark_dupes and trim_coords_bed from metadata
+        }
+
+        if ( assemble_refbased.assembly_length_unambiguous >= min_genome_bases) {
+            File passing_assemblies = assemble_refbased.assembly_fasta
+            call sarscov2_lineages.sarscov2_lineages {
+                input:
+                    genome_fasta = assemble_refbased.assembly_fasta
+            }
+        }
+    }
+
+    ### prep genbank submission
+    call sarscov2_genbank.sarscov2_genbank {
+        input:
+            assemblies_fasta = assemble_refbased.assembly_fasta,
+            taxid = taxid,
+            min_genome_bases = min_genome_bases
+    }
+
+    output {
+        Array[File] raw_reads_unaligned_bams     = illumina_demux.raw_reads_unaligned_bams
+        Array[File] cleaned_reads_unaligned_bams = deplete.cleaned_bam
+
+        Array[Int]  read_counts_raw = deplete.depletion_read_count_pre
+        Array[Int]  read_counts_depleted = deplete.depletion_read_count_post
+
+        File        sra_metadata          = sra_meta_prep.sra_metadata
+
+        Array[File] assemblies_fasta = assemble_refbased.assembly_fasta
+
+        File        demux_metrics            = illumina_demux.metrics
+        File        demux_commonBarcodes     = illumina_demux.commonBarcodes
+        File        demux_outlierBarcodes    = illumina_demux.outlierBarcodes
+
+        File        multiqc_report_raw     = multiqc_raw.multiqc_report
+        File        multiqc_report_cleaned = multiqc_cleaned.multiqc_report
+        File        spikein_counts         = spike_summary.count_summary
+    }
+}

--- a/pipes/WDL/workflows/sarscov2_lineages.wdl
+++ b/pipes/WDL/workflows/sarscov2_lineages.wdl
@@ -8,25 +8,25 @@ workflow sarscov2_lineages {
     }
 
     input {
-    	File genome_fasta
+        File genome_fasta
     }
 
     call sarscov2.nextclade_one_sample {
-    	input:
-    		genome_fasta = genome_fasta
+        input:
+            genome_fasta = genome_fasta
     }
 
     call sarscov2.pangolin_one_sample {
-    	input:
-    		genome_fasta = genome_fasta
+        input:
+            genome_fasta = genome_fasta
     }
 
     output {
-    	String nextclade_clade = nextclade_one_sample.nextclade_clade
-    	File   nextclade_tsv   = nextclade_one_sample.nextclade_tsv
-    	String nextclade_aa_subs = nextclade_one_sample.aa_subs_csv
-    	String nextclade_aa_dels = nextclade_one_sample.aa_dels_csv
-    	String pangolin_clade  = pangolin_one_sample.pangolin_clade
-    	File   pangolin_csv    = pangolin_one_sample.pangolin_csv
+        String nextclade_clade = nextclade_one_sample.nextclade_clade
+        File   nextclade_tsv   = nextclade_one_sample.nextclade_tsv
+        String nextclade_aa_subs = nextclade_one_sample.aa_subs_csv
+        String nextclade_aa_dels = nextclade_one_sample.aa_dels_csv
+        String pangolin_clade  = pangolin_one_sample.pangolin_clade
+        File   pangolin_csv    = pangolin_one_sample.pangolin_csv
     }
 }

--- a/pipes/WDL/workflows/subsample_by_metadata_with_focal.wdl
+++ b/pipes/WDL/workflows/subsample_by_metadata_with_focal.wdl
@@ -9,7 +9,7 @@ workflow subsample_by_metadata_with_focal {
     }
 
     parameter_meta {
-        sample_metadata_tsv: {
+        sample_metadata_tsvs: {
             description: "Tab-separated metadata file that contain binning variables and values. Must contain all samples: output will be filtered to the IDs present in this file.",
             patterns: ["*.txt", "*.tsv"]
         }

--- a/requirements-modules.txt
+++ b/requirements-modules.txt
@@ -6,5 +6,5 @@ broadinstitute/beast-beagle-cuda=1.10.5pre
 broadinstitute/ncbi-tools=2.10.7.1
 nextstrain/base=build-20201214T004216Z
 andersenlabapps/ivar=1.2.2
-staphb/pangolin=2.1.1
-neherlab/nextclade=0.10.0
+staphb/pangolin=2.1.6
+neherlab/nextclade=0.11.1

--- a/requirements-modules.txt
+++ b/requirements-modules.txt
@@ -1,7 +1,7 @@
 broadinstitute/viral-core=2.1.13
 broadinstitute/viral-assemble=2.1.12.1
 broadinstitute/viral-classify=2.1.12.1
-broadinstitute/viral-phylo=2.1.13.1
+broadinstitute/viral-phylo=2.1.13.2
 broadinstitute/beast-beagle-cuda=1.10.5pre
 broadinstitute/ncbi-tools=2.10.7.1
 nextstrain/base=build-20201214T004216Z

--- a/requirements-modules.txt
+++ b/requirements-modules.txt
@@ -1,7 +1,7 @@
 broadinstitute/viral-core=2.1.13
 broadinstitute/viral-assemble=2.1.12.1
 broadinstitute/viral-classify=2.1.12.1
-broadinstitute/viral-phylo=2.1.12.0
+broadinstitute/viral-phylo=2.1.13.0
 broadinstitute/beast-beagle-cuda=1.10.5pre
 broadinstitute/ncbi-tools=2.10.7.1
 nextstrain/base=build-20201214T004216Z

--- a/requirements-modules.txt
+++ b/requirements-modules.txt
@@ -1,4 +1,4 @@
-broadinstitute/viral-core=2.1.13
+broadinstitute/viral-core=2.1.14
 broadinstitute/viral-assemble=2.1.12.1
 broadinstitute/viral-classify=2.1.12.1
 broadinstitute/viral-phylo=2.1.13.2

--- a/requirements-modules.txt
+++ b/requirements-modules.txt
@@ -1,7 +1,7 @@
 broadinstitute/viral-core=2.1.13
 broadinstitute/viral-assemble=2.1.12.1
 broadinstitute/viral-classify=2.1.12.1
-broadinstitute/viral-phylo=2.1.13.0
+broadinstitute/viral-phylo=2.1.13.1
 broadinstitute/beast-beagle-cuda=1.10.5pre
 broadinstitute/ncbi-tools=2.10.7.1
 nextstrain/base=build-20201214T004216Z

--- a/test/input/WDL/test_inputs-augur_from_assemblies-local.json
+++ b/test/input/WDL/test_inputs-augur_from_assemblies-local.json
@@ -1,11 +1,11 @@
 {
-  "augur_from_assemblies.augur_from_msa.genbank_gb": "test/input/zika-tutorial/config/zika_outgroup.gb",
+  "augur_from_assemblies.translate_augur_tree.genbank_gb": "test/input/zika-tutorial/config/zika_outgroup.gb",
   "augur_from_assemblies.ref_fasta": "test/input/zika-tutorial/data/KX369547.1.fna",
   "augur_from_assemblies.export_auspice_json.colors_tsv": "test/input/zika-tutorial/config/colors.tsv",
-  "augur_from_assemblies.augur_from_msa.auspice_config": "test/input/zika-tutorial/config/auspice_config.json",
-  "augur_from_assemblies.augur_from_msa.ancestral_traits_to_infer": ["region", "country"],
+  "augur_from_assemblies.export_auspice_json.auspice_config": "test/input/zika-tutorial/config/auspice_config.json",
+  "augur_from_assemblies.ancestral_traits_to_infer": ["region", "country"],
   "augur_from_assemblies.export_auspice_json.lat_longs_tsv": "test/input/zika-tutorial/config/lat_longs.tsv",
   "augur_from_assemblies.mafft_and_snp.assembly_fastas": ["test/input/zika-tutorial/data/sequences.fasta"],
-  "augur_from_assemblies.subsample_by_metadata_with_focal.sample_metadata": "test/input/zika-tutorial/data/metadata.tsv"
+  "augur_from_assemblies.sample_metadata_tsvs": ["test/input/zika-tutorial/data/metadata.tsv"]
 }
 

--- a/test/input/WDL/test_inputs-augur_from_assemblies-local.json
+++ b/test/input/WDL/test_inputs-augur_from_assemblies-local.json
@@ -1,5 +1,6 @@
 {
   "augur_from_assemblies.translate_augur_tree.genbank_gb": "test/input/zika-tutorial/config/zika_outgroup.gb",
+  "augur_from_assemblies.min_unambig_genome": 9000,
   "augur_from_assemblies.ref_fasta": "test/input/zika-tutorial/data/KX369547.1.fna",
   "augur_from_assemblies.export_auspice_json.colors_tsv": "test/input/zika-tutorial/config/colors.tsv",
   "augur_from_assemblies.export_auspice_json.auspice_config": "test/input/zika-tutorial/config/auspice_config.json",

--- a/test/input/WDL/test_inputs-augur_from_assemblies-local.json
+++ b/test/input/WDL/test_inputs-augur_from_assemblies-local.json
@@ -1,12 +1,11 @@
 {
-  "augur_from_assemblies.genbank_gb": "test/input/zika-tutorial/config/zika_outgroup.gb",
+  "augur_from_assemblies.augur_from_msa.genbank_gb": "test/input/zika-tutorial/config/zika_outgroup.gb",
   "augur_from_assemblies.ref_fasta": "test/input/zika-tutorial/data/KX369547.1.fna",
-  "augur_from_assemblies.export_auspice_json.colors_tsv": "test/input/zika-tutorial/config/colors.tsv",
-  "augur_from_assemblies.virus": "testrun",
-  "augur_from_assemblies.auspice_config": "test/input/zika-tutorial/config/auspice_config.json",
-  "augur_from_assemblies.ancestral_traits_to_infer": ["region", "country"],
-  "augur_from_assemblies.export_auspice_json.lat_longs_tsv": "test/input/zika-tutorial/config/lat_longs.tsv",
-  "augur_from_assemblies.assembly_fastas": ["test/input/zika-tutorial/data/sequences.fasta"],
-  "augur_from_assemblies.sample_metadata": "test/input/zika-tutorial/data/metadata.tsv"
+  "augur_from_assemblies.augur_from_msa.export_auspice_json.colors_tsv": "test/input/zika-tutorial/config/colors.tsv",
+  "augur_from_assemblies.augur_from_msa.auspice_config": "test/input/zika-tutorial/config/auspice_config.json",
+  "augur_from_assemblies.augur_from_msa.ancestral_traits_to_infer": ["region", "country"],
+  "augur_from_assemblies.augur_from_msa.export_auspice_json.lat_longs_tsv": "test/input/zika-tutorial/config/lat_longs.tsv",
+  "augur_from_assemblies.mafft_and_snp.assembly_fastas": ["test/input/zika-tutorial/data/sequences.fasta"],
+  "augur_from_assemblies.subsample_by_metadata_with_focal.sample_metadata": "test/input/zika-tutorial/data/metadata.tsv"
 }
 

--- a/test/input/WDL/test_inputs-augur_from_assemblies-local.json
+++ b/test/input/WDL/test_inputs-augur_from_assemblies-local.json
@@ -5,7 +5,7 @@
   "augur_from_assemblies.export_auspice_json.auspice_config": "test/input/zika-tutorial/config/auspice_config.json",
   "augur_from_assemblies.ancestral_traits_to_infer": ["region", "country"],
   "augur_from_assemblies.export_auspice_json.lat_longs_tsv": "test/input/zika-tutorial/config/lat_longs.tsv",
-  "augur_from_assemblies.mafft_and_snp.assembly_fastas": ["test/input/zika-tutorial/data/sequences.fasta"],
+  "augur_from_assemblies.assembly_fastas": ["test/input/zika-tutorial/data/sequences.fasta"],
   "augur_from_assemblies.sample_metadata_tsvs": ["test/input/zika-tutorial/data/metadata.tsv"]
 }
 

--- a/test/input/WDL/test_inputs-augur_from_assemblies-local.json
+++ b/test/input/WDL/test_inputs-augur_from_assemblies-local.json
@@ -1,10 +1,10 @@
 {
   "augur_from_assemblies.augur_from_msa.genbank_gb": "test/input/zika-tutorial/config/zika_outgroup.gb",
   "augur_from_assemblies.ref_fasta": "test/input/zika-tutorial/data/KX369547.1.fna",
-  "augur_from_assemblies.augur_from_msa.export_auspice_json.colors_tsv": "test/input/zika-tutorial/config/colors.tsv",
+  "augur_from_assemblies.export_auspice_json.colors_tsv": "test/input/zika-tutorial/config/colors.tsv",
   "augur_from_assemblies.augur_from_msa.auspice_config": "test/input/zika-tutorial/config/auspice_config.json",
   "augur_from_assemblies.augur_from_msa.ancestral_traits_to_infer": ["region", "country"],
-  "augur_from_assemblies.augur_from_msa.export_auspice_json.lat_longs_tsv": "test/input/zika-tutorial/config/lat_longs.tsv",
+  "augur_from_assemblies.export_auspice_json.lat_longs_tsv": "test/input/zika-tutorial/config/lat_longs.tsv",
   "augur_from_assemblies.mafft_and_snp.assembly_fastas": ["test/input/zika-tutorial/data/sequences.fasta"],
   "augur_from_assemblies.subsample_by_metadata_with_focal.sample_metadata": "test/input/zika-tutorial/data/metadata.tsv"
 }


### PR DESCRIPTION
- adds sarscov2_genbank workflow, which preps assemblies for submission to genbank using their new process for SARS-CoV-2 (use the previous workflows for other taxa--though my guess is that genbank will roll these changes out across taxa eventually)
- adds the VADR (Viral Annotation DefineR) tool, written by genbank, to produce tbl files on assemblies and pre-screen submissions to those that are expected to pass QC on NCBI's end
- adds sra_meta_prep task and the new demux_deplete workflow, which runs demux on all lanes of a flowcell, runs human read depletion, and packages cleaned reads for SRA submission (requires a more verbose custom samplesheet than the default Illumina sheets and requires pre-registered NCBI BioSamples, but this should be used for all high throughput sequencing projects)

- some preliminary work on an end-to-end SARS-CoV-2 pipeline (sarscov2_illumina_full), but it is not quite ready yet

- bump pangolin and nextclade docker images
- incorporate metadata tsv merging to augur_from_msa
- replace augur_from_assemblies to incorporate tsv merging, derivedcols, subsample_by_metadata_with_focal and augur_from_msa, turning it into an end-to-end pipeline from global database download, merged in with custom data, to new nextstrain builds (takes a while though)