### PR TITLE
improvements to sarscov2_illumina_full

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -230,6 +230,11 @@ workflows:
    primaryDescriptorPath: /pipes/WDL/workflows/sarscov2_genbank.wdl
    testParameterFiles:
     - empty.json
+ - name: sarscov2_illumina_full
+   subclass: WDL
+   primaryDescriptorPath: /pipes/WDL/workflows/sarscov2_illumina_full.wdl
+   testParameterFiles:
+    - empty.json
  - name: sarscov2_lineages
    subclass: WDL
    primaryDescriptorPath: /pipes/WDL/workflows/sarscov2_lineages.wdl

--- a/pipes/WDL/tasks/tasks_assembly.wdl
+++ b/pipes/WDL/tasks/tasks_assembly.wdl
@@ -226,7 +226,7 @@ task align_reads {
     Boolean? skip_mark_dupes=false
 
     Int?     machine_mem_gb
-    String   docker="quay.io/broadinstitute/viral-core:2.1.16"
+    String   docker="quay.io/broadinstitute/viral-core:2.1.17"
 
     String   sample_name = basename(basename(basename(reads_unmapped_bam, ".bam"), ".taxfilt"), ".clean")
   }
@@ -643,7 +643,7 @@ task run_discordance {
       String   out_basename = "run"
       Int      min_coverage=4
 
-      String   docker="quay.io/broadinstitute/viral-core:2.1.16"
+      String   docker="quay.io/broadinstitute/viral-core:2.1.17"
     }
 
     command {

--- a/pipes/WDL/tasks/tasks_assembly.wdl
+++ b/pipes/WDL/tasks/tasks_assembly.wdl
@@ -15,7 +15,7 @@ task assemble {
       String   sample_name = basename(basename(reads_unmapped_bam, ".bam"), ".taxfilt")
 
       Int?     machine_mem_gb
-      String   docker="quay.io/broadinstitute/viral-assemble:2.1.16.0"
+      String   docker="quay.io/broadinstitute/viral-assemble:2.1.16.1"
     }
 
     command {
@@ -80,7 +80,7 @@ task scaffold {
       Float?       scaffold_min_pct_contig_aligned
 
       Int?         machine_mem_gb
-      String       docker="quay.io/broadinstitute/viral-assemble:2.1.16.0"
+      String       docker="quay.io/broadinstitute/viral-assemble:2.1.16.1"
 
       # do this in multiple steps in case the input doesn't actually have "assembly1-x" in the name
       String       sample_name = basename(basename(contigs_fasta, ".fasta"), ".assembly1-spades")
@@ -342,7 +342,7 @@ task refine_assembly_with_aligned_reads {
       Int?     min_coverage=3
 
       Int?     machine_mem_gb
-      String   docker="quay.io/broadinstitute/viral-assemble:2.1.16.0"
+      String   docker="quay.io/broadinstitute/viral-assemble:2.1.16.1"
     }
 
     parameter_meta {
@@ -434,7 +434,7 @@ task refine {
       Int?    min_coverage=1
 
       Int?    machine_mem_gb
-      String  docker="quay.io/broadinstitute/viral-assemble:2.1.16.0"
+      String  docker="quay.io/broadinstitute/viral-assemble:2.1.16.1"
 
       String  assembly_basename=basename(basename(assembly_fasta, ".fasta"), ".scaffold")
     }
@@ -504,7 +504,7 @@ task refine_2x_and_plot {
       String? plot_coverage_novoalign_options="-r Random -l 40 -g 40 -x 20 -t 100 -k"
 
       Int?    machine_mem_gb
-      String  docker="quay.io/broadinstitute/viral-assemble:2.1.16.0"
+      String  docker="quay.io/broadinstitute/viral-assemble:2.1.16.1"
 
       # do this in two steps in case the input doesn't actually have "cleaned" in the name
       String  sample_name = basename(basename(reads_unmapped_bam, ".bam"), ".cleaned")

--- a/pipes/WDL/tasks/tasks_assembly.wdl
+++ b/pipes/WDL/tasks/tasks_assembly.wdl
@@ -226,7 +226,7 @@ task align_reads {
     Boolean? skip_mark_dupes=false
 
     Int?     machine_mem_gb
-    String   docker="quay.io/broadinstitute/viral-core:2.1.17"
+    String   docker="quay.io/broadinstitute/viral-core:2.1.18"
 
     String   sample_name = basename(basename(basename(reads_unmapped_bam, ".bam"), ".taxfilt"), ".clean")
   }
@@ -643,7 +643,7 @@ task run_discordance {
       String   out_basename = "run"
       Int      min_coverage=4
 
-      String   docker="quay.io/broadinstitute/viral-core:2.1.17"
+      String   docker="quay.io/broadinstitute/viral-core:2.1.18"
     }
 
     command {

--- a/pipes/WDL/tasks/tasks_assembly.wdl
+++ b/pipes/WDL/tasks/tasks_assembly.wdl
@@ -389,9 +389,16 @@ task refine_assembly_with_aligned_reads {
           refined.fasta "${sample_name}.fasta" "${sample_name}"
 
         # collect variant counts
-        bcftools filter -e "FMT/DP<${min_coverage}" -S . "${sample_name}.sites.vcf.gz" -Ou | bcftools filter -i "AC>1" -Ou > "${sample_name}.diffs.vcf"
-        bcftools filter -i 'TYPE="snp"'  "${sample_name}.diffs.vcf" | bcftools query -f '%POS\n' | wc -l | tee num_snps
-        bcftools filter -i 'TYPE!="snp"' "${sample_name}.diffs.vcf" | bcftools query -f '%POS\n' | wc -l | tee num_indels
+        if (( $(cat refined.fasta | wc -l) > 1 )); then
+          bcftools filter -e "FMT/DP<${min_coverage}" -S . "${sample_name}.sites.vcf.gz" -Ou | bcftools filter -i "AC>1" -Ou > "${sample_name}.diffs.vcf"
+          bcftools filter -i 'TYPE="snp"'  "${sample_name}.diffs.vcf" | bcftools query -f '%POS\n' | wc -l | tee num_snps
+          bcftools filter -i 'TYPE!="snp"' "${sample_name}.diffs.vcf" | bcftools query -f '%POS\n' | wc -l | tee num_indels
+        else
+          # empty output
+          echo "0" > num_snps
+          echo "0" > num_indels
+          cp "${sample_name}.sites.vcf.gz" "${sample_name}.diffs.vcf"
+        fi
 
         # collect figures of merit
         set +o pipefail # grep will exit 1 if it fails to find the pattern

--- a/pipes/WDL/tasks/tasks_demux.wdl
+++ b/pipes/WDL/tasks/tasks_demux.wdl
@@ -330,16 +330,16 @@ task illumina_demux {
 
 task merge_maps {
   input {
-    Array[Map[String,Map[String,String]]] maps
+    Array[File] maps_jsons
   }
   command <<<
     python3 << CODE
     import json
-    with open('~{write_json(maps)}', 'rt') as inf:
-      inarrays = json.load(inf)
+    infiles = '~{sep='*' maps_jsons}'.split('*')
     out = {}
-    for j in inarrays:
-      out.update(j)
+    for fname in infiles:
+      with open(fname, 'rt') as inf:
+        out.update(json.load(inf))
     with open('out.json', 'wt') as outf:
       json.dump(out, outf, indent=2)
     CODE

--- a/pipes/WDL/tasks/tasks_demux.wdl
+++ b/pipes/WDL/tasks/tasks_demux.wdl
@@ -6,7 +6,7 @@ task merge_tarballs {
     String        out_filename
 
     Int?          machine_mem_gb
-    String        docker="quay.io/broadinstitute/viral-core:2.1.17"
+    String        docker="quay.io/broadinstitute/viral-core:2.1.18"
   }
 
   command {
@@ -101,7 +101,7 @@ task illumina_demux {
     Boolean? forceGC=true
 
     Int?    machine_mem_gb
-    String  docker="quay.io/broadinstitute/viral-core:2.1.17"
+    String  docker="quay.io/broadinstitute/viral-core:2.1.18"
   }
   parameter_meta {
       flowcell_tgz: {
@@ -312,6 +312,9 @@ task illumina_demux {
     Map[String,Map[String,String]] meta_by_sample   = read_json('meta_by_sample.json')
     Map[String,Map[String,String]] meta_by_filename = read_json('meta_by_fname.json')
     Map[String,String]             run_info         = read_json('runinfo.json')
+    File meta_by_sample_json   = 'meta_by_sample.json'
+    File meta_by_filename_json = 'meta_by_fname.json'
+    File run_info_json         = 'runinfo.json'
   }
 
   runtime {

--- a/pipes/WDL/tasks/tasks_demux.wdl
+++ b/pipes/WDL/tasks/tasks_demux.wdl
@@ -328,6 +328,36 @@ task illumina_demux {
   }
 }
 
+task map_map_setdefault {
+  input {
+    File          map_map_json
+    Array[String] sub_keys
+  }
+  command <<<
+    python3 << CODE
+    import json
+    sub_keys = '~{sep="*" sub_keys}'.split('*')
+    with open('~{map_map_json}', 'rt') as inf:
+      out = json.load(inf)
+    for k in out.keys():
+      for sub_key in sub_keys:
+        out[k].setdefault(sub_key, "")
+    with open('out.json', 'wt') as outf:
+      json.dump(out, outf, indent=2)
+    CODE
+  >>>
+  output {
+    File out_json = 'out.json'
+  }
+  runtime {
+    docker: "python:slim"
+    memory: "1 GB"
+    cpu: 1
+    disks: "local-disk 20 HDD"
+    dx_instance_type: "mem1_ssd1_v2_x2"
+  }
+}
+
 task merge_maps {
   input {
     Array[File] maps_jsons

--- a/pipes/WDL/tasks/tasks_demux.wdl
+++ b/pipes/WDL/tasks/tasks_demux.wdl
@@ -74,7 +74,7 @@ task samplesheet_rename_ids {
     docker: "python"
     memory: "1 GB"
     cpu: 1
-    disks: "local-disk 20 GB"
+    disks: "local-disk 50 HDD"
     dx_instance_type: "mem1_ssd1_v2_x2"
   }
 }

--- a/pipes/WDL/tasks/tasks_demux.wdl
+++ b/pipes/WDL/tasks/tasks_demux.wdl
@@ -71,7 +71,7 @@ task samplesheet_rename_ids {
     File new_sheet = '~{new_base}.renamed.txt'
   }
   runtime {
-    docker: "python"
+    docker: "python:slim"
     memory: "1 GB"
     cpu: 1
     disks: "local-disk 50 HDD"
@@ -345,7 +345,7 @@ task merge_maps {
     Map[String,Map[String,String]] merged = read_json('out.json')
   }
   runtime {
-    docker: "python"
+    docker: "python:slim"
     memory: "1 GB"
     cpu: 1
     disks: "local-disk 20 HDD"

--- a/pipes/WDL/tasks/tasks_demux.wdl
+++ b/pipes/WDL/tasks/tasks_demux.wdl
@@ -310,7 +310,7 @@ task illumina_demux {
     String      viralngs_version         = read_string("VERSION")
 
     Map[String,Map[String,String]] meta_by_sample   = read_json('meta_by_sample.json')
-    Map[String,Map[String,String]] meta_by_filename = read_json('meta_by_filename.json')
+    Map[String,Map[String,String]] meta_by_filename = read_json('meta_by_fname.json')
     Map[String,String]             run_info         = read_json('runinfo.json')
   }
 

--- a/pipes/WDL/tasks/tasks_demux.wdl
+++ b/pipes/WDL/tasks/tasks_demux.wdl
@@ -344,4 +344,11 @@ task merge_maps {
   output {
     Map[String,Map[String,String]] merged = read_json('out.json')
   }
+  runtime {
+    docker: "python"
+    memory: "1 GB"
+    cpu: 1
+    disks: "local-disk 20 HDD"
+    dx_instance_type: "mem1_ssd1_v2_x2"
+  }
 }

--- a/pipes/WDL/tasks/tasks_demux.wdl
+++ b/pipes/WDL/tasks/tasks_demux.wdl
@@ -41,7 +41,7 @@ task merge_tarballs {
 task samplesheet_rename_ids {
   input {
     File   old_sheet
-    File   rename_map
+    File?  rename_map
     String old_id_col = 'internal_id'
     String new_id_col = 'external_id'
   }
@@ -52,7 +52,7 @@ task samplesheet_rename_ids {
 
     # read in the rename_map file
     old_to_new = {}
-    with open('~{rename_map}', 'rt') as inf:
+    with open('~{default="/dev/null" rename_map}', 'rt') as inf:
       for row in csv.DictReader(inf, delimiter='\t'):
         old_to_new[row['~{old_id_col}']] = row['~{new_id_col}']
 
@@ -102,6 +102,12 @@ task illumina_demux {
 
     Int?    machine_mem_gb
     String  docker="quay.io/broadinstitute/viral-core:2.1.16"
+  }
+  parameter_meta {
+      flowcell_tgz: {
+          description: "Illumina BCL directory compressed as tarball. Must contain RunInfo.xml (unless overridden by runinfo), SampleSheet.csv (unless overridden by samplesheet), RTAComplete.txt, and Data/Intensities/BaseCalls/*",
+          patterns: ["*.tar.gz", ".tar.zst", ".tar.bz2", ".tar.lz4", ".tgz"]
+      }
   }
 
   command {

--- a/pipes/WDL/tasks/tasks_demux.wdl
+++ b/pipes/WDL/tasks/tasks_demux.wdl
@@ -332,11 +332,10 @@ task merge_maps {
   command <<<
     python3 << CODE
     import json
-    injsons = '~{sep="*" maps}'.split('*')
+    inarrays = [ ~{sep="," maps} ]
     out = {}
-    for j in injsons:
-      with open(j, 'rt') as inf:
-        out.update(json.load(inf))
+    for j in inarrays:
+      out.update(j)
     with open('out.json', 'wt') as outf:
       json.dump(out, outf, indent=2)
     CODE

--- a/pipes/WDL/tasks/tasks_demux.wdl
+++ b/pipes/WDL/tasks/tasks_demux.wdl
@@ -332,7 +332,8 @@ task merge_maps {
   command <<<
     python3 << CODE
     import json
-    inarrays = [ ~{sep="," maps} ]
+    with open('~{write_json(maps)}', 'rt') as inf:
+      inarrays = json.load(inf)
     out = {}
     for j in inarrays:
       out.update(j)

--- a/pipes/WDL/tasks/tasks_interhost.wdl
+++ b/pipes/WDL/tasks/tasks_interhost.wdl
@@ -142,7 +142,7 @@ task index_ref {
     File?    novocraft_license
 
     Int?     machine_mem_gb
-    String   docker="quay.io/broadinstitute/viral-core:2.1.16"
+    String   docker="quay.io/broadinstitute/viral-core:2.1.17"
   }
 
   command {

--- a/pipes/WDL/tasks/tasks_interhost.wdl
+++ b/pipes/WDL/tasks/tasks_interhost.wdl
@@ -142,7 +142,7 @@ task index_ref {
     File?    novocraft_license
 
     Int?     machine_mem_gb
-    String   docker="quay.io/broadinstitute/viral-core:2.1.17"
+    String   docker="quay.io/broadinstitute/viral-core:2.1.18"
   }
 
   command {

--- a/pipes/WDL/tasks/tasks_ncbi.wdl
+++ b/pipes/WDL/tasks/tasks_ncbi.wdl
@@ -269,7 +269,7 @@ task prefix_fasta_header {
     File renamed_fasta = "~{out_basename}.fasta"
   }
   runtime {
-    docker: "python"
+    docker: "python:slim"
     memory: "1 GB"
     cpu: 1
     dx_instance_type: "mem1_ssd1_v2_x2"
@@ -365,7 +365,7 @@ task gisaid_meta_prep {
     File meta_tsv = "~{out_name}"
   }
   runtime {
-    docker: "python"
+    docker: "python:slim"
     memory: "1 GB"
     cpu: 1
     dx_instance_type: "mem1_ssd1_v2_x2"

--- a/pipes/WDL/tasks/tasks_ncbi.wdl
+++ b/pipes/WDL/tasks/tasks_ncbi.wdl
@@ -611,7 +611,7 @@ task package_genbank_ftp_submission {
     String spuid_namespace
     String account_name
 
-    String  docker="quay.io/broadinstitute/viral-baseimage:0.1.19"
+    String  docker="quay.io/broadinstitute/viral-baseimage:0.1.20"
   }
   command <<<
     set -e

--- a/pipes/WDL/tasks/tasks_ncbi.wdl
+++ b/pipes/WDL/tasks/tasks_ncbi.wdl
@@ -205,7 +205,7 @@ task structured_comments {
 
     File?   filter_to_ids
 
-    String  docker="quay.io/broadinstitute/viral-core:2.1.16"
+    String  docker="quay.io/broadinstitute/viral-core:2.1.17"
   }
   String out_base = basename(assembly_stats_tsv, '.txt')
   command <<<
@@ -283,7 +283,7 @@ task rename_fasta_header {
 
     String  out_basename = basename(genome_fasta, ".fasta")
 
-    String  docker="quay.io/broadinstitute/viral-core:2.1.16"
+    String  docker="quay.io/broadinstitute/viral-core:2.1.17"
   }
   command {
     set -e
@@ -329,7 +329,7 @@ task sra_meta_prep {
     description: "Prepare tables for submission to NCBI's SRA database. This only works on bam files produced by illumina.py illumina_demux --append_run_id in viral-core."
   }
   input {
-    Array[String]  cleaned_bam_filepaths
+    Array[File]    cleaned_bam_filepaths
     File           biosample_map
     Array[File]    library_metadata
     String         platform
@@ -338,11 +338,13 @@ task sra_meta_prep {
     Boolean        paired
 
     String         out_name = "sra_metadata.tsv"
-    String  docker="quay.io/broadinstitute/viral-core:2.1.16"
+    String  docker="quay.io/broadinstitute/viral-core:2.1.17"
   }
   parameter_meta {
     cleaned_bam_filepaths: {
-      description: "Complete path and filename of unaligned bam files containing cleaned (submittable) reads.",
+      description: "Unaligned bam files containing cleaned (submittable) reads.",
+      localization_optional: true,
+      stream: true,
       patterns: ["*.bam"]
     }
     biosample_map: {
@@ -443,7 +445,7 @@ task sra_meta_prep {
     docker: docker
     memory: "1 GB"
     cpu: 1
-    disks: "local-disk 50 HDD"
+    disks: "local-disk 100 HDD"
     dx_instance_type: "mem1_ssd1_v2_x2"
   }
 }

--- a/pipes/WDL/tasks/tasks_ncbi.wdl
+++ b/pipes/WDL/tasks/tasks_ncbi.wdl
@@ -205,7 +205,7 @@ task structured_comments {
 
     File?   filter_to_ids
 
-    String  docker="quay.io/broadinstitute/viral-core:2.1.17"
+    String  docker="quay.io/broadinstitute/viral-core:2.1.18"
   }
   String out_base = basename(assembly_stats_tsv, '.txt')
   command <<<
@@ -283,7 +283,7 @@ task rename_fasta_header {
 
     String  out_basename = basename(genome_fasta, ".fasta")
 
-    String  docker="quay.io/broadinstitute/viral-core:2.1.17"
+    String  docker="quay.io/broadinstitute/viral-core:2.1.18"
   }
   command {
     set -e
@@ -409,7 +409,7 @@ task sra_meta_prep {
     Boolean        paired
 
     String         out_name = "sra_metadata.tsv"
-    String  docker="quay.io/broadinstitute/viral-core:2.1.17"
+    String  docker="quay.io/broadinstitute/viral-core:2.1.18"
   }
   parameter_meta {
     cleaned_bam_filepaths: {

--- a/pipes/WDL/tasks/tasks_ncbi.wdl
+++ b/pipes/WDL/tasks/tasks_ncbi.wdl
@@ -301,6 +301,26 @@ task rename_fasta_header {
   }
 }
 
+task gisaid_meta_prep {
+  input {
+    File   source_modifier_table
+    String out_name
+  }
+  command {
+
+  }
+  output {
+    File meta_tsv = "~{out_name}"
+    String value = read_string("OUTVAL")
+  }
+  runtime {
+    docker: "ubuntu"
+    memory: "1 GB"
+    cpu: 1
+    dx_instance_type: "mem1_ssd1_v2_x2"
+  }
+}
+
 task lookup_table_by_filename {
   input {
     String  id

--- a/pipes/WDL/tasks/tasks_ncbi.wdl
+++ b/pipes/WDL/tasks/tasks_ncbi.wdl
@@ -248,6 +248,34 @@ task structured_comments {
   }
 }
 
+task prefix_fasta_header {
+  input {
+    File    genome_fasta
+    String  prefix
+  }
+  String  out_basename = basename(genome_fasta, ".fasta")
+  command <<<
+    set -e
+    python3 <<CODE
+    with open('~{genome_fasta}', 'rt') as inf:
+      with open('~{out_basename}.fasta', 'wt') as outf:
+        for line in inf:
+          if line.startswith('>'):
+            line = ">{}{}\n".format('~{prefix}', line.rstrip()[1:])
+          outf.write(line)
+    CODE
+  >>>
+  output {
+    File renamed_fasta = "~{out_basename}.fasta"
+  }
+  runtime {
+    docker: "python"
+    memory: "1 GB"
+    cpu: 1
+    dx_instance_type: "mem1_ssd1_v2_x2"
+  }
+}
+
 task rename_fasta_header {
   input {
     File    genome_fasta
@@ -453,7 +481,7 @@ task biosample_to_genbank {
     File biosample_map                 = "${base}.biosample.map.txt"
   }
   runtime {
-    docker: "${docker}"
+    docker: docker
     memory: "1 GB"
     cpu: 1
     dx_instance_type: "mem1_ssd1_v2_x2"

--- a/pipes/WDL/tasks/tasks_nextstrain.wdl
+++ b/pipes/WDL/tasks/tasks_nextstrain.wdl
@@ -30,7 +30,7 @@ task gzcat {
     input {
         Array[File] infiles
         String      output_name
-        String      docker="quay.io/broadinstitute/viral-core:2.1.16"
+        String      docker="quay.io/broadinstitute/viral-core:2.1.17"
     }
     command <<<
         python3 <<CODE
@@ -63,7 +63,7 @@ task derived_cols {
         String?       lab_highlight_loc
         Array[File]   table_map=[]
 
-        String        docker="quay.io/broadinstitute/viral-core:2.1.16"
+        String        docker="quay.io/broadinstitute/viral-core:2.1.17"
     }
     String basename = basename(basename(metadata_tsv, ".txt"), ".tsv")
     command {
@@ -264,7 +264,7 @@ task filter_sequences_by_length {
         File    sequences_fasta
         Int     min_non_N = 1
 
-        String  docker="quay.io/broadinstitute/viral-core:2.1.16"
+        String  docker="quay.io/broadinstitute/viral-core:2.1.17"
     }
     parameter_meta {
         sequences_fasta: {

--- a/pipes/WDL/tasks/tasks_nextstrain.wdl
+++ b/pipes/WDL/tasks/tasks_nextstrain.wdl
@@ -30,7 +30,7 @@ task gzcat {
     input {
         Array[File] infiles
         String      output_name
-        String      docker="quay.io/broadinstitute/viral-core:2.1.17"
+        String      docker="quay.io/broadinstitute/viral-core:2.1.18"
     }
     command <<<
         python3 <<CODE
@@ -63,7 +63,7 @@ task derived_cols {
         String?       lab_highlight_loc
         Array[File]   table_map=[]
 
-        String        docker="quay.io/broadinstitute/viral-core:2.1.17"
+        String        docker="quay.io/broadinstitute/viral-core:2.1.18"
     }
     String basename = basename(basename(metadata_tsv, ".txt"), ".tsv")
     command {
@@ -264,7 +264,7 @@ task filter_sequences_by_length {
         File    sequences_fasta
         Int     min_non_N = 1
 
-        String  docker="quay.io/broadinstitute/viral-core:2.1.17"
+        String  docker="quay.io/broadinstitute/viral-core:2.1.18"
     }
     parameter_meta {
         sequences_fasta: {

--- a/pipes/WDL/tasks/tasks_nextstrain.wdl
+++ b/pipes/WDL/tasks/tasks_nextstrain.wdl
@@ -149,9 +149,9 @@ task filter_segments {
     CODE
     >>>
     runtime {
-        docker : "python"
-        memory : select_first([machine_mem_gb, 3]) + " GB"
-        cpu :    1
+        docker: "python:slim"
+        memory: select_first([machine_mem_gb, 3]) + " GB"
+        cpu:    1
         disks: "local-disk 375 LOCAL"
         dx_instance_type: "mem1_ssd1_v2_x2"
     }

--- a/pipes/WDL/tasks/tasks_read_utils.wdl
+++ b/pipes/WDL/tasks/tasks_read_utils.wdl
@@ -30,7 +30,9 @@ task group_bams_by_sample {
   parameter_meta {
     bam_filepaths: {
       description: "all bam files",
-      localization_optional: true
+      localization_optional: true,
+      stream: true,
+      patterns: ["*.bam"]
     }
   }
   command <<<
@@ -68,8 +70,8 @@ task group_bams_by_sample {
     docker: "python"
     memory: "1 GB"
     cpu: 1
-    disks: "local-disk 1000 HDD"
-    dx_instance_type: "mem1_ssd2_v2_x16"
+    disks: "local-disk 100 HDD"
+    dx_instance_type: "mem1_ssd1_v2_x2"
   }
 }
 
@@ -77,7 +79,7 @@ task get_sample_meta {
   input {
     Array[File]    samplesheets_extended
 
-    String  docker="quay.io/broadinstitute/viral-core:2.1.16"
+    String  docker="quay.io/broadinstitute/viral-core:2.1.17"
   }
   command <<<
     python3 << CODE
@@ -135,7 +137,7 @@ task merge_and_reheader_bams {
       File?           reheader_table
       String          out_basename
 
-      String          docker="quay.io/broadinstitute/viral-core:2.1.16"
+      String          docker="quay.io/broadinstitute/viral-core:2.1.17"
     }
 
     command {
@@ -195,7 +197,7 @@ task rmdup_ubam {
     String   method="mvicuna"
 
     Int?     machine_mem_gb
-    String?  docker="quay.io/broadinstitute/viral-core:2.1.16"
+    String?  docker="quay.io/broadinstitute/viral-core:2.1.17"
   }
 
   parameter_meta {
@@ -249,7 +251,7 @@ task downsample_bams {
     Boolean?     deduplicateAfter=false
 
     Int?         machine_mem_gb
-    String       docker="quay.io/broadinstitute/viral-core:2.1.16"
+    String       docker="quay.io/broadinstitute/viral-core:2.1.17"
   }
 
   command {
@@ -308,7 +310,7 @@ task FastqToUBAM {
     String? platform_name
     String? sequencing_center
 
-    String  docker="quay.io/broadinstitute/viral-core:2.1.16"
+    String  docker="quay.io/broadinstitute/viral-core:2.1.17"
   }
   parameter_meta {
     fastq_1: { description: "Unaligned read1 file in fastq format", patterns: ["*.fastq", "*.fastq.gz", "*.fq", "*.fq.gz"] }

--- a/pipes/WDL/tasks/tasks_read_utils.wdl
+++ b/pipes/WDL/tasks/tasks_read_utils.wdl
@@ -25,7 +25,13 @@ task max {
 
 task group_bams_by_sample {
   input {
-    Array[String]  bam_filepaths
+    Array[File]  bam_filepaths
+  }
+  parameter_meta {
+    bam_filepaths: {
+      description: "all bam files",
+      localization_optional: true
+    }
   }
   command <<<
     python3 << CODE
@@ -55,15 +61,15 @@ task group_bams_by_sample {
     CODE
   >>>
   output {
-    Array[Array[String]+] grouped_bam_filepaths = read_tsv('grouped_bams')
-    Array[String]         sample_names = read_lines('sample_names')
+    Array[Array[File]+] grouped_bam_filepaths = read_tsv('grouped_bams')
+    Array[String]       sample_names = read_lines('sample_names')
   }
   runtime {
     docker: "python"
     memory: "1 GB"
     cpu: 1
-    disks: "local-disk 50 HDD"
-    dx_instance_type: "mem1_ssd1_v2_x2"
+    disks: "local-disk 1000 HDD"
+    dx_instance_type: "mem1_ssd2_v2_x16"
   }
 }
 

--- a/pipes/WDL/tasks/tasks_read_utils.wdl
+++ b/pipes/WDL/tasks/tasks_read_utils.wdl
@@ -81,9 +81,9 @@ task get_sample_meta {
     CODE
   >>>
   output {
-    Map[String,String] original_names = read_map('sample')
-    Map[String,String] amplicon_set = read_map('amplicon_set')
-    Map[String,String] control = read_map('control')
+    File original_names = 'sample'
+    File amplicon_set = 'amplicon_set'
+    File control = 'control'
   }
   runtime {
     docker: docker

--- a/pipes/WDL/tasks/tasks_read_utils.wdl
+++ b/pipes/WDL/tasks/tasks_read_utils.wdl
@@ -79,7 +79,7 @@ task get_sample_meta {
   input {
     Array[File]    samplesheets_extended
 
-    String  docker="quay.io/broadinstitute/viral-core:2.1.17"
+    String  docker="quay.io/broadinstitute/viral-core:2.1.18"
   }
   command <<<
     python3 << CODE
@@ -137,7 +137,7 @@ task merge_and_reheader_bams {
       File?           reheader_table
       String          out_basename
 
-      String          docker="quay.io/broadinstitute/viral-core:2.1.17"
+      String          docker="quay.io/broadinstitute/viral-core:2.1.18"
     }
 
     command {
@@ -197,7 +197,7 @@ task rmdup_ubam {
     String   method="mvicuna"
 
     Int?     machine_mem_gb
-    String?  docker="quay.io/broadinstitute/viral-core:2.1.17"
+    String?  docker="quay.io/broadinstitute/viral-core:2.1.18"
   }
 
   parameter_meta {
@@ -251,7 +251,7 @@ task downsample_bams {
     Boolean?     deduplicateAfter=false
 
     Int?         machine_mem_gb
-    String       docker="quay.io/broadinstitute/viral-core:2.1.17"
+    String       docker="quay.io/broadinstitute/viral-core:2.1.18"
   }
 
   command {
@@ -310,7 +310,7 @@ task FastqToUBAM {
     String? platform_name
     String? sequencing_center
 
-    String  docker="quay.io/broadinstitute/viral-core:2.1.17"
+    String  docker="quay.io/broadinstitute/viral-core:2.1.18"
   }
   parameter_meta {
     fastq_1: { description: "Unaligned read1 file in fastq format", patterns: ["*.fastq", "*.fastq.gz", "*.fq", "*.fq.gz"] }

--- a/pipes/WDL/tasks/tasks_read_utils.wdl
+++ b/pipes/WDL/tasks/tasks_read_utils.wdl
@@ -7,7 +7,8 @@ task max {
   }
   command <<<
     python3 << CODE
-    print(str(max(map(int, '~{sep="*" list}'.split('*')), default = ~{default_empty})))
+    inlist = '~{sep="*" list}'.split('*')
+    print(str(max(map(int, [x for x in inlist if x]), default = ~{default_empty})))
     CODE
   >>>
   output {

--- a/pipes/WDL/tasks/tasks_read_utils.wdl
+++ b/pipes/WDL/tasks/tasks_read_utils.wdl
@@ -87,9 +87,9 @@ task get_sample_meta {
     CODE
   >>>
   output {
-    File original_names = 'sample'
-    File amplicon_set = 'amplicon_set'
-    File control = 'control'
+    Map[String,String] original_names = read_json('sample')
+    Map[String,String] amplicon_set = read_json('amplicon_set')
+    Map[String,String] control = read_json('control')
   }
   runtime {
     docker: docker

--- a/pipes/WDL/tasks/tasks_read_utils.wdl
+++ b/pipes/WDL/tasks/tasks_read_utils.wdl
@@ -1,5 +1,27 @@
 version 1.0
 
+task max {
+  input {
+    Array[Int] list
+    Int        default_empty=0
+  }
+  command <<<
+    python3 << CODE
+    print(str(max(map(int, '~{sep="*" list}'.split('*')), default = ~{default_empty})))
+    CODE
+  >>>
+  output {
+    Int max = read_int(stdout())
+  }
+  runtime {
+    docker: "python"
+    memory: "1 GB"
+    cpu: 1
+    disks: "local-disk 10 HDD"
+    dx_instance_type: "mem1_ssd1_v2_x2"
+  }
+}
+
 task group_bams_by_sample {
   input {
     Array[String]  bam_filepaths

--- a/pipes/WDL/tasks/tasks_read_utils.wdl
+++ b/pipes/WDL/tasks/tasks_read_utils.wdl
@@ -15,7 +15,7 @@ task max {
     Int max = read_int(stdout())
   }
   runtime {
-    docker: "python"
+    docker: "python:slim"
     memory: "1 GB"
     cpu: 1
     disks: "local-disk 10 HDD"
@@ -67,7 +67,7 @@ task group_bams_by_sample {
     Array[String]       sample_names = read_lines('sample_names')
   }
   runtime {
-    docker: "python"
+    docker: "python:slim"
     memory: "1 GB"
     cpu: 1
     disks: "local-disk 100 HDD"

--- a/pipes/WDL/tasks/tasks_read_utils.wdl
+++ b/pipes/WDL/tasks/tasks_read_utils.wdl
@@ -63,7 +63,7 @@ task get_sample_meta {
 
     # lookup table files to dicts
     sanitized_to_meta = {}
-    meta_cols = ('sample',amplicon_set','control')
+    meta_cols = ('sample','amplicon_set','control')
     for libfile in library_metadata:
       with open(libfile, 'rt') as inf:
         for row in csv.DictReader(inf, delimiter='\t'):
@@ -81,9 +81,6 @@ task get_sample_meta {
     CODE
   >>>
   output {
-    Array[Array[String]+] grouped_bam_filepaths = read_tsv('grouped_bams')
-    Array[String]         sample_names = read_lines('sample_names')
-    Array[String]         sample_names_sanitary = read_lines('sample_names_sanitary')
     Map[String,String] original_names = read_map('sample')
     Map[String,String] amplicon_set = read_map('amplicon_set')
     Map[String,String] control = read_map('control')

--- a/pipes/WDL/tasks/tasks_reports.wdl
+++ b/pipes/WDL/tasks/tasks_reports.wdl
@@ -10,7 +10,7 @@ task plot_coverage {
     Boolean bin_large_plots=false
     String?  binning_summary_statistic="max" # max or min
 
-    String   docker="quay.io/broadinstitute/viral-core:2.1.16"
+    String   docker="quay.io/broadinstitute/viral-core:2.1.17"
   }
   
   command {
@@ -85,7 +85,7 @@ task coverage_report {
     Array[File]  mapped_bam_idx # optional.. speeds it up if you provide it, otherwise we auto-index
     String       out_report_name="coverage_report.txt"
 
-    String       docker="quay.io/broadinstitute/viral-core:2.1.16"
+    String       docker="quay.io/broadinstitute/viral-core:2.1.17"
   }
 
   command {
@@ -144,7 +144,7 @@ task fastqc {
   input {
     File     reads_bam
 
-    String   docker="quay.io/broadinstitute/viral-core:2.1.16"
+    String   docker="quay.io/broadinstitute/viral-core:2.1.17"
   }
 
   String   reads_basename=basename(reads_bam, ".bam")
@@ -177,7 +177,7 @@ task align_and_count {
     Int     topNHits = 3
 
     Int?    machine_mem_gb
-    String  docker="quay.io/broadinstitute/viral-core:2.1.16"
+    String  docker="quay.io/broadinstitute/viral-core:2.1.17"
   }
 
   String  reads_basename=basename(reads_bam, ".bam")
@@ -222,7 +222,7 @@ task align_and_count_summary {
 
     String       output_prefix="count_summary"
 
-    String        docker="quay.io/broadinstitute/viral-core:2.1.16"
+    String        docker="quay.io/broadinstitute/viral-core:2.1.17"
   }
 
   command {
@@ -395,7 +395,7 @@ task tsv_join {
     String         id_col
     String         out_basename
 
-    String         docker="quay.io/broadinstitute/viral-core:2.1.16"
+    String         docker="quay.io/broadinstitute/viral-core:2.1.17"
   }
 
   command {
@@ -422,7 +422,7 @@ task tsv_stack {
   input {
     Array[File]+   input_tsvs
     String         out_basename
-    String         docker="quay.io/broadinstitute/viral-core:2.1.16"
+    String         docker="quay.io/broadinstitute/viral-core:2.1.17"
   }
 
   command {

--- a/pipes/WDL/tasks/tasks_reports.wdl
+++ b/pipes/WDL/tasks/tasks_reports.wdl
@@ -188,20 +188,22 @@ task align_and_count {
 
     read_utils.py --version | tee VERSION
 
-    ln -s ${reads_bam} ${reads_basename}.bam
+    ln -s "${reads_bam}" "${reads_basename}.bam"
     read_utils.py minimap2_idxstats \
-      ${reads_basename}.bam \
-      ${ref_db} \
-      --outStats ${reads_basename}.count.${ref_basename}.txt.unsorted \
+      "${reads_basename}.bam" \
+      "${ref_db}" \
+      --outStats "${reads_basename}.count.${ref_basename}.txt.unsorted" \
       --loglevel=DEBUG
 
-      sort -b -r -n -k3 ${reads_basename}.count.${ref_basename}.txt.unsorted > ${reads_basename}.count.${ref_basename}.txt
-      head -n ${topNHits} ${reads_basename}.count.${ref_basename}.txt > ${reads_basename}.count.${ref_basename}.top_${topNHits}_hits.txt
+    sort -b -r -n -k3 "${reads_basename}.count.${ref_basename}.txt.unsorted" > "${reads_basename}.count.${ref_basename}.txt"
+    head -n ${topNHits} "${reads_basename}.count.${ref_basename}.txt" > "${reads_basename}.count.${ref_basename}.top_${topNHits}_hits.txt"
+    head -1 "${reads_basename}.count.${ref_basename}.txt" | cut -f 1 > "${reads_basename}.count.${ref_basename}.top.txt"
   }
 
   output {
     File   report           = "${reads_basename}.count.${ref_basename}.txt"
     File   report_top_hits  = "${reads_basename}.count.${ref_basename}.top_${topNHits}_hits.txt"
+    String top_hit_id = read_string("${reads_basename}.count.${ref_basename}.top.txt")
     String viralngs_version = read_string("VERSION")
   }
 

--- a/pipes/WDL/tasks/tasks_reports.wdl
+++ b/pipes/WDL/tasks/tasks_reports.wdl
@@ -10,7 +10,7 @@ task plot_coverage {
     Boolean bin_large_plots=false
     String?  binning_summary_statistic="max" # max or min
 
-    String   docker="quay.io/broadinstitute/viral-core:2.1.17"
+    String   docker="quay.io/broadinstitute/viral-core:2.1.18"
   }
   
   command {
@@ -85,7 +85,7 @@ task coverage_report {
     Array[File]  mapped_bam_idx # optional.. speeds it up if you provide it, otherwise we auto-index
     String       out_report_name="coverage_report.txt"
 
-    String       docker="quay.io/broadinstitute/viral-core:2.1.17"
+    String       docker="quay.io/broadinstitute/viral-core:2.1.18"
   }
 
   command {
@@ -144,7 +144,7 @@ task fastqc {
   input {
     File     reads_bam
 
-    String   docker="quay.io/broadinstitute/viral-core:2.1.17"
+    String   docker="quay.io/broadinstitute/viral-core:2.1.18"
   }
 
   String   reads_basename=basename(reads_bam, ".bam")
@@ -177,7 +177,7 @@ task align_and_count {
     Int     topNHits = 3
 
     Int?    machine_mem_gb
-    String  docker="quay.io/broadinstitute/viral-core:2.1.17"
+    String  docker="quay.io/broadinstitute/viral-core:2.1.18"
   }
 
   String  reads_basename=basename(reads_bam, ".bam")
@@ -222,7 +222,7 @@ task align_and_count_summary {
 
     String       output_prefix="count_summary"
 
-    String        docker="quay.io/broadinstitute/viral-core:2.1.17"
+    String        docker="quay.io/broadinstitute/viral-core:2.1.18"
   }
 
   command {
@@ -395,7 +395,7 @@ task tsv_join {
     String         id_col
     String         out_basename
 
-    String         docker="quay.io/broadinstitute/viral-core:2.1.17"
+    String         docker="quay.io/broadinstitute/viral-core:2.1.18"
   }
 
   command {
@@ -422,7 +422,7 @@ task tsv_stack {
   input {
     Array[File]+   input_tsvs
     String         out_basename
-    String         docker="quay.io/broadinstitute/viral-core:2.1.17"
+    String         docker="quay.io/broadinstitute/viral-core:2.1.18"
   }
 
   command {

--- a/pipes/WDL/tasks/tasks_reports.wdl
+++ b/pipes/WDL/tasks/tasks_reports.wdl
@@ -450,7 +450,7 @@ task compare_two_genomes {
     File          genome_two
     String        out_basename
 
-    String        docker="quay.io/broadinstitute/viral-assemble:2.1.16.0"
+    String        docker="quay.io/broadinstitute/viral-assemble:2.1.16.1"
   }
 
   command {

--- a/pipes/WDL/tasks/tasks_sarscov2.wdl
+++ b/pipes/WDL/tasks/tasks_sarscov2.wdl
@@ -29,8 +29,9 @@ task nextclade_one_sample {
         cp "~{basename}".nextclade.tsv input.tsv
         python3 <<CODE
         # transpose table
-        with open('input.tsv', 'rt') as inf:
-            with open('transposed.tsv', 'wt') as outf:
+        import codecs
+        with codecs.open('input.tsv', 'r', encoding='utf-8') as inf:
+            with codecs.open('transposed.tsv', 'w', encoding='utf-8') as outf:
                 for c in zip(*(l.rstrip().split('\t') for l in inf)):
                     outf.write('\t'.join(c)+'\n')
         CODE

--- a/pipes/WDL/tasks/tasks_taxon_filter.wdl
+++ b/pipes/WDL/tasks/tasks_taxon_filter.wdl
@@ -202,7 +202,7 @@ task merge_one_per_sample {
     Boolean?     rmdup=false
 
     Int?         machine_mem_gb
-    String       docker="quay.io/broadinstitute/viral-core:2.1.17"
+    String       docker="quay.io/broadinstitute/viral-core:2.1.18"
   }
 
   command {

--- a/pipes/WDL/tasks/tasks_taxon_filter.wdl
+++ b/pipes/WDL/tasks/tasks_taxon_filter.wdl
@@ -202,7 +202,7 @@ task merge_one_per_sample {
     Boolean?     rmdup=false
 
     Int?         machine_mem_gb
-    String       docker="quay.io/broadinstitute/viral-core:2.1.16"
+    String       docker="quay.io/broadinstitute/viral-core:2.1.17"
   }
 
   command {

--- a/pipes/WDL/workflows/assemble_refbased.wdl
+++ b/pipes/WDL/workflows/assemble_refbased.wdl
@@ -59,7 +59,7 @@ workflow assemble_refbased {
         String          aligner="minimap2"
         File?           novocraft_license
         Int             min_coverage=3
-        Boolean?        skip_mark_dupes=false
+        Boolean         skip_mark_dupes=false
         File?           trim_coords_bed
     }
 

--- a/pipes/WDL/workflows/assemble_refbased.wdl
+++ b/pipes/WDL/workflows/assemble_refbased.wdl
@@ -40,6 +40,9 @@ workflow assemble_refbased {
             patterns: ["*.bed"],
             category: "common"
         }
+        min_coverage: {
+            description: "Minimum read coverage required to call a position unambiguous."
+        }
 
 
         assembly_fasta: { description: "The new assembly / consensus sequence for this sample" }
@@ -55,6 +58,7 @@ workflow assemble_refbased {
 
         String          aligner="minimap2"
         File?           novocraft_license
+        Int             min_coverage=3
         Boolean?        skip_mark_dupes=false
         File?           trim_coords_bed
     }
@@ -98,6 +102,7 @@ workflow assemble_refbased {
         input:
             reads_aligned_bam = merge_align_to_ref.out_bam,
             reference_fasta   = reference_fasta,
+            min_coverage      = min_coverage+1,
             out_basename      = sample_name
     }
 
@@ -111,6 +116,7 @@ workflow assemble_refbased {
         input:
             reference_fasta   = reference_fasta,
             reads_aligned_bam = merge_align_to_ref.out_bam,
+            min_coverage      = min_coverage,
             sample_name       = sample_name
     }
 

--- a/pipes/WDL/workflows/demux_deplete.wdl
+++ b/pipes/WDL/workflows/demux_deplete.wdl
@@ -61,10 +61,10 @@ workflow demux_deplete {
         }
     }
     call demux.merge_maps as meta_sample {
-        input: maps_jsons = meta_default_sample.out_json
+        input: maps_jsons = illumina_demux.meta_by_sample_json
     }
     call demux.merge_maps as meta_filename {
-        input: maps_jsons = meta_default_filename.out_json
+        input: maps_jsons = illumina_demux.meta_by_filename_json
     }
 
     #### human depletion & spike-in counting for all files

--- a/pipes/WDL/workflows/demux_deplete.wdl
+++ b/pipes/WDL/workflows/demux_deplete.wdl
@@ -60,6 +60,12 @@ workflow demux_deplete {
                 samplesheet = samplesheet_rename_ids.new_sheet
         }
     }
+    call demux.merge_maps as meta_sample {
+        input: maps_jsons = meta_default_sample.out_json
+    }
+    call demux.merge_maps as meta_filename {
+        input: maps_jsons = meta_default_filename.out_json
+    }
 
     #### human depletion & spike-in counting for all files
     scatter(raw_reads in flatten(illumina_demux.raw_reads_unaligned_bams)) {
@@ -116,6 +122,9 @@ workflow demux_deplete {
     output {
         Array[File] raw_reads_unaligned_bams     = flatten(illumina_demux.raw_reads_unaligned_bams)
         Array[Int]  read_counts_raw = deplete.depletion_read_count_pre
+
+        Map[String,Map[String,String]] meta_by_filename = meta_filename.merged
+        Map[String,Map[String,String]] meta_by_sample = meta_sample.merged
 
         Array[File] cleaned_reads_unaligned_bams = select_all(cleaned_bam_passing)
         Array[File] cleaned_bams_tiny = select_all(empty_bam)

--- a/pipes/WDL/workflows/demux_deplete.wdl
+++ b/pipes/WDL/workflows/demux_deplete.wdl
@@ -83,6 +83,7 @@ workflow demux_deplete {
                 cleaned_bam_filepaths = deplete.cleaned_bam,
                 biosample_map = select_first([biosample_map]),
                 library_metadata = samplesheet_rename_ids.new_sheet,
+                platform = "ILLUMINA",
                 out_name = "sra_metadata-~{basename(flowcell_tgz, '.tar.gz')}.tsv"
         }
     }

--- a/pipes/WDL/workflows/demux_deplete.wdl
+++ b/pipes/WDL/workflows/demux_deplete.wdl
@@ -40,7 +40,7 @@ workflow demux_deplete {
     Array[File]+ sheets = select_first([renamed_sheets, samplesheets])
 
     #### demux each lane
-    scatter(lane_sheet in zip(range(length(samplesheets)), samplesheets)) {
+    scatter(lane_sheet in zip(range(length(sheets)), sheets)) {
         call demux.illumina_demux as illumina_demux {
             input:
                 flowcell_tgz = flowcell_tgz,

--- a/pipes/WDL/workflows/demux_deplete.wdl
+++ b/pipes/WDL/workflows/demux_deplete.wdl
@@ -71,6 +71,7 @@ workflow demux_deplete {
             input:
                 cleaned_bam_filepaths = deplete.cleaned_bam,
                 biosample_map = select_first([biosample_map]),
+                library_metadata = sheets,
                 out_name = "sra_metadata-~{basename(flowcell_tgz, '.tar.gz')}.tsv"
         }
     }

--- a/pipes/WDL/workflows/sarscov2_illumina_full.wdl
+++ b/pipes/WDL/workflows/sarscov2_illumina_full.wdl
@@ -189,14 +189,14 @@ workflow sarscov2_illumina_full {
             }
             if (vadr.num_alerts==0) {
               File submittable_genomes = passing_assemblies
-              String submittable_id = name_reads.left
+              String submittable_id = get_sample_meta.original_names[name_reads.left]
             }
             if (vadr.num_alerts>0) {
-              String failed_annotation_id = name_reads.left
+              String failed_annotation_id = get_sample_meta.original_names[name_reads.left]
             }
         }
         if (assemble_refbased.assembly_length_unambiguous < min_genome_bases) {
-            String failed_assembly_id = name_reads.left
+            String failed_assembly_id = get_sample_meta.original_names[name_reads.left]
         }
     }
 

--- a/pipes/WDL/workflows/sarscov2_illumina_full.wdl
+++ b/pipes/WDL/workflows/sarscov2_illumina_full.wdl
@@ -85,10 +85,10 @@ workflow sarscov2_illumina_full {
         }
     }
     call demux.merge_maps as meta_sample {
-        input: maps = illumina_demux.meta_by_sample
+        input: maps_jsons = illumina_demux.meta_by_sample_json
     }
     call demux.merge_maps as meta_filename {
-        input: maps = illumina_demux.meta_by_filename
+        input: maps_jsons = illumina_demux.meta_by_filename_json
     }
 
     #### human depletion & spike-in counting for all files

--- a/pipes/WDL/workflows/sarscov2_illumina_full.wdl
+++ b/pipes/WDL/workflows/sarscov2_illumina_full.wdl
@@ -151,10 +151,10 @@ workflow sarscov2_illumina_full {
 
     ### assembly and analyses per biosample
     scatter(name_reads in zip(group_bams_by_sample.sample_names, group_bams_by_sample.grouped_bam_filepaths)) {
-        # assemble genome
         Boolean ampseq = (meta_sample.merged[name_reads.left]["amplicon_set"] != "")
         String orig_name = meta_sample.merged[name_reads.left]["sample_original"]
 
+        # assemble genome
         if (ampseq) {
             String trim_coords_bed = amplicon_bed_prefix + meta_sample.merged[name_reads.left]["amplicon_set"] + ".bed"
         }
@@ -184,7 +184,7 @@ workflow sarscov2_illumina_full {
 
             File passing_assemblies = rename_fasta_header.renamed_fasta
             String passing_assembly_ids = orig_name
-            Array[String] assembly_meta = [orig_name, "Broad viral-ngs v. " + illumina_demux.viralngs_version, assemble_refbased.assembly_mean_coverage]
+            Array[String] assembly_meta = [orig_name, "Broad viral-ngs v. " + illumina_demux.viralngs_version[0], assemble_refbased.assembly_mean_coverage]
 
             # lineage assignment
             call sarscov2.nextclade_one_sample {

--- a/pipes/WDL/workflows/sarscov2_illumina_full.wdl
+++ b/pipes/WDL/workflows/sarscov2_illumina_full.wdl
@@ -83,6 +83,10 @@ workflow sarscov2_illumina_full {
                 samplesheet = samplesheet_rename_ids.new_sheet
         }
     }
+    call read_utils.get_sample_meta {
+        input:
+            samplesheets_extended = samplesheet_rename_ids.new_sheet
+    }
 
     #### human depletion & spike-in counting for all files
     scatter(raw_reads in flatten(illumina_demux.raw_reads_unaligned_bams)) {
@@ -132,11 +136,6 @@ workflow sarscov2_illumina_full {
     call read_utils.group_bams_by_sample {
         input:
             bam_filepaths = deplete.cleaned_bam
-    }
-    call read_utils.get_sample_meta {
-        input:
-            sanitized_sample_names = group_bams_by_sample.sample_names,
-            samplesheets_extended = samplesheet_rename_ids.new_sheet
     }
 
     ### assembly and analyses per biosample

--- a/pipes/WDL/workflows/sarscov2_illumina_full.wdl
+++ b/pipes/WDL/workflows/sarscov2_illumina_full.wdl
@@ -291,6 +291,7 @@ workflow sarscov2_illumina_full {
         Array[String] submittable_ids = select_all(submittable_id)
         Array[String] failed_assembly_ids = select_all(failed_assembly_id)
         Array[String] failed_annotation_ids = select_all(failed_annotation_id)
+        Int           num_read_files = length(select_all(cleaned_bam_passing))
         Int           num_assembled = length(select_all(passing_assemblies))
         Int           num_failed_assembly = length(select_all(failed_assembly_id))
         Int           num_submittable = length(select_all(submittable_id))

--- a/pipes/WDL/workflows/sarscov2_illumina_full.wdl
+++ b/pipes/WDL/workflows/sarscov2_illumina_full.wdl
@@ -83,7 +83,6 @@ workflow sarscov2_illumina_full {
                 lane = lane_sheet.left + 1,
                 samplesheet = samplesheet_rename_ids.new_sheet
         }
-
     }
     call demux.merge_maps as meta_sample {
         input: maps = illumina_demux.meta_by_sample

--- a/pipes/WDL/workflows/sarscov2_illumina_full.wdl
+++ b/pipes/WDL/workflows/sarscov2_illumina_full.wdl
@@ -108,7 +108,8 @@ workflow sarscov2_illumina_full {
             cleaned_bam_filepaths = deplete.cleaned_bam,
             biosample_map = biosample_attributes,
             library_metadata = samplesheet_rename_ids.new_sheet,
-            out_name = "sra_metadata-~{basename(flowcell_tgz, '.tar.gz')}.tsv"
+            out_name = "sra_metadata-~{basename(flowcell_tgz, '.tar.gz')}.tsv",
+            platform = "ILLUMINA"
     }
 
     #### summary stats

--- a/pipes/WDL/workflows/sarscov2_illumina_full.wdl
+++ b/pipes/WDL/workflows/sarscov2_illumina_full.wdl
@@ -138,14 +138,12 @@ workflow sarscov2_illumina_full {
             sanitized_sample_names = group_bams_by_sample.sample_names,
             samplesheets_extended = samplesheet_rename_ids.new_sheet
     }
-    Map[String,String] original_names = read_json(get_sample_meta.original_names)
-    Map[String,String] amplicon_set = read_json(get_sample_meta.amplicon_set)
 
     ### assembly and analyses per biosample
     scatter(name_reads in zip(group_bams_by_sample.sample_names, group_bams_by_sample.grouped_bam_filepaths)) {
         # assemble genome
-        if (amplicon_set[name_reads.left] != "") {
-            String trim_coords_bed = amplicon_bed_prefix + amplicon_set[name_reads.left] + ".bed"
+        if (get_sample_meta.amplicon_set[name_reads.left] != "") {
+            String trim_coords_bed = amplicon_bed_prefix + get_sample_meta.amplicon_set[name_reads.left] + ".bed"
         }
         call assemble_refbased.assemble_refbased {
             input:
@@ -153,9 +151,9 @@ workflow sarscov2_illumina_full {
                 reference_fasta = reference_fasta,
                 sample_name = name_reads.left,
                 aligner = "minimap2",
-                skip_mark_dupes = (amplicon_set[name_reads.left] != ""),
+                skip_mark_dupes = (get_sample_meta.amplicon_set[name_reads.left] != ""),
                 trim_coords_bed = trim_coords_bed,
-                min_coverage = if (amplicon_set[name_reads.left] != "") then 20 else 3
+                min_coverage = if (get_sample_meta.amplicon_set[name_reads.left] != "") then 20 else 3
         }
 
         # for genomes that somewhat assemble
@@ -163,12 +161,12 @@ workflow sarscov2_illumina_full {
             call ncbi.rename_fasta_header {
               input:
                 genome_fasta = assemble_refbased.assembly_fasta,
-                new_name = original_names[name_reads.left]
+                new_name = get_sample_meta.original_names[name_reads.left]
             }
 
             File passing_assemblies = rename_fasta_header.renamed_fasta
-            String passing_assembly_ids = original_names[name_reads.left]
-            Array[String] assembly_meta = [original_names[name_reads.left], assemble_refbased.assembly_mean_coverage]
+            String passing_assembly_ids = get_sample_meta.original_names[name_reads.left]
+            Array[String] assembly_meta = [get_sample_meta.original_names[name_reads.left], assemble_refbased.assembly_mean_coverage]
 
             # lineage assignment
             call sarscov2.nextclade_one_sample {

--- a/pipes/WDL/workflows/sarscov2_illumina_full.wdl
+++ b/pipes/WDL/workflows/sarscov2_illumina_full.wdl
@@ -54,7 +54,7 @@ workflow sarscov2_illumina_full {
         Array[File]+  samplesheets  ## must be in lane order!
 
         File          reference_fasta
-        File          amplicon_bed_prefix
+        String        amplicon_bed_prefix
 
         File          biosample_attributes
         File?         sample_rename_map
@@ -64,7 +64,6 @@ workflow sarscov2_illumina_full {
         String        gisaid_prefix = 'hCoV-19/'
 
         File          spikein_db
-        File          trim_clip_db
         Array[File]?  bmtaggerDbs  # .tar.gz, .tgz, .tar.bz2, .tar.lz4, .fasta, or .fasta.gz
         Array[File]?  blastDbs  # .tar.gz, .tgz, .tar.bz2, .tar.lz4, .fasta, or .fasta.gz
         Array[File]?  bwaDbs

--- a/pipes/WDL/workflows/sarscov2_illumina_full.wdl
+++ b/pipes/WDL/workflows/sarscov2_illumina_full.wdl
@@ -83,12 +83,22 @@ workflow sarscov2_illumina_full {
                 lane = lane_sheet.left + 1,
                 samplesheet = samplesheet_rename_ids.new_sheet
         }
+        call demux.map_map_setdefault as meta_default_sample {
+            input:
+                map_map_json = illumina_demux.meta_by_sample_json,
+                sub_keys = ["amplicon_set", "control"]
+        }
+        call demux.map_map_setdefault as meta_default_filename {
+            input:
+                map_map_json = illumina_demux.meta_by_filename_json,
+                sub_keys = ["spike_in"]
+        }
     }
     call demux.merge_maps as meta_sample {
-        input: maps_jsons = illumina_demux.meta_by_sample_json
+        input: maps_jsons = meta_default_sample.out_json
     }
     call demux.merge_maps as meta_filename {
-        input: maps_jsons = illumina_demux.meta_by_filename_json
+        input: maps_jsons = meta_default_filename.out_json
     }
 
     #### human depletion & spike-in counting for all files

--- a/pipes/WDL/workflows/sarscov2_illumina_full.wdl
+++ b/pipes/WDL/workflows/sarscov2_illumina_full.wdl
@@ -37,7 +37,7 @@ workflow sarscov2_illumina_full {
             description: "Reference genome to align reads to.",
             patterns: ["*.fasta"]
         }
-        ampseq_trim_coords_bed: {
+        amplicon_bed_prefix: {
             description: "amplicon primers to trim in reference coordinate space (0-based BED format)",
             patterns: ["*.bed"]
         }

--- a/pipes/WDL/workflows/sarscov2_illumina_full.wdl
+++ b/pipes/WDL/workflows/sarscov2_illumina_full.wdl
@@ -138,8 +138,8 @@ workflow sarscov2_illumina_full {
             sanitized_sample_names = group_bams_by_sample.sample_names,
             samplesheets_extended = samplesheet_rename_ids.new_sheet
     }
-    Map[String,String] original_names = read_map(get_sample_meta.original_names)
-    Map[String,String] amplicon_set = read_map(get_sample_meta.amplicon_set)
+    Map[String,String] original_names = read_json(get_sample_meta.original_names)
+    Map[String,String] amplicon_set = read_json(get_sample_meta.amplicon_set)
 
     ### assembly and analyses per biosample
     scatter(name_reads in zip(group_bams_by_sample.sample_names, group_bams_by_sample.grouped_bam_filepaths)) {

--- a/requirements-modules.txt
+++ b/requirements-modules.txt
@@ -1,4 +1,4 @@
-broadinstitute/viral-core=2.1.16
+broadinstitute/viral-core=2.1.17
 broadinstitute/viral-assemble=2.1.16.1
 broadinstitute/viral-classify=2.1.16.0
 broadinstitute/viral-phylo=2.1.16.0

--- a/requirements-modules.txt
+++ b/requirements-modules.txt
@@ -1,5 +1,5 @@
 broadinstitute/viral-core=2.1.16
-broadinstitute/viral-assemble=2.1.16.0
+broadinstitute/viral-assemble=2.1.16.1
 broadinstitute/viral-classify=2.1.16.0
 broadinstitute/viral-phylo=2.1.16.0
 broadinstitute/beast-beagle-cuda=1.10.5pre

--- a/requirements-modules.txt
+++ b/requirements-modules.txt
@@ -1,4 +1,4 @@
-broadinstitute/viral-core=2.1.17
+broadinstitute/viral-core=2.1.18
 broadinstitute/viral-assemble=2.1.16.1
 broadinstitute/viral-classify=2.1.16.0
 broadinstitute/viral-phylo=2.1.16.0


### PR DESCRIPTION
- bugfix: bump viral-assemble from 2.1.16.0 to 2.1.16.1 (fix behavior on empty input)
- expose sarscov2_illumina_full properly on dockstore
- rename sample ids at the beginning prior to demux in both sarscov2_illumina_full and demux_deplete
- fix sample metadata map under cromwell/terra (use `read_json` instead of `read_map`)
- add gisaid fasta output
- add metric for worst NTC
- align_and_count now names the single biggest spike in for each sample
- more sample and library metadata emitted in json and/or structured format for downstream decoding