### PR TITLE
vm shape bump on downstream nextstrain steps

### DIFF
--- a/pipes/WDL/tasks/tasks_nextstrain.wdl
+++ b/pipes/WDL/tasks/tasks_nextstrain.wdl
@@ -1409,7 +1409,7 @@ task export_auspice_json {
     }
     runtime {
         docker: docker
-        memory: "3 GB"
+        memory: "7 GB"
         cpu :   2
         disks:  "local-disk 100 HDD"
         dx_instance_type: "mem1_ssd1_v2_x2"

--- a/pipes/WDL/tasks/tasks_nextstrain.wdl
+++ b/pipes/WDL/tasks/tasks_nextstrain.wdl
@@ -1051,7 +1051,7 @@ task ancestral_traits {
     }
     runtime {
         docker: docker
-        memory: "3 GB"
+        memory: "7 GB"
         cpu :   2
         disks:  "local-disk 50 HDD"
         dx_instance_type: "mem1_ssd1_v2_x2"
@@ -1223,7 +1223,7 @@ task tip_frequencies {
     }
     runtime {
         docker: docker
-        memory: "3 GB"
+        memory: "7 GB"
         cpu :   2
         disks:  "local-disk 100 HDD"
         dx_instance_type: "mem1_ssd1_v2_x2"


### PR DESCRIPTION
Not quite sure what the conditions are that cause this, but recent runs of nextstrain builds seem to require >3GB of RAM at the `ancestral_traits` and `tip_frequencies` and `export_auspice_json` tasks. It's a little odd because the size of inputs (# of genomes) should not be increasing at all as the size of GISAID increases, but perhaps these steps have memory growth purely based on metadata table size (even all the irrelevant entries).

We could potentially filter the metadata tsv to only the entries selected by the subsampling (and make it an output of the subsample task) so that downstream augur steps only see smaller tables.

Or we could just use more RAM. This PR does the latter.