### PR TITLE
pangolin/learn image update and vm shape tuning

### DIFF
--- a/pipes/WDL/tasks/tasks_nextstrain.wdl
+++ b/pipes/WDL/tasks/tasks_nextstrain.wdl
@@ -330,7 +330,7 @@ task nextstrain_build_subsample {
         memory: select_first([machine_mem_gb, 90]) + " GB" # priorities.py on 500k genomes
         cpu :   4
         disks:  "local-disk 375 HDD"
-        dx_instance_type: "mem3_ssd1_v2_x8"
+        dx_instance_type: "mem3_ssd1_v2_x16"
     }
     output {
         File   subsampled_msa = "ncov/results/~{build_name}/subsampled_alignment.fasta"

--- a/pipes/WDL/tasks/tasks_nextstrain.wdl
+++ b/pipes/WDL/tasks/tasks_nextstrain.wdl
@@ -327,7 +327,7 @@ task nextstrain_build_subsample {
     >>>
     runtime {
         docker: docker
-        memory: select_first([machine_mem_gb, 60]) + " GB" # priorities.py on 500k genomes
+        memory: select_first([machine_mem_gb, 90]) + " GB" # priorities.py on 500k genomes
         cpu :   4
         disks:  "local-disk 375 HDD"
         dx_instance_type: "mem3_ssd1_v2_x8"

--- a/pipes/WDL/tasks/tasks_sarscov2.wdl
+++ b/pipes/WDL/tasks/tasks_sarscov2.wdl
@@ -137,7 +137,7 @@ task pangolin_one_sample {
         grep ^lineage transposed.tsv | cut -f 2 | grep -v lineage > PANGOLIN_CLADE
     }
     runtime {
-        docker: "staphb/pangolin:2.1.8-pangolearn-2021-01-22"
+        docker: "staphb/pangolin:2.1.10-pangolearn-2021-02-01"
         memory: "3 GB"
         cpu:    2
         disks: "local-disk 50 HDD"

--- a/requirements-modules.txt
+++ b/requirements-modules.txt
@@ -6,5 +6,5 @@ broadinstitute/beast-beagle-cuda=1.10.5pre
 broadinstitute/ncbi-tools=2.10.7.1
 nextstrain/base=build-20210127T135203Z
 andersenlabapps/ivar=1.3
-staphb/pangolin=2.1.8-pangolearn-2021-01-22
+staphb/pangolin=2.1.10-pangolearn-2021-02-01
 neherlab/nextclade=0.12.0


### PR DESCRIPTION
- update pangolin docker from `staphb/pangolin:2.1.8-pangolearn-2021-01-22` to `staphb/pangolin:2.1.10-pangolearn-2021-02-01`
- bump nextstrain_build_subsample task vm from 60GB RAM to 90GB RAM by default (for priorities.py)