### PR TITLE
terra table download delay

### DIFF
--- a/pipes/WDL/tasks/tasks_terra.wdl
+++ b/pipes/WDL/tasks/tasks_terra.wdl
@@ -1,6 +1,5 @@
 version 1.0
 
-
 task upload_entities_tsv {
   input {
     String        workspace_name
@@ -37,6 +36,7 @@ task download_entities_tsv {
     String  workspace_name
     String  table_name
     String  outname = "~{terra_project}-~{workspace_name}-~{table_name}.tsv"
+    String? nop_input_string # this does absolutely nothing, except that it allows an optional mechanism for you to block execution of this step upon the completion of another task in your workflow
 
     String  docker="schaluvadi/pathogen-genomic-surveillance:api-wdl"
   }
@@ -57,6 +57,7 @@ task download_entities_tsv {
     workspace_name = '~{workspace_name}'
     table_name = '~{table_name}'
     out_fname = '~{outname}'
+    nop_string = '~{default="" nop_input_string}'
 
     # load terra table and convert to list of dicts
     # I've found that fapi.get_entities_tsv produces malformed outputs if funky chars are in any of the cells of the table

--- a/pipes/WDL/tasks/tasks_terra.wdl
+++ b/pipes/WDL/tasks/tasks_terra.wdl
@@ -14,11 +14,12 @@ task upload_entities_tsv {
   command {
     echo ~{sep="," cleaned_reads_unaligned_bams_string} > cleaned_bam_strings.txt
 
-    python3 /projects/cdc-sabeti-covid-19/create_data_tables.py -t ~{tsv_file} \
-            -p ~{terra_project} \
-            -w ~{workspace_name} \
-            -b cleaned_bam_strings.txt \
-            -j ~{meta_by_filename_json}
+    python3 /projects/cdc-sabeti-covid-19/create_data_tables.py \
+        -t "~{tsv_file}" \
+        -p "~{terra_project}" \
+        -w "~{workspace_name}" \
+        -b cleaned_bam_strings.txt \
+        -j "~{meta_by_filename_json}"
   }
   runtime {
     docker: docker

--- a/pipes/WDL/workflows/sarscov2_illumina_full.wdl
+++ b/pipes/WDL/workflows/sarscov2_illumina_full.wdl
@@ -294,7 +294,8 @@ workflow sarscov2_illumina_full {
         input:
           workspace_name = select_first([workspace_name]),
           terra_project = select_first([terra_project]),
-          table_name = 'assemblies'
+          table_name = 'assemblies',
+          nop_input_string = data_tables.status
       }
 
       call sarscov2.sequencing_report {


### PR DESCRIPTION
In sarscov2_illumina_full, make sure that terra.download_entities_tsv starts *after* terra.upload_entities_tsv finishes! The only way to do this is to tie the dependencies in the dag explicitly.