### PR TITLE
vadr option updates

### DIFF
--- a/pipes/WDL/tasks/tasks_ncbi.wdl
+++ b/pipes/WDL/tasks/tasks_ncbi.wdl
@@ -827,7 +827,7 @@ task vadr {
   }
   input {
     File   genome_fasta
-    String vadr_opts="-s -r --nomisc --mkey NC_045512 --lowsim5term 2 --lowsim3term 2 --fstlowthr 0.0 --alt_fail lowscore,fsthicnf,fstlocnf"
+    String vadr_opts="-s -r --nomisc --mkey NC_045512 --fstlowthr 0.0 --alt_fail lowscore,fsthicnf,fstlocnf,insertnn,deletinn"
 
     String  docker="staphb/vadr:1.1.3"
   }


### PR DESCRIPTION
- remove the `--lowsim5term` and `--lowsim3term` as per request of Genbank. A number of otherwise fine genomes have been dropped due to having more than 2 SNPs at the edges of the genome. Genbank no longer considers these to be an automatic rejection anyway. Removing these parameters revert them to VADR's internal default of 15, which still captures egregious errors at the ends (e.g. palindromes/hairpins and stuff).
- add the new insertnn/deletinn alerts