### PR TITLE
sequencing rmd reports

### DIFF
--- a/pipes/WDL/tasks/tasks_sarscov2.wdl
+++ b/pipes/WDL/tasks/tasks_sarscov2.wdl
@@ -166,7 +166,7 @@ task sequencing_report {
         String?        min_date
         Int?           min_unambig
 
-        String  docker = "quay.io/broadinstitute/sc2-rmd:0.1.6"
+        String  docker = "quay.io/broadinstitute/sc2-rmd:0.1.7"
     }
     command {
         set -e

--- a/pipes/WDL/tasks/tasks_sarscov2.wdl
+++ b/pipes/WDL/tasks/tasks_sarscov2.wdl
@@ -160,8 +160,8 @@ task sequencing_report {
         File           assembly_stats_tsv
         File?          collab_ids_tsv
 
-        String?        sequencing_lab
-        String?        intro_blurb
+        String?        sequencing_lab = "Broad Institute"
+        String?        intro_blurb = "The Broad Institute Viral Genomics group, in partnership with the Genomics Platform and Data Sciences Platform, has been engaged in viral sequencing of COVID-19 patients since March 2020."
         String?        max_date
         String?        min_date
         Int?           min_unambig

--- a/pipes/WDL/tasks/tasks_sarscov2.wdl
+++ b/pipes/WDL/tasks/tasks_sarscov2.wdl
@@ -177,6 +177,7 @@ task sequencing_report {
             ~{'--max_date=' + max_date} \
             ~{'--min_date=' + min_date} \
             ~{'--min_unambig=' + min_unambig}
+        zip all_reports.zip *.pdf *.xlsx
     }
     runtime {
         docker: docker
@@ -188,6 +189,7 @@ task sequencing_report {
     output {
         Array[File] reports = glob("*.pdf")
         Array[File] sheets = glob("*.xlsx")
+        File        all_zip = "all_reports.zip"
     }
 }
 

--- a/pipes/WDL/tasks/tasks_sarscov2.wdl
+++ b/pipes/WDL/tasks/tasks_sarscov2.wdl
@@ -165,8 +165,10 @@ task sequencing_report {
         String?        max_date
         String?        min_date
         Int?           min_unambig
+        String?        voc_list
+        String?        voi_list
 
-        String  docker = "quay.io/broadinstitute/sc2-rmd:0.1.7"
+        String  docker = "quay.io/broadinstitute/sc2-rmd:0.1.8"
     }
     command {
         set -e
@@ -177,7 +179,9 @@ task sequencing_report {
             ~{'--intro_blurb="' + intro_blurb + '"'} \
             ~{'--max_date=' + max_date} \
             ~{'--min_date=' + min_date} \
-            ~{'--min_unambig=' + min_unambig}
+            ~{'--min_unambig=' + min_unambig} \
+            ~{'--voc_list=' + voc_list} \
+            ~{'--voi_list=' + voi_list}
         zip all_reports.zip *.pdf *.xlsx
     }
     runtime {

--- a/pipes/WDL/tasks/tasks_sarscov2.wdl
+++ b/pipes/WDL/tasks/tasks_sarscov2.wdl
@@ -158,7 +158,7 @@ task sequencing_report {
     }
     input {
         File           assembly_stats_tsv
-        File           collab_ids_tsv
+        File?          collab_ids_tsv
 
         String?        sequencing_lab
         String?        intro_blurb
@@ -171,7 +171,8 @@ task sequencing_report {
     command {
         set -e
         /docker/reports.py \
-            "~{assembly_stats_tsv}" "~{collab_ids_tsv}" \
+            "~{assembly_stats_tsv}" \
+            ~{'--collab_tsv="' + collab_ids_tsv + '"'} \
             ~{'--sequencing_lab="' + sequencing_lab + '"'} \
             ~{'--intro_blurb="' + intro_blurb + '"'} \
             ~{'--max_date=' + max_date} \

--- a/pipes/WDL/tasks/tasks_sarscov2.wdl
+++ b/pipes/WDL/tasks/tasks_sarscov2.wdl
@@ -162,10 +162,11 @@ task sequencing_report {
 
         String?        sequencing_lab
         String?        intro_blurb
+        String?        max_date
         String?        min_date
         Int?           min_unambig
 
-        String  docker = "quay.io/broadinstitute/sc2-rmd:0.1.5"
+        String  docker = "quay.io/broadinstitute/sc2-rmd:0.1.6"
     }
     command {
         set -e
@@ -173,6 +174,7 @@ task sequencing_report {
             "~{assembly_stats_tsv}" "~{collab_ids_tsv}" \
             ~{'--sequencing_lab="' + sequencing_lab + '"'} \
             ~{'--intro_blurb="' + intro_blurb + '"'} \
+            ~{'--max_date=' + max_date} \
             ~{'--min_date=' + min_date} \
             ~{'--min_unambig=' + min_unambig}
     }

--- a/pipes/WDL/tasks/tasks_terra.wdl
+++ b/pipes/WDL/tasks/tasks_terra.wdl
@@ -40,6 +40,10 @@ task download_entities_tsv {
     String  docker="schaluvadi/pathogen-genomic-surveillance:api-wdl"
   }
 
+  meta {
+    volatile: true
+  }
+
   command {
     python3<<CODE
     import csv

--- a/pipes/WDL/workflows/sarscov2_illumina_full.wdl
+++ b/pipes/WDL/workflows/sarscov2_illumina_full.wdl
@@ -296,7 +296,7 @@ workflow sarscov2_illumina_full {
       call sarscov2.sequencing_report {
         input:
             assembly_stats_tsv = download_entities_tsv.tsv_file,
-            collab_ids_tsv = select_first([collab_ids_tsv]),
+            collab_ids_tsv = collab_ids_tsv,
             max_date = demux_deplete.run_date,
             min_unambig = min_genome_bases
       }

--- a/pipes/WDL/workflows/sarscov2_illumina_full.wdl
+++ b/pipes/WDL/workflows/sarscov2_illumina_full.wdl
@@ -55,6 +55,7 @@ workflow sarscov2_illumina_full {
 
         String?       workspace_name
         String?       terra_project
+        File?         collab_ids_tsv
 
     }
     Int     taxid = 2697049
@@ -295,7 +296,7 @@ workflow sarscov2_illumina_full {
       call sarscov2.sequencing_report {
         input:
             assembly_stats_tsv = download_entities_tsv.tsv_file,
-            #collab_ids_tsv = ,
+            collab_ids_tsv = select_first([collab_ids_tsv]),
             max_date = demux_deplete.run_date,
             min_unambig = min_genome_bases
       }

--- a/pipes/WDL/workflows/sarscov2_illumina_full.wdl
+++ b/pipes/WDL/workflows/sarscov2_illumina_full.wdl
@@ -297,7 +297,7 @@ workflow sarscov2_illumina_full {
             assembly_stats_tsv = download_entities_tsv.tsv_file,
             #collab_ids_tsv = ,
             max_date = demux_deplete.run_date,
-            min_unmabig = min_genome_bases
+            min_unambig = min_genome_bases
       }
     }
 
@@ -365,7 +365,7 @@ workflow sarscov2_illumina_full {
 
         String        run_date = demux_deplete.run_date
 
-        Array[File]   sequencing_reports = select_first([sequencing_report.all_zip, []])
+        File?         sequencing_reports = sequencing_report.all_zip
 
         String?       data_table_status = data_tables.status
     }


### PR DESCRIPTION
- add optional params to sequencing reports: max_date, voi_list, voc_list
- add sequencing report to the end of sarscov2_illumina_full
- add `volatile` tag to terra.download_entities_tsv
- increase min_genome_bases in sarscov2_illumina_full from 15kb to 24kb (to comport with CDC standards)