### PR TITLE
small updates

### DIFF
--- a/pipes/WDL/tasks/tasks_sarscov2.wdl
+++ b/pipes/WDL/tasks/tasks_sarscov2.wdl
@@ -137,7 +137,7 @@ task pangolin_one_sample {
         grep ^lineage transposed.tsv | cut -f 2 | grep -v lineage > PANGOLIN_CLADE
     }
     runtime {
-        docker: "staphb/pangolin:2.1.7-pangolearn-2021-01-20"
+        docker: "staphb/pangolin:2.1.8-pangolearn-2021-01-22"
         memory: "3 GB"
         cpu:    2
         disks: "local-disk 50 HDD"

--- a/pipes/WDL/workflows/sarscov2_genbank.wdl
+++ b/pipes/WDL/workflows/sarscov2_genbank.wdl
@@ -58,7 +58,7 @@ workflow sarscov2_genbank {
         File renamed_assembly = select_first([rename_fasta_header.renamed_fasta, assembly])
         call reports.assembly_bases {
           input:
-            fasta = renamed_assembly
+            fasta = assembly
         }
         call ncbi.vadr {
           input:

--- a/pipes/WDL/workflows/sarscov2_genbank.wdl
+++ b/pipes/WDL/workflows/sarscov2_genbank.wdl
@@ -20,7 +20,8 @@ workflow sarscov2_genbank {
         File          assembly_stats_tsv
         File?         fasta_rename_map
 
-        Int           min_genome_bases = 20000
+        Int           min_genome_bases = 15000
+        Int           max_vadr_alerts = 0
 
         Int           taxid = 2697049
         String        gisaid_prefix = 'hCoV-19/'
@@ -63,7 +64,7 @@ workflow sarscov2_genbank {
           input:
             genome_fasta = renamed_assembly
         }
-        if ( (vadr.num_alerts==0) && (assembly_bases.assembly_length_unambiguous >= min_genome_bases) ) {
+        if ( (vadr.num_alerts<=max_vadr_alerts) && (assembly_bases.assembly_length_unambiguous >= min_genome_bases) ) {
           File passing_assemblies = renamed_assembly
         }
     }

--- a/pipes/WDL/workflows/sarscov2_illumina_full.wdl
+++ b/pipes/WDL/workflows/sarscov2_illumina_full.wdl
@@ -48,6 +48,7 @@ workflow sarscov2_illumina_full {
         String        sra_title
 
         Int           min_genome_bases = 15000
+        Int           max_vadr_alerts = 0
     }
     Int     taxid = 2697049
     String  gisaid_prefix = 'hCoV-19/'
@@ -124,11 +125,11 @@ workflow sarscov2_illumina_full {
               input:
                 genome_fasta = passing_assemblies
             }
-            if (vadr.num_alerts==0) {
+            if (vadr.num_alerts<=max_vadr_alerts) {
               File submittable_genomes = passing_assemblies
               String submittable_id = orig_name
             }
-            if (vadr.num_alerts>0) {
+            if (vadr.num_alerts>max_vadr_alerts) {
               String failed_annotation_id = orig_name
             }
         }

--- a/pipes/WDL/workflows/sarscov2_sra_to_genbank.wdl
+++ b/pipes/WDL/workflows/sarscov2_sra_to_genbank.wdl
@@ -38,6 +38,7 @@ workflow sarscov2_sra_to_genbank {
 
         Int           min_genome_bases = 15000
         Int           min_reads_per_bam = 100
+        Int           max_vadr_alerts = 0
     }
     Int     taxid = 2697049
     String  gisaid_prefix = 'hCoV-19/'
@@ -120,11 +121,11 @@ workflow sarscov2_sra_to_genbank {
               input:
                 genome_fasta = passing_assemblies
             }
-            if (vadr.num_alerts==0) {
+            if (vadr.num_alerts<=max_vadr_alerts) {
               File submittable_genomes = passing_assemblies
               String submittable_id = orig_name
             }
-            if (vadr.num_alerts>0) {
+            if (vadr.num_alerts>max_vadr_alerts) {
               String failed_annotation_id = orig_name
             }
         }

--- a/requirements-modules.txt
+++ b/requirements-modules.txt
@@ -6,5 +6,5 @@ broadinstitute/beast-beagle-cuda=1.10.5pre
 broadinstitute/ncbi-tools=2.10.7.1
 nextstrain/base=build-20201214T004216Z
 andersenlabapps/ivar=1.3
-staphb/pangolin=2.1.7-pangolearn-2021-01-20
+staphb/pangolin=2.1.8-pangolearn-2021-01-22
 neherlab/nextclade=0.12.0


### PR DESCRIPTION
- update staphb/pangolin container to `2.1.8-pangolearn-2021-01-22`
- add `max_vadr_alerts` optional parameter (default 0) to workflows sarscov2_genbank, sarscov2_illumina_full, and sarscov2_sra_to_genbank
- reduce default value of `min_genome_bases` in sarscov2_genbank to match illumina_full and sra_to_genbank