### PR TITLE
propagate purpose of sequencing to genbank and gisaid

### DIFF
--- a/pipes/WDL/tasks/tasks_interhost.wdl
+++ b/pipes/WDL/tasks/tasks_interhost.wdl
@@ -9,7 +9,7 @@ task multi_align_mafft_ref {
     Float?         mafft_gapOpeningPenalty
 
     Int?           machine_mem_gb
-    String         docker="quay.io/broadinstitute/viral-phylo:2.1.19.0"
+    String         docker="quay.io/broadinstitute/viral-phylo:2.1.19.1"
   }
 
   String           fasta_basename = basename(reference_fasta, '.fasta')
@@ -53,7 +53,7 @@ task multi_align_mafft {
     Float?         mafft_gapOpeningPenalty
 
     Int?           machine_mem_gb
-    String         docker="quay.io/broadinstitute/viral-phylo:2.1.19.0"
+    String         docker="quay.io/broadinstitute/viral-phylo:2.1.19.1"
   }
 
   command {
@@ -252,7 +252,7 @@ task merge_vcfs_gatk {
     File        ref_fasta
 
     Int?     machine_mem_gb
-    String   docker="quay.io/broadinstitute/viral-phylo:2.1.19.0"
+    String   docker="quay.io/broadinstitute/viral-phylo:2.1.19.1"
 
     String   output_prefix = "merged"
   }

--- a/pipes/WDL/tasks/tasks_interhost.wdl
+++ b/pipes/WDL/tasks/tasks_interhost.wdl
@@ -9,7 +9,7 @@ task multi_align_mafft_ref {
     Float?         mafft_gapOpeningPenalty
 
     Int?           machine_mem_gb
-    String         docker="quay.io/broadinstitute/viral-phylo:2.1.16.0"
+    String         docker="quay.io/broadinstitute/viral-phylo:2.1.19.0"
   }
 
   String           fasta_basename = basename(reference_fasta, '.fasta')
@@ -53,7 +53,7 @@ task multi_align_mafft {
     Float?         mafft_gapOpeningPenalty
 
     Int?           machine_mem_gb
-    String         docker="quay.io/broadinstitute/viral-phylo:2.1.16.0"
+    String         docker="quay.io/broadinstitute/viral-phylo:2.1.19.0"
   }
 
   command {
@@ -252,7 +252,7 @@ task merge_vcfs_gatk {
     File        ref_fasta
 
     Int?     machine_mem_gb
-    String   docker="quay.io/broadinstitute/viral-phylo:2.1.16.0"
+    String   docker="quay.io/broadinstitute/viral-phylo:2.1.19.0"
 
     String   output_prefix = "merged"
   }

--- a/pipes/WDL/tasks/tasks_intrahost.wdl
+++ b/pipes/WDL/tasks/tasks_intrahost.wdl
@@ -11,7 +11,7 @@ task isnvs_per_sample {
     Boolean removeDoublyMappedReads=true
 
     Int?    machine_mem_gb
-    String  docker="quay.io/broadinstitute/viral-phylo:2.1.16.0"
+    String  docker="quay.io/broadinstitute/viral-phylo:2.1.19.0"
 
     String  sample_name = basename(basename(basename(mapped_bam, ".bam"), ".all"), ".mapped")
   }
@@ -52,7 +52,7 @@ task isnvs_vcf {
     Boolean        naiveFilter=false
 
     Int?           machine_mem_gb
-    String         docker="quay.io/broadinstitute/viral-phylo:2.1.16.0"
+    String         docker="quay.io/broadinstitute/viral-phylo:2.1.19.0"
   }
 
   parameter_meta {
@@ -125,7 +125,7 @@ task annotate_vcf_snpeff {
     String?        emailAddress
 
     Int?           machine_mem_gb
-    String         docker="quay.io/broadinstitute/viral-phylo:2.1.16.0"
+    String         docker="quay.io/broadinstitute/viral-phylo:2.1.19.0"
 
     String         output_basename = basename(basename(in_vcf, ".gz"), ".vcf")
   }

--- a/pipes/WDL/tasks/tasks_intrahost.wdl
+++ b/pipes/WDL/tasks/tasks_intrahost.wdl
@@ -11,7 +11,7 @@ task isnvs_per_sample {
     Boolean removeDoublyMappedReads=true
 
     Int?    machine_mem_gb
-    String  docker="quay.io/broadinstitute/viral-phylo:2.1.19.0"
+    String  docker="quay.io/broadinstitute/viral-phylo:2.1.19.1"
 
     String  sample_name = basename(basename(basename(mapped_bam, ".bam"), ".all"), ".mapped")
   }
@@ -52,7 +52,7 @@ task isnvs_vcf {
     Boolean        naiveFilter=false
 
     Int?           machine_mem_gb
-    String         docker="quay.io/broadinstitute/viral-phylo:2.1.19.0"
+    String         docker="quay.io/broadinstitute/viral-phylo:2.1.19.1"
   }
 
   parameter_meta {
@@ -125,7 +125,7 @@ task annotate_vcf_snpeff {
     String?        emailAddress
 
     Int?           machine_mem_gb
-    String         docker="quay.io/broadinstitute/viral-phylo:2.1.19.0"
+    String         docker="quay.io/broadinstitute/viral-phylo:2.1.19.1"
 
     String         output_basename = basename(basename(in_vcf, ".gz"), ".vcf")
   }

--- a/pipes/WDL/tasks/tasks_ncbi.wdl
+++ b/pipes/WDL/tasks/tasks_ncbi.wdl
@@ -25,7 +25,7 @@ task download_fasta {
     Array[String]+ accessions
     String         emailAddress
 
-    String         docker="quay.io/broadinstitute/viral-phylo:2.1.19.0"
+    String         docker="quay.io/broadinstitute/viral-phylo:2.1.19.1"
   }
 
   command {
@@ -56,7 +56,7 @@ task download_annotations {
     String         emailAddress
     String         combined_out_prefix
 
-    String         docker="quay.io/broadinstitute/viral-phylo:2.1.19.0"
+    String         docker="quay.io/broadinstitute/viral-phylo:2.1.19.1"
   }
 
   command {
@@ -100,7 +100,7 @@ task annot_transfer {
     File         reference_fasta
     Array[File]+ reference_feature_table
 
-    String  docker="quay.io/broadinstitute/viral-phylo:2.1.19.0"
+    String  docker="quay.io/broadinstitute/viral-phylo:2.1.19.1"
   }
 
   parameter_meta {
@@ -153,7 +153,7 @@ task align_and_annot_transfer_single {
     Array[File]+ reference_fastas
     Array[File]+ reference_feature_tables
 
-    String  docker="quay.io/broadinstitute/viral-phylo:2.1.19.0"
+    String  docker="quay.io/broadinstitute/viral-phylo:2.1.19.1"
   }
 
   parameter_meta {
@@ -545,7 +545,7 @@ task biosample_to_genbank {
     File? filter_to_ids
 
     Boolean s_dropout_note=true
-    String  docker="quay.io/broadinstitute/viral-phylo:2.1.19.0"
+    String  docker="quay.io/broadinstitute/viral-phylo:2.1.19.1"
   }
   String base = basename(biosample_attributes, ".txt")
   command {
@@ -597,7 +597,7 @@ task prepare_genbank {
     String?      assembly_method_version
 
     Int?         machine_mem_gb
-    String       docker="quay.io/broadinstitute/viral-phylo:2.1.19.0"
+    String       docker="quay.io/broadinstitute/viral-phylo:2.1.19.1"
   }
 
   parameter_meta {

--- a/pipes/WDL/tasks/tasks_ncbi.wdl
+++ b/pipes/WDL/tasks/tasks_ncbi.wdl
@@ -25,7 +25,7 @@ task download_fasta {
     Array[String]+ accessions
     String         emailAddress
 
-    String         docker="quay.io/broadinstitute/viral-phylo:2.1.16.0"
+    String         docker="quay.io/broadinstitute/viral-phylo:2.1.19.0"
   }
 
   command {
@@ -56,7 +56,7 @@ task download_annotations {
     String         emailAddress
     String         combined_out_prefix
 
-    String         docker="quay.io/broadinstitute/viral-phylo:2.1.16.0"
+    String         docker="quay.io/broadinstitute/viral-phylo:2.1.19.0"
   }
 
   command {
@@ -100,7 +100,7 @@ task annot_transfer {
     File         reference_fasta
     Array[File]+ reference_feature_table
 
-    String  docker="quay.io/broadinstitute/viral-phylo:2.1.16.0"
+    String  docker="quay.io/broadinstitute/viral-phylo:2.1.19.0"
   }
 
   parameter_meta {
@@ -153,7 +153,7 @@ task align_and_annot_transfer_single {
     Array[File]+ reference_fastas
     Array[File]+ reference_feature_tables
 
-    String  docker="quay.io/broadinstitute/viral-phylo:2.1.16.0"
+    String  docker="quay.io/broadinstitute/viral-phylo:2.1.19.0"
   }
 
   parameter_meta {
@@ -357,8 +357,11 @@ task gisaid_meta_prep {
             'covv_authors': "~{default='REQUIRED' authors}",
             'covv_orig_lab_addr': "~{default='REQUIRED' originating_lab_addr}",
             'covv_subm_lab_addr': "~{default='REQUIRED' submitting_lab_addr}",
+
             'submitter': "~{default='REQUIRED' username}",
             'fn': "~{default='REQUIRED' fasta_filename}",
+
+            'covv_add_host_info': row.get('note',''),
           })
 
           #covv_specimen
@@ -541,7 +544,8 @@ task biosample_to_genbank {
 
     File? filter_to_ids
 
-    String  docker="quay.io/broadinstitute/viral-phylo:2.1.16.0"
+    Boolean s_dropout_note=true
+    String  docker="quay.io/broadinstitute/viral-phylo:2.1.19.0"
   }
   String base = basename(biosample_attributes, ".txt")
   command {
@@ -556,6 +560,7 @@ task biosample_to_genbank {
         ${'--filter_to_samples ' + filter_to_ids} \
         --biosample_in_smt \
         --iso_dates \
+        ~{true="--sgtf_override" s_dropout_note} \
         --loglevel DEBUG
     cut -f 1 "${base}.genbank.src" | tail +2 > "${base}.sample_ids.txt"
   }
@@ -592,7 +597,7 @@ task prepare_genbank {
     String?      assembly_method_version
 
     Int?         machine_mem_gb
-    String       docker="quay.io/broadinstitute/viral-phylo:2.1.16.0"
+    String       docker="quay.io/broadinstitute/viral-phylo:2.1.19.0"
   }
 
   parameter_meta {

--- a/pipes/WDL/tasks/tasks_ncbi.wdl
+++ b/pipes/WDL/tasks/tasks_ncbi.wdl
@@ -560,7 +560,7 @@ task biosample_to_genbank {
         ${'--filter_to_samples ' + filter_to_ids} \
         --biosample_in_smt \
         --iso_dates \
-        ~{true="--sgtf_override" s_dropout_note} \
+        ~{true="--sgtf_override" false="" s_dropout_note} \
         --loglevel DEBUG
     cut -f 1 "${base}.genbank.src" | tail +2 > "${base}.sample_ids.txt"
   }

--- a/pipes/WDL/tasks/tasks_nextstrain.wdl
+++ b/pipes/WDL/tasks/tasks_nextstrain.wdl
@@ -412,7 +412,7 @@ task mafft_one_chr {
         Boolean  large = false
         Boolean  memsavetree = false
 
-        String   docker = "quay.io/broadinstitute/viral-phylo:2.1.19.0"
+        String   docker = "quay.io/broadinstitute/viral-phylo:2.1.19.1"
         Int      mem_size = 250
         Int      cpus = 32
     }

--- a/pipes/WDL/tasks/tasks_nextstrain.wdl
+++ b/pipes/WDL/tasks/tasks_nextstrain.wdl
@@ -412,7 +412,7 @@ task mafft_one_chr {
         Boolean  large = false
         Boolean  memsavetree = false
 
-        String   docker = "quay.io/broadinstitute/viral-phylo:2.1.16.0"
+        String   docker = "quay.io/broadinstitute/viral-phylo:2.1.19.0"
         Int      mem_size = 250
         Int      cpus = 32
     }

--- a/pipes/WDL/workflows/sarscov2_illumina_full.wdl
+++ b/pipes/WDL/workflows/sarscov2_illumina_full.wdl
@@ -161,6 +161,8 @@ workflow sarscov2_illumina_full {
             assemble_refbased.replicate_discordant_indels,
             assemble_refbased.num_read_groups,
             assemble_refbased.num_libraries,
+            assemble_refbased.align_to_ref_merged_reads_aligned,
+            assemble_refbased.align_to_ref_merged_bases_aligned,
         ]
     }
     Array[String] assembly_tsv_header = [
@@ -170,6 +172,7 @@ workflow sarscov2_illumina_full {
         'assembly_fasta', 'coverage_plot', 'aligned_bam', 'replicate_discordant_vcf',
         'nextclade_tsv', 'pangolin_csv', 'vadr_tgz',
         'replicate_concordant_sites', 'replicate_discordant_snps', 'replicate_discordant_indels', 'num_read_groups', 'num_libraries',
+        'align_to_ref_merged_reads_aligned', 'align_to_ref_merged_bases_aligned',
         ]
 
     call nextstrain.concatenate as assembly_meta_tsv {

--- a/pipes/WDL/workflows/sarscov2_sra_to_genbank.wdl
+++ b/pipes/WDL/workflows/sarscov2_sra_to_genbank.wdl
@@ -157,6 +157,8 @@ workflow sarscov2_sra_to_genbank {
             assemble_refbased.replicate_discordant_indels,
             assemble_refbased.num_read_groups,
             assemble_refbased.num_libraries,
+            assemble_refbased.align_to_ref_merged_reads_aligned,
+            assemble_refbased.align_to_ref_merged_bases_aligned,
         ]
     }
 
@@ -167,6 +169,7 @@ workflow sarscov2_sra_to_genbank {
         'assembly_fasta', 'coverage_plot', 'aligned_bam', 'replicate_discordant_vcf',
         'nextclade_tsv', 'pangolin_csv', 'vadr_tgz',
         'replicate_concordant_sites', 'replicate_discordant_snps', 'replicate_discordant_indels', 'num_read_groups', 'num_libraries',
+        'align_to_ref_merged_reads_aligned', 'align_to_ref_merged_bases_aligned',
         ]
 
     call nextstrain.concatenate as assembly_meta_tsv {

--- a/requirements-modules.txt
+++ b/requirements-modules.txt
@@ -1,7 +1,7 @@
 broadinstitute/viral-core=2.1.19
 broadinstitute/viral-assemble=2.1.16.1
 broadinstitute/viral-classify=2.1.16.0
-broadinstitute/viral-phylo=2.1.16.0
+broadinstitute/viral-phylo=2.1.19.0
 broadinstitute/beast-beagle-cuda=1.10.5pre
 broadinstitute/ncbi-tools=2.10.7.1
 nextstrain/base=build-20201214T004216Z

--- a/requirements-modules.txt
+++ b/requirements-modules.txt
@@ -1,7 +1,7 @@
 broadinstitute/viral-core=2.1.19
 broadinstitute/viral-assemble=2.1.16.1
 broadinstitute/viral-classify=2.1.16.0
-broadinstitute/viral-phylo=2.1.19.0
+broadinstitute/viral-phylo=2.1.19.1
 broadinstitute/beast-beagle-cuda=1.10.5pre
 broadinstitute/ncbi-tools=2.10.7.1
 nextstrain/base=build-20201214T004216Z


### PR DESCRIPTION
This PR includes two changes:
1. This propagates the NCBI BioSample's `purpose_of_sequencing` field (or, failing that, the `purpose_of_sampling` field) into the Genbank `note` field and the GISAID `additional_host_info` field, if either are available. If it is set to a PHA4GE-ontology-defined value for Variants of Concern screening, rewrite it to match a SPHERES-ontology-defined value for the same. The relevant python code is in the `viral-phylo` repo.
2. Adds the `align_to_ref_merged_reads_aligned` and `align_to_ref_merged_bases_aligned` columns to the `assembly_stats_tsv` output from `sarscov2_illumina_full` and `sarscov2_sra_to_genbank`
