### PR TITLE
sarscov2 large workflow improvements

### DIFF
--- a/pipes/WDL/tasks/tasks_assembly.wdl
+++ b/pipes/WDL/tasks/tasks_assembly.wdl
@@ -418,7 +418,7 @@ task refine_assembly_with_aligned_reads {
 
     runtime {
         docker: "${docker}"
-        memory: select_first([machine_mem_gb, 7]) + " GB"
+        memory: select_first([machine_mem_gb, 15]) + " GB"
         cpu: 8
         disks: "local-disk 375 LOCAL"
         dx_instance_type: "mem1_ssd1_v2_x8"

--- a/pipes/WDL/tasks/tasks_ncbi.wdl
+++ b/pipes/WDL/tasks/tasks_ncbi.wdl
@@ -353,7 +353,7 @@ task gisaid_meta_prep {
             'covv_seq_technology': sample_to_cmt[row['Sequence_ID']]['Sequencing Technology'],
 
             'covv_orig_lab': row['collected_by'],
-            'covv_subm_lab': "~{default='REQUIRED' submitting_lab_name}"
+            'covv_subm_lab': "~{default='REQUIRED' submitting_lab_name}",
             'covv_authors': "~{default='REQUIRED' authors}",
             'covv_orig_lab_addr': "~{default='REQUIRED' originating_lab_addr}",
             'covv_subm_lab_addr': "~{default='REQUIRED' submitting_lab_addr}",

--- a/pipes/WDL/tasks/tasks_ncbi.wdl
+++ b/pipes/WDL/tasks/tasks_ncbi.wdl
@@ -308,6 +308,12 @@ task gisaid_meta_prep {
     String out_name
     String continent = "North America"
     Boolean strict = true
+    String? username
+    String? submitting_lab_name
+    String? submitting_lab_addr
+    String? originating_lab_addr
+    String? authors
+    String? fasta_filename
   }
   command <<<
     python3 << CODE
@@ -347,12 +353,12 @@ task gisaid_meta_prep {
             'covv_seq_technology': sample_to_cmt[row['Sequence_ID']]['Sequencing Technology'],
 
             'covv_orig_lab': row['collected_by'],
-            'covv_subm_lab': 'REQUIRED',
-            'covv_authors': 'REQUIRED',
-            'covv_orig_lab_addr': 'REQUIRED',
-            'covv_subm_lab_addr': 'REQUIRED',
-            'submitter': 'REQUIRED',
-            'fn': 'REQUIRED',
+            'covv_subm_lab': "~{default='REQUIRED' submitting_lab_name}"
+            'covv_authors': "~{default='REQUIRED' authors}",
+            'covv_orig_lab_addr': "~{default='REQUIRED' originating_lab_addr}",
+            'covv_subm_lab_addr': "~{default='REQUIRED' submitting_lab_addr}",
+            'submitter': "~{default='REQUIRED' username}",
+            'fn': "~{default='REQUIRED' fasta_filename}",
           })
 
           #covv_specimen

--- a/pipes/WDL/tasks/tasks_ncbi.wdl
+++ b/pipes/WDL/tasks/tasks_ncbi.wdl
@@ -252,8 +252,8 @@ task prefix_fasta_header {
   input {
     File    genome_fasta
     String  prefix
+    String  out_basename = basename(genome_fasta, ".fasta")
   }
-  String  out_basename = basename(genome_fasta, ".fasta")
   command <<<
     set -e
     python3 <<CODE

--- a/pipes/WDL/tasks/tasks_ncbi.wdl
+++ b/pipes/WDL/tasks/tasks_ncbi.wdl
@@ -551,10 +551,12 @@ task biosample_to_genbank {
         --biosample_in_smt \
         --iso_dates \
         --loglevel DEBUG
+    cut -f 1 "${base}.genbank.src" | tail +2 > "${base}.sample_ids.txt"
   }
   output {
     File genbank_source_modifier_table = "${base}.genbank.src"
     File biosample_map                 = "${base}.biosample.map.txt"
+    File sample_ids                    = "${base}.sample_ids.txt"
   }
   runtime {
     docker: docker

--- a/pipes/WDL/tasks/tasks_read_utils.wdl
+++ b/pipes/WDL/tasks/tasks_read_utils.wdl
@@ -12,7 +12,7 @@ task max {
     CODE
   >>>
   output {
-    Int max = read_int(stdout())
+    Int out = read_int(stdout())
   }
   runtime {
     docker: "python:slim"

--- a/pipes/WDL/workflows/demux_deplete.wdl
+++ b/pipes/WDL/workflows/demux_deplete.wdl
@@ -152,6 +152,7 @@ workflow demux_deplete {
         Array[Int]  read_counts_depleted = deplete.depletion_read_count_post
 
         File?       sra_metadata          = sra_meta_prep.sra_metadata
+        File?       cleaned_bam_uris      = sra_meta_prep.cleaned_bam_uris
 
         Array[File] demux_metrics         = illumina_demux.metrics
         Array[File] demux_commonBarcodes  = illumina_demux.commonBarcodes

--- a/pipes/WDL/workflows/sarscov2_illumina_full.wdl
+++ b/pipes/WDL/workflows/sarscov2_illumina_full.wdl
@@ -228,6 +228,7 @@ workflow sarscov2_illumina_full {
       input:
         source_modifier_table = biosample_to_genbank.genbank_source_modifier_table,
         structured_comments = structured_comments.structured_comment_table,
+        fasta_filename = "gisaid-sequences-~{flowcell_id}.fasta",
         out_name = "gisaid-meta-~{flowcell_id}.tsv"
     }
 

--- a/pipes/WDL/workflows/sarscov2_illumina_full.wdl
+++ b/pipes/WDL/workflows/sarscov2_illumina_full.wdl
@@ -46,7 +46,7 @@ workflow sarscov2_illumina_full {
         String        instrument_model
         String        sra_title
 
-        Int           min_genome_bases = 20000
+        Int           min_genome_bases = 15000
     }
     Int     taxid = 2697049
     String  gisaid_prefix = 'hCoV-19/'
@@ -131,37 +131,6 @@ workflow sarscov2_illumina_full {
         }
         if (assemble_refbased.assembly_length_unambiguous < min_genome_bases) {
             String failed_assembly_id = orig_name
-        }
-
-        Map[String,String?] assembly_stats = {
-            'sample_orig': orig_name,
-            'sample': name_reads.left,
-            'amplicon_set': demux_deplete.meta_by_sample[name_reads.left]["amplicon_set"],
-            'assembly_mean_coverage': assemble_refbased.assembly_mean_coverage,
-            'nextclade_clade':   sarscov2_lineages.nextclade_clade,
-            'nextclade_aa_subs': sarscov2_lineages.nextclade_aa_subs,
-            'nextclade_aa_dels': sarscov2_lineages.nextclade_aa_dels,
-            'pango_lineage':     sarscov2_lineages.pango_lineage
-        }
-        Map[String,File?] assembly_files = {
-            'assembly_fasta':           assemble_refbased.assembly_fasta,
-            'coverage_plot':            assemble_refbased.align_to_ref_merged_coverage_plot,
-            'aligned_bam':              assemble_refbased.align_to_ref_merged_aligned_trimmed_only_bam,
-            'replicate_discordant_vcf': assemble_refbased.replicate_discordant_vcf,
-            'nextclade_tsv': sarscov2_lineages.nextclade_tsv,
-            'pangolin_csv':  sarscov2_lineages.pangolin_csv,
-            'vadr_tgz': vadr.outputs_tgz
-        }
-        Map[String,Int?] assembly_metrics = {
-            'assembly_length_unambiguous': assemble_refbased.assembly_length_unambiguous,
-            'dist_to_ref_snps':            assemble_refbased.dist_to_ref_snps,
-            'dist_to_ref_indels':          assemble_refbased.dist_to_ref_indels,
-            'replicate_concordant_sites':  assemble_refbased.replicate_concordant_sites,
-            'replicate_discordant_snps':   assemble_refbased.replicate_discordant_snps,
-            'replicate_discordant_indels': assemble_refbased.replicate_discordant_indels,
-            'num_read_groups':             assemble_refbased.num_read_groups,
-            'num_libraries':               assemble_refbased.num_libraries,
-            'vadr_num_alerts': vadr.num_alerts
         }
 
         Array[String] assembly_tsv_row = [
@@ -282,9 +251,6 @@ workflow sarscov2_illumina_full {
         File        multiqc_report_cleaned = demux_deplete.multiqc_report_cleaned
         File        spikein_counts         = demux_deplete.spikein_counts
 
-        Array[Map[String,String?]] per_assembly_stats = assembly_stats
-        Array[Map[String,File?]]   per_assembly_files = assembly_files
-        Array[Map[String,Int?]]    per_assembly_metrics = assembly_metrics
         File assembly_stats_tsv = assembly_meta_tsv.combined
 
         File submission_zip = package_genbank_ftp_submission.submission_zip

--- a/pipes/WDL/workflows/sarscov2_illumina_full.wdl
+++ b/pipes/WDL/workflows/sarscov2_illumina_full.wdl
@@ -191,6 +191,12 @@ workflow sarscov2_illumina_full {
         'replicate_concordant_sites', 'replicate_discordant_snps', 'replicate_discordant_indels', 'num_read_groups', 'num_libraries',
         ]
 
+    call nextstrain.concatenate as assembly_meta_tsv {
+      input:
+        infiles = [write_tsv([assembly_tsv_header]), write_tsv(assembly_tsv_row)],
+        output_name = "assembly_metadata.tsv"
+    }
+
 
     # TO DO: filter out genomes from submission that are less than ntc_max.out
     call read_utils.max as ntc_max {
@@ -265,7 +271,7 @@ workflow sarscov2_illumina_full {
         Array[Map[String,String?]] per_assembly_stats = assembly_stats
         Array[Map[String,File?]]   per_assembly_files = assembly_files
         Array[Map[String,Int?]]    per_assembly_metrics = assembly_metrics
-        File assembly_stats_tsv = write_tsv(flatten([[assembly_tsv_header],assembly_tsv_row]))
+        File assembly_stats_tsv = assembly_meta_tsv.combined
 
         File submission_zip = package_genbank_ftp_submission.submission_zip
         File submission_xml = package_genbank_ftp_submission.submission_xml

--- a/pipes/WDL/workflows/sarscov2_illumina_full.wdl
+++ b/pipes/WDL/workflows/sarscov2_illumina_full.wdl
@@ -224,7 +224,7 @@ workflow sarscov2_illumina_full {
     call ncbi.structured_comments {
       input:
         assembly_stats_tsv = write_tsv(flatten([[['SeqID','Assembly Method','Coverage']],select_all(assembly_cmt)])),
-        filter_to_ids = write_lines(select_all(submittable_id))
+        filter_to_ids = biosample_to_genbank.sample_ids
     }
     call nextstrain.concatenate as passing_genomes {
       input:

--- a/pipes/WDL/workflows/sarscov2_illumina_full.wdl
+++ b/pipes/WDL/workflows/sarscov2_illumina_full.wdl
@@ -230,6 +230,10 @@ workflow sarscov2_illumina_full {
         Array[Map[String,String?]] per_assembly_stats = assembly_stats
         Array[Map[String,File?]]   per_assembly_files = assembly_files
         Array[Map[String,Int?]]    per_assembly_metrics = assembly_metrics
+        File per_assembly_stats_json   = write_json(assembly_stats)
+        File per_assembly_files_json   = write_json(assembly_files)
+        File per_assembly_metrics_json = write_json(assembly_metrics)
+
 
         File submission_zip = package_genbank_ftp_submission.submission_zip
         File submission_xml = package_genbank_ftp_submission.submission_xml

--- a/pipes/WDL/workflows/sarscov2_illumina_full.wdl
+++ b/pipes/WDL/workflows/sarscov2_illumina_full.wdl
@@ -108,7 +108,7 @@ workflow sarscov2_illumina_full {
 
             File passing_assemblies = rename_fasta_header.renamed_fasta
             String passing_assembly_ids = orig_name
-            Array[String] assembly_cmt = [orig_name, "Broad viral-ngs v. " + demux_deplete.demux_viral_core_version, assemble_refbased.assembly_mean_coverage]
+            Array[String] assembly_cmt = [orig_name, "Broad viral-ngs v. " + demux_deplete.demux_viral_core_version, assemble_refbased.assembly_mean_coverage, instrument_model]
 
             # lineage assignment
             call sarscov2_lineages.sarscov2_lineages {
@@ -192,7 +192,7 @@ workflow sarscov2_illumina_full {
     }
     call ncbi.structured_comments {
       input:
-        assembly_stats_tsv = write_tsv(flatten([[['SeqID','Assembly Method','Coverage']],select_all(assembly_cmt)])),
+        assembly_stats_tsv = write_tsv(flatten([[['SeqID','Assembly Method','Coverage','Sequencing Technology']],select_all(assembly_cmt)])),
         filter_to_ids = biosample_to_genbank.sample_ids
     }
     call nextstrain.concatenate as passing_genomes {

--- a/pipes/WDL/workflows/sarscov2_sra_to_genbank.wdl
+++ b/pipes/WDL/workflows/sarscov2_sra_to_genbank.wdl
@@ -36,7 +36,7 @@ workflow sarscov2_sra_to_genbank {
         File          amplicon_bed_default
         File          spikein_db
 
-        Int           min_genome_bases = 20000
+        Int           min_genome_bases = 15000
         Int           min_reads_per_bam = 100
     }
     Int     taxid = 2697049


### PR DESCRIPTION
Improvements to `sarscov2_illumina_full` and `sarscov2_sra_to_genbank`:
 - filter genbank/gisaid submission packages to only sequences present in biosample attributes file
 - relax minimum genome unambig bp cutoff from 20kb to 15kb
 - allow for merging multiple biosample attributes tsvs together in `sarscov2_illumina_full`
 - add "Sequencing Technology" column to both genbank and gisaid submission packages
 - greatly simplify the final assembly metrics metadata output from both workflows (single tsv instead of compound array structures)
 - makes filename outputs a bit more organized
 - exposes cleaned_bam_uris text file output for easy SRA submission

Also increases default RAM for GATK UG consensus calling from 7GB to 15GB. We need to replace that step in viral-assembly.