### PR TITLE
sarscov2 workflow updates

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -245,6 +245,11 @@ workflows:
    primaryDescriptorPath: /pipes/WDL/workflows/sarscov2_nextclade_multi.wdl
    testParameterFiles:
     - empty.json
+ - name: sarscov2_sra_to_genbank
+   subclass: WDL
+   primaryDescriptorPath: /pipes/WDL/workflows/sarscov2_sra_to_genbank.wdl
+   testParameterFiles:
+    - empty.json
  - name: scaffold_and_refine
    subclass: WDL
    primaryDescriptorPath: /pipes/WDL/workflows/scaffold_and_refine.wdl

--- a/pipes/WDL/tasks/tasks_demux.wdl
+++ b/pipes/WDL/tasks/tasks_demux.wdl
@@ -376,6 +376,7 @@ task merge_maps {
   >>>
   output {
     Map[String,Map[String,String]] merged = read_json('out.json')
+    File merged_json = 'out.json'
   }
   runtime {
     docker: "python:slim"

--- a/pipes/WDL/tasks/tasks_ncbi.wdl
+++ b/pipes/WDL/tasks/tasks_ncbi.wdl
@@ -307,11 +307,14 @@ task gisaid_meta_prep {
     File   structured_comments
     String out_name
     String continent = "North America"
+    Boolean strict = true
   }
   command <<<
     python3 << CODE
     import os.path
     import csv
+
+    strict = ~{true="True" false="False" strict}
 
     # lookup table files to dicts
     sample_to_cmt = {}
@@ -353,11 +356,11 @@ task gisaid_meta_prep {
           })
 
           #covv_specimen
-
-          assert row['isolation_source'] == 'Clinical'
-          assert row['host'] == 'Homo sapiens'
-          assert row['organism'] == 'Severe acute respiratory syndrome coronavirus 2'
-          assert row['db_xref'] == 'taxon:2697049'
+          if strict:
+            assert row['isolation_source'] == 'Clinical'
+            assert row['host'] == 'Homo sapiens'
+            assert row['organism'] == 'Severe acute respiratory syndrome coronavirus 2'
+            assert row['db_xref'] == 'taxon:2697049'
 
     CODE
   >>>

--- a/pipes/WDL/tasks/tasks_ncbi_tools.wdl
+++ b/pipes/WDL/tasks/tasks_ncbi_tools.wdl
@@ -23,11 +23,11 @@ task Fetch_SRA_to_BAM {
         LIBRARY=$(jq -r .EXPERIMENT_PACKAGE_SET.EXPERIMENT_PACKAGE.EXPERIMENT.alias SRA.json)
         RUNDATE=$(jq -r '.EXPERIMENT_PACKAGE_SET.EXPERIMENT_PACKAGE.RUN_SET.RUN.SRAFiles|if (.SRAFile|type) == "object" then .SRAFile.date else [.SRAFile[]|select(.supertype == "Original")][0].date end' SRA.json | cut -f 1 -d ' ')
 
-        if [ "$LIBRARY" = "OXFORD_NANOPORE" ]; then
+        if [ "$PLATFORM" = "OXFORD_NANOPORE" ]; then
             # per the SAM/BAM specification
-            SAM_LIBRARY="ONT"
+            SAM_PLATFORM="ONT"
         else
-            SAM_LIBRARY="$LIBRARY"
+            SAM_PLATFORM="$LIBRARY"
         fi
 
         sam-dump --unaligned --header ${SRA_ID} \
@@ -39,7 +39,7 @@ task Fetch_SRA_to_BAM {
             RGID=1 \
             RGLB="$LIBRARY" \
             RGSM="$SAMPLE" \
-            RGPL="$SAM_LIBRARY" \
+            RGPL="$SAM_PLATFORM" \
             RGPU="$LIBRARY" \
             RGPM="$MODEL" \
             RGDT="$RUNDATE" \

--- a/pipes/WDL/tasks/tasks_ncbi_tools.wdl
+++ b/pipes/WDL/tasks/tasks_ncbi_tools.wdl
@@ -27,7 +27,7 @@ task Fetch_SRA_to_BAM {
             # per the SAM/BAM specification
             SAM_PLATFORM="ONT"
         else
-            SAM_PLATFORM="$LIBRARY"
+            SAM_PLATFORM="$PLATFORM"
         fi
 
         sam-dump --unaligned --header ${SRA_ID} \

--- a/pipes/WDL/tasks/tasks_ncbi_tools.wdl
+++ b/pipes/WDL/tasks/tasks_ncbi_tools.wdl
@@ -55,7 +55,8 @@ task Fetch_SRA_to_BAM {
             biosample['message'] = 'Successfully loaded'
             biosample['bioproject_accession'] = meta['EXPERIMENT_PACKAGE_SET']['EXPERIMENT_PACKAGE']['SAMPLE']['SAMPLE_LINKS']['SAMPLE_LINK']['XREF_LINK']['LABEL']
             biosample['sample_name'] = biosample['isolate']
-            with open('~{SRA_ID}-biosample_attributes.json', 'wt')
+            with open('~{SRA_ID}-biosample_attributes.json', 'wt') as outf:
+                json.dump(biosample, outf)
         CODE
     }
 

--- a/pipes/WDL/tasks/tasks_ncbi_tools.wdl
+++ b/pipes/WDL/tasks/tasks_ncbi_tools.wdl
@@ -183,9 +183,9 @@ task group_sra_bams_by_biosample {
       sample_to_libstrat[samn].add(libstrat)
 
     # write outputs
-    with open('attributes.json') as out_attr:
+    with open('attributes.json', 'wt') as out_attr:
         json.dump(sample_to_attributes, out_attr)
-    with open('attributes.tsv') as out_attr:
+    with open('attributes.tsv', 'wt') as out_attr:
         headers = tuple(sorted(attr_keys))
         out_attr.write('\t'.join(headers)+'\n')
         for sample in sorted(sample_to_bams.keys()):
@@ -195,7 +195,7 @@ task group_sra_bams_by_biosample {
         for sample in sorted(sample_to_bams.keys()):
           out_samples.write(sample+'\n')
           out_groups.write('\t'.join(sample_to_bams[sample])+'\n')
-    with open('library_strategies.json') as out_attr:
+    with open('library_strategies.json', 'wt') as out_attr:
         for k,v in sample_to_libstrat.items():
             sample_to_libstrat[k] = ';'.join(sorted(v))
         json.dump(sample_to_libstrat, out_attr)

--- a/pipes/WDL/tasks/tasks_ncbi_tools.wdl
+++ b/pipes/WDL/tasks/tasks_ncbi_tools.wdl
@@ -30,7 +30,7 @@ task Fetch_SRA_to_BAM {
             SAM_PLATFORM="$PLATFORM"
         fi
 
-        sam-dump --unaligned --header ${SRA_ID} \
+        sam-dump --unaligned --header "~{SRA_ID}" \
             | samtools view -bhS - \
             > temp.bam
         picard AddOrReplaceReadGroups \

--- a/pipes/WDL/tasks/tasks_ncbi_tools.wdl
+++ b/pipes/WDL/tasks/tasks_ncbi_tools.wdl
@@ -172,9 +172,11 @@ task group_sra_bams_by_biosample {
     sample_to_attributes = {}
     sample_to_libstrat = {}
     attr_keys = set()
-    for samn,bam,attr,libstrat in zip(biosample_accs,bam_uris, attributes, libstrats):
+    for samn,bam,attr_file,libstrat in zip(biosample_accs,bam_uris, attributes, libstrats):
       sample_to_bams.setdefault(samn, [])
       sample_to_bams[samn].append(bam)
+      with open(attr_file, 'rt') as inf:
+        attr = json.load(inf)
       sample_to_attributes[samn] = attr
       attr_keys.update(k for k,v in attr.items() if v)
       sample_to_libstrat.setdefault(samn, set())

--- a/pipes/WDL/tasks/tasks_ncbi_tools.wdl
+++ b/pipes/WDL/tasks/tasks_ncbi_tools.wdl
@@ -48,6 +48,7 @@ task Fetch_SRA_to_BAM {
             SRA.json | tee OUT_LIBRARY_STRATEGY
 
         python3 << CODE
+        import json
         with open('SRA.json', 'rt') as inf:
             meta = json.load(inf)
             biosample = dict((x['TAG'],x['VALUE']) for x in meta['EXPERIMENT_PACKAGE_SET']['EXPERIMENT_PACKAGE']['SAMPLE']['SAMPLE_ATTRIBUTES']['SAMPLE_ATTRIBUTE'])

--- a/pipes/WDL/tasks/tasks_sarscov2.wdl
+++ b/pipes/WDL/tasks/tasks_sarscov2.wdl
@@ -148,6 +148,6 @@ task pangolin_one_sample {
         String lineages_version   = read_string("VERSION_LINEAGES")
         String pangolearn_version = read_string("VERSION_PANGOLEARN")
         File   pangolin_csv       = "~{basename}.pangolin_report.csv"
-        String pangolin_clade     = read_string("PANGOLIN_CLADE")
+        String pango_lineage      = read_string("PANGOLIN_CLADE")
     }
 }

--- a/pipes/WDL/workflows/demux_deplete.wdl
+++ b/pipes/WDL/workflows/demux_deplete.wdl
@@ -144,6 +144,8 @@ workflow demux_deplete {
 
         Map[String,Map[String,String]] meta_by_filename = meta_filename.merged
         Map[String,Map[String,String]] meta_by_sample = meta_sample.merged
+        File meta_by_filename_json = meta_filename.merged_json
+        File meta_by_sample_json = meta_sample.merged_json
 
         Array[File] cleaned_reads_unaligned_bams = select_all(cleaned_bam_passing)
         Array[File] cleaned_bams_tiny = select_all(empty_bam)

--- a/pipes/WDL/workflows/demux_deplete.wdl
+++ b/pipes/WDL/workflows/demux_deplete.wdl
@@ -21,10 +21,16 @@ workflow demux_deplete {
         File?        biosample_map
         Int          min_reads_per_bam = 100
 
+        String?      instrument_model
+        String?      sra_title
+
         File         spikein_db
         Array[File]? bmtaggerDbs  # .tar.gz, .tgz, .tar.bz2, .tar.lz4, .fasta, or .fasta.gz
         Array[File]? blastDbs  # .tar.gz, .tgz, .tar.bz2, .tar.lz4, .fasta, or .fasta.gz
         Array[File]? bwaDbs
+
+        Array[String] default_sample_keys = ["amplicon_set", "control"]
+        Array[String] default_filename_keys = ["spike_in"]
     }
 
     parameter_meta {
@@ -53,18 +59,28 @@ workflow demux_deplete {
                 old_sheet = lane_sheet.right,
                 rename_map = sample_rename_map
         }
-        call demux.illumina_demux as illumina_demux {
+        call demux.illumina_demux {
             input:
                 flowcell_tgz = flowcell_tgz,
                 lane = lane_sheet.left + 1,
                 samplesheet = samplesheet_rename_ids.new_sheet
         }
+        call demux.map_map_setdefault as meta_default_sample {
+            input:
+                map_map_json = illumina_demux.meta_by_sample_json,
+                sub_keys = default_sample_keys
+        }
+        call demux.map_map_setdefault as meta_default_filename {
+            input:
+                map_map_json = illumina_demux.meta_by_filename_json,
+                sub_keys = default_filename_keys
+        }
     }
     call demux.merge_maps as meta_sample {
-        input: maps_jsons = illumina_demux.meta_by_sample_json
+        input: maps_jsons = meta_default_sample.out_json
     }
     call demux.merge_maps as meta_filename {
-        input: maps_jsons = illumina_demux.meta_by_filename_json
+        input: maps_jsons = meta_default_filename.out_json
     }
 
     #### human depletion & spike-in counting for all files
@@ -97,7 +113,10 @@ workflow demux_deplete {
                 biosample_map = select_first([biosample_map]),
                 library_metadata = samplesheet_rename_ids.new_sheet,
                 platform = "ILLUMINA",
-                out_name = "sra_metadata-~{basename(flowcell_tgz, '.tar.gz')}.tsv"
+                paired = (illumina_demux.run_info[0]['indexes'] == '2'),
+                out_name = "sra_metadata-~{basename(flowcell_tgz, '.tar.gz')}.tsv",
+                instrument_model = select_first([instrument_model]),
+                title = select_first([sra_title])
         }
     }
 

--- a/pipes/WDL/workflows/sarscov2_genbank.wdl
+++ b/pipes/WDL/workflows/sarscov2_genbank.wdl
@@ -20,8 +20,10 @@ workflow sarscov2_genbank {
         File          assembly_stats_tsv
         File?         fasta_rename_map
 
-        Int           taxid = 2697049
         Int           min_genome_bases = 20000
+
+        Int           taxid = 2697049
+        String        gisaid_prefix = 'hCoV-19/'
     }
 
     parameter_meta {
@@ -98,6 +100,18 @@ workflow sarscov2_genbank {
         structured_comment_table = structured_comments.structured_comment_table
     }
 
+    call ncbi.prefix_fasta_header as prefix_gisaid {
+      input:
+        genome_fasta = concatenate.combined,
+        prefix = gisaid_prefix
+    }
+    call ncbi.gisaid_meta_prep {
+      input:
+        source_modifier_table = biosample_to_genbank.genbank_source_modifier_table,
+        structured_comments = structured_comments.structured_comment_table,
+        out_name = "gisaid_meta.tsv"
+    }
+
     output {
         File submission_zip = package_genbank_ftp_submission.submission_zip
         File submission_xml    = package_genbank_ftp_submission.submission_xml
@@ -110,6 +124,9 @@ workflow sarscov2_genbank {
 
         File biosample_map = biosample_to_genbank.biosample_map
         File genbank_source_table = biosample_to_genbank.genbank_source_modifier_table
+
+        File gisaid_fasta = prefix_gisaid.renamed_fasta
+        File gisaid_meta_tsv = gisaid_meta_prep.meta_tsv
     }
 
 }

--- a/pipes/WDL/workflows/sarscov2_illumina_full.wdl
+++ b/pipes/WDL/workflows/sarscov2_illumina_full.wdl
@@ -1,13 +1,8 @@
 version 1.0
 
-import "../tasks/tasks_metagenomics.wdl" as metagenomics
 import "../tasks/tasks_read_utils.wdl" as read_utils
-import "../tasks/tasks_taxon_filter.wdl" as taxon_filter
-import "../tasks/tasks_assembly.wdl" as assembly
-import "../tasks/tasks_reports.wdl" as reports
 import "../tasks/tasks_ncbi.wdl" as ncbi
 import "../tasks/tasks_nextstrain.wdl" as nextstrain
-import "../tasks/tasks_demux.wdl" as demux
 
 import "demux_deplete.wdl"
 import "assemble_refbased.wdl"

--- a/pipes/WDL/workflows/sarscov2_illumina_full.wdl
+++ b/pipes/WDL/workflows/sarscov2_illumina_full.wdl
@@ -50,10 +50,10 @@ workflow sarscov2_illumina_full {
         String        instrument_model
         String        sra_title
 
-        Int           taxid = 2697049
         Int           min_genome_bases = 20000
-        String        gisaid_prefix = 'hCoV-19/'
     }
+    Int     taxid = 2697049
+    String  gisaid_prefix = 'hCoV-19/'
 
     ### demux, deplete, SRA submission prep, fastqc/multiqc
     call demux_deplete.demux_deplete {

--- a/pipes/WDL/workflows/sarscov2_illumina_full.wdl
+++ b/pipes/WDL/workflows/sarscov2_illumina_full.wdl
@@ -211,7 +211,7 @@ workflow sarscov2_illumina_full {
         Array[File] cleaned_reads_unaligned_bams = demux_deplete.cleaned_reads_unaligned_bams
         Array[File] cleaned_bams_tiny            = demux_deplete.cleaned_bams_tiny
 
-        File meta_by_filename = write_json(demux_deplete.meta_by_filename)
+        File meta_by_filename_json = demux_deplete.meta_by_filename_json
 
         Array[Int]  read_counts_raw       = demux_deplete.read_counts_raw
         Array[Int]  read_counts_depleted  = demux_deplete.read_counts_depleted

--- a/pipes/WDL/workflows/sarscov2_lineages.wdl
+++ b/pipes/WDL/workflows/sarscov2_lineages.wdl
@@ -26,7 +26,7 @@ workflow sarscov2_lineages {
         File   nextclade_tsv   = nextclade_one_sample.nextclade_tsv
         String nextclade_aa_subs = nextclade_one_sample.aa_subs_csv
         String nextclade_aa_dels = nextclade_one_sample.aa_dels_csv
-        String pangolin_clade  = pangolin_one_sample.pangolin_clade
+        String pango_lineage   = pangolin_one_sample.pango_lineage
         File   pangolin_csv    = pangolin_one_sample.pangolin_csv
     }
 }

--- a/pipes/WDL/workflows/sarscov2_sra_to_genbank.wdl
+++ b/pipes/WDL/workflows/sarscov2_sra_to_genbank.wdl
@@ -197,7 +197,8 @@ workflow sarscov2_sra_to_genbank {
       input:
         source_modifier_table = biosample_to_genbank.genbank_source_modifier_table,
         structured_comments = structured_comments.structured_comment_table,
-        out_name = "gisaid_meta.tsv"
+        out_name = "gisaid_meta.tsv",
+        strict = false
     }
 
     #### summary stats

--- a/pipes/WDL/workflows/sarscov2_sra_to_genbank.wdl
+++ b/pipes/WDL/workflows/sarscov2_sra_to_genbank.wdl
@@ -1,0 +1,250 @@
+version 1.0
+
+import "../tasks/tasks_read_utils.wdl" as read_utils
+import "../tasks/tasks_ncbi.wdl" as ncbi
+import "../tasks/tasks_ncbi_tools.wdl" as ncbi_tools
+import "../tasks/tasks_nextstrain.wdl" as nextstrain
+
+import "assemble_refbased.wdl"
+import "sarscov2_lineages.wdl"
+
+workflow sarscov2_illumina_full {
+    meta {
+        description: "Full SARS-CoV-2 analysis workflow starting from SRA data and metadata and performing assembly, spike-in analysis, qc, lineage assignment, and packaging assemblies for data release."
+        author: "Broad Viral Genomics"
+        email:  "viral-ngs@broadinstitute.org"
+    }
+
+    parameter_meta {
+        samplesheets: {
+            description: "Custom formatted 'extended' format tsv samplesheets that will override any SampleSheet.csv in the illumina BCL directory. Must supply one file per lane of the flowcell, and must provide them in lane order. Required tsv column headings are: sample, library_id_per_sample, barcode_1, barcode_2 (if paired reads, omit if single-end), library_strategy, library_source, library_selection, design_description. 'sample' must correspond to a biological sample. 'sample' x 'library_id_per_sample' must be unique within a samplesheet and correspond to independent libraries from the same original sample. barcode_1 and barcode_2 must correspond to the actual index sequence. Remaining columns must follow strict ontology: see 3rd tab of https://www.ncbi.nlm.nih.gov/core/assets/sra/files/SRA_metadata_acc_example.xlsx for controlled vocabulary and term definitions.",
+            patterns: ["*.txt", "*.tsv"]
+        }
+
+        reference_fasta: {
+            description: "Reference genome to align reads to.",
+            patterns: ["*.fasta"]
+        }
+        amplicon_bed_prefix: {
+            description: "amplicon primers to trim in reference coordinate space (0-based BED format)",
+            patterns: ["*.bed"]
+        }
+
+        biosample_attributes: {
+          description: "A post-submission attributes file from NCBI BioSample, which is available at https://submit.ncbi.nlm.nih.gov/subs/ and clicking on 'Download attributes file with BioSample accessions'. The 'sample_name' column must match the external_ids used in sample_rename_map (or internal ids if sample_rename_map is omitted).",
+          patterns: ["*.txt", "*.tsv"]
+        }
+
+    }
+
+    input {
+        Array[String] SRX_accessions
+
+        File          reference_fasta
+        File          amplicon_bed_default
+
+        Int           min_genome_bases = 20000
+    }
+    Int     taxid = 2697049
+    String  gisaid_prefix = 'hCoV-19/'
+
+    ### demux, deplete, SRA submission prep, fastqc/multiqc
+    call demux_deplete.demux_deplete {
+        input:
+            biosample_map = biosample_attributes
+    }
+
+    ### gather data by biosample
+    call read_utils.group_bams_by_sample {
+        input:
+            bam_filepaths = demux_deplete.cleaned_reads_unaligned_bams
+    }
+
+    ### assembly and analyses per biosample
+    scatter(name_reads in zip(group_bams_by_sample.sample_names, group_bams_by_sample.grouped_bam_filepaths)) {
+        Boolean ampseq = (demux_deplete.meta_by_sample[name_reads.left]["amplicon_set"] != "")
+        String orig_name = demux_deplete.meta_by_sample[name_reads.left]["sample_original"]
+
+        # assemble genome
+        if (ampseq) {
+            String trim_coords_bed = amplicon_bed_prefix + demux_deplete.meta_by_sample[name_reads.left]["amplicon_set"] + ".bed"
+        }
+        call assemble_refbased.assemble_refbased {
+            input:
+                reads_unmapped_bams = name_reads.right,
+                reference_fasta = reference_fasta,
+                sample_name = name_reads.left,
+                aligner = "minimap2",
+                skip_mark_dupes = ampseq,
+                trim_coords_bed = trim_coords_bed,
+                min_coverage = if ampseq then 20 else 3
+        }
+
+        # log controls
+        if (demux_deplete.meta_by_sample[name_reads.left]["control"] == 'NTC') {
+            Int ntc_bases = assemble_refbased.assembly_length_unambiguous
+        }
+
+        # for genomes that somewhat assemble
+        if (assemble_refbased.assembly_length_unambiguous >= min_genome_bases) {
+            call ncbi.rename_fasta_header {
+              input:
+                genome_fasta = assemble_refbased.assembly_fasta,
+                new_name = orig_name
+            }
+
+            File passing_assemblies = rename_fasta_header.renamed_fasta
+            String passing_assembly_ids = orig_name
+            Array[String] assembly_cmt = [orig_name, "Broad viral-ngs v. " + demux_deplete.demux_viral_core_version, assemble_refbased.assembly_mean_coverage]
+
+            # lineage assignment
+            call sarscov2_lineages.sarscov2_lineages {
+                input:
+                    genome_fasta = passing_assemblies
+            }
+
+            # VADR annotation & QC
+            call ncbi.vadr {
+              input:
+                genome_fasta = passing_assemblies
+            }
+            if (vadr.num_alerts==0) {
+              File submittable_genomes = passing_assemblies
+              String submittable_id = orig_name
+            }
+            if (vadr.num_alerts>0) {
+              String failed_annotation_id = orig_name
+            }
+        }
+        if (assemble_refbased.assembly_length_unambiguous < min_genome_bases) {
+            String failed_assembly_id = orig_name
+        }
+
+        Map[String,String?] assembly_stats = {
+            'sample_orig': orig_name,
+            'sample': name_reads.left,
+            'amplicon_set': demux_deplete.meta_by_sample[name_reads.left]["amplicon_set"],
+            'assembly_mean_coverage': assemble_refbased.assembly_mean_coverage,
+            'nextclade_clade':   sarscov2_lineages.nextclade_clade,
+            'nextclade_aa_subs': sarscov2_lineages.nextclade_aa_subs,
+            'nextclade_aa_dels': sarscov2_lineages.nextclade_aa_dels,
+            'pango_lineage':     sarscov2_lineages.pango_lineage
+        }
+        Map[String,File?] assembly_files = {
+            'assembly_fasta':           assemble_refbased.assembly_fasta,
+            'coverage_plot':            assemble_refbased.align_to_ref_merged_coverage_plot,
+            'aligned_bam':              assemble_refbased.align_to_ref_merged_aligned_trimmed_only_bam,
+            'replicate_discordant_vcf': assemble_refbased.replicate_discordant_vcf,
+            'nextclade_tsv': sarscov2_lineages.nextclade_tsv,
+            'pangolin_csv':  sarscov2_lineages.pangolin_csv,
+            'vadr_tgz': vadr.outputs_tgz
+        }
+        Map[String,Int?] assembly_metrics = {
+            'assembly_length_unambiguous': assemble_refbased.assembly_length_unambiguous,
+            'dist_to_ref_snps':            assemble_refbased.dist_to_ref_snps,
+            'dist_to_ref_indels':          assemble_refbased.dist_to_ref_indels,
+            'replicate_concordant_sites':  assemble_refbased.replicate_concordant_sites,
+            'replicate_discordant_snps':   assemble_refbased.replicate_discordant_snps,
+            'replicate_discordant_indels': assemble_refbased.replicate_discordant_indels,
+            'num_read_groups':             assemble_refbased.num_read_groups,
+            'num_libraries':               assemble_refbased.num_libraries,
+            'vadr_num_alerts': vadr.num_alerts
+        }
+
+    }
+
+    # TO DO: filter out genomes from submission that are less than ntc_bases.max
+    call read_utils.max as ntc {
+      input:
+        list = select_all(ntc_bases)
+    }
+
+    ### prep genbank submission
+    call nextstrain.concatenate as submit_genomes {
+      input:
+        infiles = select_all(submittable_genomes),
+        output_name = "assemblies.fasta"
+    }
+    call ncbi.biosample_to_genbank {
+      input:
+        biosample_attributes = biosample_attributes,
+        num_segments = 1,
+        taxid = taxid,
+        filter_to_ids = write_lines(select_all(submittable_id))
+    }
+    call ncbi.structured_comments {
+      input:
+        assembly_stats_tsv = write_tsv(flatten([[['SeqID','Assembly Method','Coverage']],select_all(assembly_cmt)])),
+        filter_to_ids = write_lines(select_all(submittable_id))
+    }
+    call ncbi.package_genbank_ftp_submission {
+      input:
+        sequences_fasta = submit_genomes.combined,
+        source_modifier_table = biosample_to_genbank.genbank_source_modifier_table,
+        structured_comment_table = structured_comments.structured_comment_table
+    }
+
+    ### prep gisaid submission
+    call ncbi.prefix_fasta_header as prefix_gisaid {
+      input:
+        genome_fasta = submit_genomes.combined,
+        prefix = gisaid_prefix
+    }
+    call ncbi.gisaid_meta_prep {
+      input:
+        source_modifier_table = biosample_to_genbank.genbank_source_modifier_table,
+        structured_comments = structured_comments.structured_comment_table,
+        out_name = "gisaid_meta.tsv"
+    }
+
+    output {
+        Array[File] raw_reads_unaligned_bams     = demux_deplete.raw_reads_unaligned_bams
+        Array[File] cleaned_reads_unaligned_bams = demux_deplete.cleaned_reads_unaligned_bams
+        Array[File] cleaned_bams_tiny            = demux_deplete.cleaned_bams_tiny
+
+        File meta_by_filename_json = demux_deplete.meta_by_filename_json
+
+        Array[Int]  read_counts_raw       = demux_deplete.read_counts_raw
+        Array[Int]  read_counts_depleted  = demux_deplete.read_counts_depleted
+
+        File        sra_metadata          = select_first([demux_deplete.sra_metadata])
+
+        Array[File] assemblies_fasta = assemble_refbased.assembly_fasta
+        Array[File] passing_assemblies_fasta = select_all(passing_assemblies)
+        Array[File] submittable_assemblies_fasta = select_all(submittable_genomes)
+
+        Int         max_ntc_bases = ntc.max
+
+        Array[File] demux_metrics            = demux_deplete.demux_metrics
+        Array[File] demux_commonBarcodes     = demux_deplete.demux_commonBarcodes
+        Array[File] demux_outlierBarcodes    = demux_deplete.demux_outlierBarcodes
+
+        File        multiqc_report_raw     = demux_deplete.multiqc_report_raw
+        File        multiqc_report_cleaned = demux_deplete.multiqc_report_cleaned
+        File        spikein_counts         = demux_deplete.spikein_counts
+
+        Array[Map[String,String?]] per_assembly_stats = assembly_stats
+        Array[Map[String,File?]]   per_assembly_files = assembly_files
+        Array[Map[String,Int?]]    per_assembly_metrics = assembly_metrics
+
+        File submission_zip = package_genbank_ftp_submission.submission_zip
+        File submission_xml = package_genbank_ftp_submission.submission_xml
+        File submit_ready   = package_genbank_ftp_submission.submit_ready
+        Array[File] vadr_outputs = select_all(vadr.outputs_tgz)
+        File genbank_source_table = biosample_to_genbank.genbank_source_modifier_table
+
+        File gisaid_fasta = prefix_gisaid.renamed_fasta
+        File gisaid_meta_tsv = gisaid_meta_prep.meta_tsv
+
+        Array[String] assembled_ids = select_all(passing_assembly_ids)
+        Array[String] submittable_ids = select_all(submittable_id)
+        Array[String] failed_assembly_ids = select_all(failed_assembly_id)
+        Array[String] failed_annotation_ids = select_all(failed_annotation_id)
+        Int           num_read_files = length(demux_deplete.cleaned_reads_unaligned_bams)
+        Int           num_assembled = length(select_all(passing_assemblies))
+        Int           num_failed_assembly = length(select_all(failed_assembly_id))
+        Int           num_submittable = length(select_all(submittable_id))
+        Int           num_failed_annotation = length(select_all(failed_annotation_id))
+        Int           num_samples = length(group_bams_by_sample.sample_names)
+    }
+}

--- a/test/input/WDL/test_outputs-sarscov2_lineages-local.json
+++ b/test/input/WDL/test_outputs-sarscov2_lineages-local.json
@@ -2,5 +2,5 @@
   "sarscov2_lineages.nextclade_clade": "20A",
   "sarscov2_lineages.nextclade_aa_subs": "ORF1b:P314L,ORF3a:Q57H,S:D614G",
   "sarscov2_lineages.nextclade_aa_dels": "",
-  "sarscov2_lineages.pangolin_clade": "B.1"
+  "sarscov2_lineages.pango_lineage": "B.1"
 }


### PR DESCRIPTION
- new workflow: `sarscov2_sra_to_genbank` -- this takes sequencing reads from INSDC (via NCBI SRA), assembles, annotates, and QCs genomes, and produces Genbank and GISAID submission bundles based on the metadata in NCBI (SRA and BioSample). The Genbank submission will be tied to the same source BioProject and BioSamples that the reads were linked to in SRA. This workflow is able to merge together multiple read sets (SRA records) from the same BioSample and produce one assembly per BioSample. It will automatically detect sequencing platform (only Illumina and Oxford Nanopore currently supported) as well as amplicon vs metagenomic library designs based on the SRA metadata, and assemble appropriately. This has been tested on Illumina reads, ONT reads, amplicon libraries, metagenomic libraries, reads submitted to NCBI SRA, and reads originally submitted to ENA and synced with NCBI.
- `sarscov2_lineages` and `sarscov2_illumina_full`: output variable name change from "pangolin_clade" to "pango_lineage" (to stay consistent with terminology used by the authors)
- `sarscov2_illumina_full`: replace the first several steps with an invocation of `demux_deplete` as a subworkflow