### PR TITLE
bump viral-ngs docker dependencies

### DIFF
--- a/pipes/WDL/tasks/tasks_assembly.wdl
+++ b/pipes/WDL/tasks/tasks_assembly.wdl
@@ -15,7 +15,7 @@ task assemble {
       String   sample_name = basename(basename(reads_unmapped_bam, ".bam"), ".taxfilt")
 
       Int?     machine_mem_gb
-      String   docker="quay.io/broadinstitute/viral-assemble:2.1.16.1"
+      String   docker="quay.io/broadinstitute/viral-assemble:2.1.20.0"
     }
 
     command {
@@ -80,7 +80,7 @@ task scaffold {
       Float?       scaffold_min_pct_contig_aligned
 
       Int?         machine_mem_gb
-      String       docker="quay.io/broadinstitute/viral-assemble:2.1.16.1"
+      String       docker="quay.io/broadinstitute/viral-assemble:2.1.20.0"
 
       # do this in multiple steps in case the input doesn't actually have "assembly1-x" in the name
       String       sample_name = basename(basename(contigs_fasta, ".fasta"), ".assembly1-spades")
@@ -295,7 +295,7 @@ task align_reads {
     Boolean? skip_mark_dupes=false
 
     Int?     machine_mem_gb
-    String   docker="quay.io/broadinstitute/viral-core:2.1.19"
+    String   docker="quay.io/broadinstitute/viral-core:2.1.20"
 
     String   sample_name = basename(basename(basename(reads_unmapped_bam, ".bam"), ".taxfilt"), ".clean")
   }
@@ -411,7 +411,7 @@ task refine_assembly_with_aligned_reads {
       Int?     min_coverage=3
 
       Int?     machine_mem_gb
-      String   docker="quay.io/broadinstitute/viral-assemble:2.1.16.1"
+      String   docker="quay.io/broadinstitute/viral-assemble:2.1.20.0"
     }
 
     parameter_meta {
@@ -510,7 +510,7 @@ task refine {
       Int?    min_coverage=1
 
       Int?    machine_mem_gb
-      String  docker="quay.io/broadinstitute/viral-assemble:2.1.16.1"
+      String  docker="quay.io/broadinstitute/viral-assemble:2.1.20.0"
 
       String  assembly_basename=basename(basename(assembly_fasta, ".fasta"), ".scaffold")
     }
@@ -580,7 +580,7 @@ task refine_2x_and_plot {
       String? plot_coverage_novoalign_options="-r Random -l 40 -g 40 -x 20 -t 100 -k"
 
       Int?    machine_mem_gb
-      String  docker="quay.io/broadinstitute/viral-assemble:2.1.16.1"
+      String  docker="quay.io/broadinstitute/viral-assemble:2.1.20.0"
 
       # do this in two steps in case the input doesn't actually have "cleaned" in the name
       String  sample_name = basename(basename(reads_unmapped_bam, ".bam"), ".cleaned")
@@ -712,7 +712,7 @@ task run_discordance {
       String   out_basename = "run"
       Int      min_coverage=4
 
-      String   docker="quay.io/broadinstitute/viral-core:2.1.19"
+      String   docker="quay.io/broadinstitute/viral-core:2.1.20"
     }
 
     command {

--- a/pipes/WDL/tasks/tasks_demux.wdl
+++ b/pipes/WDL/tasks/tasks_demux.wdl
@@ -6,7 +6,7 @@ task merge_tarballs {
     String        out_filename
 
     Int?          machine_mem_gb
-    String        docker="quay.io/broadinstitute/viral-core:2.1.19"
+    String        docker="quay.io/broadinstitute/viral-core:2.1.20"
   }
 
   command {
@@ -101,7 +101,7 @@ task illumina_demux {
     Boolean? forceGC=true
 
     Int?    machine_mem_gb
-    String  docker="quay.io/broadinstitute/viral-core:2.1.19"
+    String  docker="quay.io/broadinstitute/viral-core:2.1.20"
   }
   parameter_meta {
       flowcell_tgz: {

--- a/pipes/WDL/tasks/tasks_interhost.wdl
+++ b/pipes/WDL/tasks/tasks_interhost.wdl
@@ -9,7 +9,7 @@ task multi_align_mafft_ref {
     Float?         mafft_gapOpeningPenalty
 
     Int?           machine_mem_gb
-    String         docker="quay.io/broadinstitute/viral-phylo:2.1.19.1"
+    String         docker="quay.io/broadinstitute/viral-phylo:2.1.20.0"
   }
 
   String           fasta_basename = basename(reference_fasta, '.fasta')
@@ -53,7 +53,7 @@ task multi_align_mafft {
     Float?         mafft_gapOpeningPenalty
 
     Int?           machine_mem_gb
-    String         docker="quay.io/broadinstitute/viral-phylo:2.1.19.1"
+    String         docker="quay.io/broadinstitute/viral-phylo:2.1.20.0"
   }
 
   command {
@@ -142,7 +142,7 @@ task index_ref {
     File?    novocraft_license
 
     Int?     machine_mem_gb
-    String   docker="quay.io/broadinstitute/viral-core:2.1.19"
+    String   docker="quay.io/broadinstitute/viral-core:2.1.20"
   }
 
   command {
@@ -252,7 +252,7 @@ task merge_vcfs_gatk {
     File        ref_fasta
 
     Int?     machine_mem_gb
-    String   docker="quay.io/broadinstitute/viral-phylo:2.1.19.1"
+    String   docker="quay.io/broadinstitute/viral-phylo:2.1.20.0"
 
     String   output_prefix = "merged"
   }

--- a/pipes/WDL/tasks/tasks_intrahost.wdl
+++ b/pipes/WDL/tasks/tasks_intrahost.wdl
@@ -11,7 +11,7 @@ task isnvs_per_sample {
     Boolean removeDoublyMappedReads=true
 
     Int?    machine_mem_gb
-    String  docker="quay.io/broadinstitute/viral-phylo:2.1.19.1"
+    String  docker="quay.io/broadinstitute/viral-phylo:2.1.20.0"
 
     String  sample_name = basename(basename(basename(mapped_bam, ".bam"), ".all"), ".mapped")
   }
@@ -52,7 +52,7 @@ task isnvs_vcf {
     Boolean        naiveFilter=false
 
     Int?           machine_mem_gb
-    String         docker="quay.io/broadinstitute/viral-phylo:2.1.19.1"
+    String         docker="quay.io/broadinstitute/viral-phylo:2.1.20.0"
   }
 
   parameter_meta {
@@ -125,7 +125,7 @@ task annotate_vcf_snpeff {
     String?        emailAddress
 
     Int?           machine_mem_gb
-    String         docker="quay.io/broadinstitute/viral-phylo:2.1.19.1"
+    String         docker="quay.io/broadinstitute/viral-phylo:2.1.20.0"
 
     String         output_basename = basename(basename(in_vcf, ".gz"), ".vcf")
   }

--- a/pipes/WDL/tasks/tasks_metagenomics.wdl
+++ b/pipes/WDL/tasks/tasks_metagenomics.wdl
@@ -11,7 +11,7 @@ task krakenuniq {
     File        krona_taxonomy_db_tgz  # taxonomy.tab
 
     Int?        machine_mem_gb
-    String      docker="quay.io/broadinstitute/viral-classify:2.1.16.0"
+    String      docker="quay.io/broadinstitute/viral-classify:2.1.20.0"
   }
 
   parameter_meta {
@@ -136,7 +136,7 @@ task build_krakenuniq_db {
     Int?        zstd_compression_level
 
     Int?        machine_mem_gb
-    String      docker="quay.io/broadinstitute/viral-classify:2.1.16.0"
+    String      docker="quay.io/broadinstitute/viral-classify:2.1.20.0"
   }
 
   command {
@@ -202,7 +202,7 @@ task kraken2 {
     Int?     min_base_qual
 
     Int?     machine_mem_gb
-    String   docker="quay.io/broadinstitute/viral-classify:2.1.16.0"
+    String   docker="quay.io/broadinstitute/viral-classify:2.1.20.0"
   }
 
   parameter_meta {
@@ -334,7 +334,7 @@ task build_kraken2_db {
     Int?        zstd_compression_level
 
     Int?        machine_mem_gb
-    String      docker="quay.io/broadinstitute/viral-classify:2.1.16.0"
+    String      docker="quay.io/broadinstitute/viral-classify:2.1.20.0"
   }
 
   parameter_meta {
@@ -472,7 +472,7 @@ task blastx {
     File     krona_taxonomy_db_tgz
 
     Int?     machine_mem_gb
-    String   docker="quay.io/broadinstitute/viral-classify:2.1.16.0"
+    String   docker="quay.io/broadinstitute/viral-classify:2.1.20.0"
   }
 
   parameter_meta {
@@ -559,7 +559,7 @@ task krona {
     Int?     magnitude_column
 
     Int?     machine_mem_gb
-    String   docker="quay.io/broadinstitute/viral-classify:2.1.16.0"
+    String   docker="quay.io/broadinstitute/viral-classify:2.1.20.0"
   }
 
   command {
@@ -658,7 +658,7 @@ task filter_bam_to_taxa {
     String         out_filename_suffix = "filtered"
 
     Int?           machine_mem_gb
-    String         docker="quay.io/broadinstitute/viral-classify:2.1.16.0"
+    String         docker="quay.io/broadinstitute/viral-classify:2.1.20.0"
   }
 
   String out_basename = basename(classified_bam, ".bam") + "." + out_filename_suffix
@@ -743,7 +743,7 @@ task kaiju {
     File     krona_taxonomy_db_tgz  # taxonomy/taxonomy.tab
 
     Int?     machine_mem_gb
-    String   docker="quay.io/broadinstitute/viral-classify:2.1.16.0"
+    String   docker="quay.io/broadinstitute/viral-classify:2.1.20.0"
   }
 
   String   input_basename = basename(reads_unmapped_bam, ".bam")

--- a/pipes/WDL/tasks/tasks_ncbi.wdl
+++ b/pipes/WDL/tasks/tasks_ncbi.wdl
@@ -25,7 +25,7 @@ task download_fasta {
     Array[String]+ accessions
     String         emailAddress
 
-    String         docker="quay.io/broadinstitute/viral-phylo:2.1.19.1"
+    String         docker="quay.io/broadinstitute/viral-phylo:2.1.20.0"
   }
 
   command {
@@ -56,7 +56,7 @@ task download_annotations {
     String         emailAddress
     String         combined_out_prefix
 
-    String         docker="quay.io/broadinstitute/viral-phylo:2.1.19.1"
+    String         docker="quay.io/broadinstitute/viral-phylo:2.1.20.0"
   }
 
   command {
@@ -100,7 +100,7 @@ task annot_transfer {
     File         reference_fasta
     Array[File]+ reference_feature_table
 
-    String  docker="quay.io/broadinstitute/viral-phylo:2.1.19.1"
+    String  docker="quay.io/broadinstitute/viral-phylo:2.1.20.0"
   }
 
   parameter_meta {
@@ -153,7 +153,7 @@ task align_and_annot_transfer_single {
     Array[File]+ reference_fastas
     Array[File]+ reference_feature_tables
 
-    String  docker="quay.io/broadinstitute/viral-phylo:2.1.19.1"
+    String  docker="quay.io/broadinstitute/viral-phylo:2.1.20.0"
   }
 
   parameter_meta {
@@ -205,7 +205,7 @@ task structured_comments {
 
     File?   filter_to_ids
 
-    String  docker="quay.io/broadinstitute/viral-core:2.1.19"
+    String  docker="quay.io/broadinstitute/viral-core:2.1.20"
   }
   String out_base = basename(assembly_stats_tsv, '.txt')
   command <<<
@@ -283,7 +283,7 @@ task rename_fasta_header {
 
     String  out_basename = basename(genome_fasta, ".fasta")
 
-    String  docker="quay.io/broadinstitute/viral-core:2.1.19"
+    String  docker="quay.io/broadinstitute/viral-core:2.1.20"
   }
   command {
     set -e
@@ -421,7 +421,7 @@ task sra_meta_prep {
     Boolean        paired
 
     String         out_name = "sra_metadata.tsv"
-    String  docker="quay.io/broadinstitute/viral-core:2.1.19"
+    String  docker="quay.io/broadinstitute/viral-core:2.1.20"
   }
   parameter_meta {
     cleaned_bam_filepaths: {
@@ -583,7 +583,7 @@ task biosample_to_genbank {
     File? filter_to_ids
 
     Boolean s_dropout_note=true
-    String  docker="quay.io/broadinstitute/viral-phylo:2.1.19.1"
+    String  docker="quay.io/broadinstitute/viral-phylo:2.1.20.0"
   }
   String base = basename(biosample_attributes, ".txt")
   command {
@@ -635,7 +635,7 @@ task prepare_genbank {
     String?      assembly_method_version
 
     Int?         machine_mem_gb
-    String       docker="quay.io/broadinstitute/viral-phylo:2.1.19.1"
+    String       docker="quay.io/broadinstitute/viral-phylo:2.1.20.0"
   }
 
   parameter_meta {

--- a/pipes/WDL/tasks/tasks_nextstrain.wdl
+++ b/pipes/WDL/tasks/tasks_nextstrain.wdl
@@ -126,7 +126,7 @@ task derived_cols {
         String?       lab_highlight_loc
         Array[File]   table_map=[]
 
-        String        docker="quay.io/broadinstitute/viral-core:2.1.19"
+        String        docker="quay.io/broadinstitute/viral-core:2.1.20"
     }
     parameter_meta {
         lab_highlight_loc: {
@@ -541,7 +541,7 @@ task filter_sequences_by_length {
         File    sequences_fasta
         Int     min_non_N = 1
 
-        String  docker="quay.io/broadinstitute/viral-core:2.1.19"
+        String  docker="quay.io/broadinstitute/viral-core:2.1.20"
     }
     parameter_meta {
         sequences_fasta: {
@@ -690,7 +690,7 @@ task mafft_one_chr {
         Boolean  large = false
         Boolean  memsavetree = false
 
-        String   docker = "quay.io/broadinstitute/viral-phylo:2.1.19.1"
+        String   docker = "quay.io/broadinstitute/viral-phylo:2.1.20.0"
         Int      mem_size = 500
         Int      cpus = 64
     }

--- a/pipes/WDL/tasks/tasks_read_utils.wdl
+++ b/pipes/WDL/tasks/tasks_read_utils.wdl
@@ -79,7 +79,7 @@ task get_sample_meta {
   input {
     Array[File]    samplesheets_extended
 
-    String  docker="quay.io/broadinstitute/viral-core:2.1.19"
+    String  docker="quay.io/broadinstitute/viral-core:2.1.20"
   }
   command <<<
     python3 << CODE
@@ -137,7 +137,7 @@ task merge_and_reheader_bams {
       File?           reheader_table
       String          out_basename
 
-      String          docker="quay.io/broadinstitute/viral-core:2.1.19"
+      String          docker="quay.io/broadinstitute/viral-core:2.1.20"
     }
 
     command {
@@ -197,7 +197,7 @@ task rmdup_ubam {
     String   method="mvicuna"
 
     Int?     machine_mem_gb
-    String?  docker="quay.io/broadinstitute/viral-core:2.1.19"
+    String?  docker="quay.io/broadinstitute/viral-core:2.1.20"
   }
 
   parameter_meta {
@@ -251,7 +251,7 @@ task downsample_bams {
     Boolean?     deduplicateAfter=false
 
     Int?         machine_mem_gb
-    String       docker="quay.io/broadinstitute/viral-core:2.1.19"
+    String       docker="quay.io/broadinstitute/viral-core:2.1.20"
   }
 
   command {
@@ -310,7 +310,7 @@ task FastqToUBAM {
     String? platform_name
     String? sequencing_center
 
-    String  docker="quay.io/broadinstitute/viral-core:2.1.19"
+    String  docker="quay.io/broadinstitute/viral-core:2.1.20"
   }
   parameter_meta {
     fastq_1: { description: "Unaligned read1 file in fastq format", patterns: ["*.fastq", "*.fastq.gz", "*.fq", "*.fq.gz"] }

--- a/pipes/WDL/tasks/tasks_reports.wdl
+++ b/pipes/WDL/tasks/tasks_reports.wdl
@@ -6,7 +6,7 @@ task alignment_metrics {
     File  ref_fasta
     File? primers_bed
 
-    String   docker="quay.io/broadinstitute/viral-core:2.1.19"
+    String   docker="quay.io/broadinstitute/viral-core:2.1.20"
   }
 
   String out_basename = basename(aligned_bam, ".bam")

--- a/pipes/WDL/tasks/tasks_reports.wdl
+++ b/pipes/WDL/tasks/tasks_reports.wdl
@@ -10,7 +10,7 @@ task plot_coverage {
     Boolean bin_large_plots=false
     String?  binning_summary_statistic="max" # max or min
 
-    String   docker="quay.io/broadinstitute/viral-core:2.1.19"
+    String   docker="quay.io/broadinstitute/viral-core:2.1.20"
   }
   
   command {
@@ -85,7 +85,7 @@ task coverage_report {
     Array[File]  mapped_bam_idx # optional.. speeds it up if you provide it, otherwise we auto-index
     String       out_report_name="coverage_report.txt"
 
-    String       docker="quay.io/broadinstitute/viral-core:2.1.19"
+    String       docker="quay.io/broadinstitute/viral-core:2.1.20"
   }
 
   command {
@@ -144,7 +144,7 @@ task fastqc {
   input {
     File     reads_bam
 
-    String   docker="quay.io/broadinstitute/viral-core:2.1.19"
+    String   docker="quay.io/broadinstitute/viral-core:2.1.20"
   }
 
   String   reads_basename=basename(reads_bam, ".bam")
@@ -177,7 +177,7 @@ task align_and_count {
     Int     topNHits = 3
 
     Int?    machine_mem_gb
-    String  docker="quay.io/broadinstitute/viral-core:2.1.19"
+    String  docker="quay.io/broadinstitute/viral-core:2.1.20"
   }
 
   String  reads_basename=basename(reads_bam, ".bam")
@@ -222,7 +222,7 @@ task align_and_count_summary {
 
     String       output_prefix="count_summary"
 
-    String        docker="quay.io/broadinstitute/viral-core:2.1.19"
+    String        docker="quay.io/broadinstitute/viral-core:2.1.20"
   }
 
   command {
@@ -253,7 +253,7 @@ task aggregate_metagenomics_reports {
     String       aggregate_taxlevel_focus                 = "species"
     Int          aggregate_top_N_hits                     = 5
 
-    String       docker="quay.io/broadinstitute/viral-classify:2.1.16.0"
+    String       docker="quay.io/broadinstitute/viral-classify:2.1.20.0"
   }
 
   parameter_meta {
@@ -461,7 +461,7 @@ task tsv_stack {
   input {
     Array[File]+   input_tsvs
     String         out_basename
-    String         docker="quay.io/broadinstitute/viral-core:2.1.19"
+    String         docker="quay.io/broadinstitute/viral-core:2.1.20"
   }
 
   command {
@@ -491,7 +491,7 @@ task compare_two_genomes {
     File          genome_two
     String        out_basename
 
-    String        docker="quay.io/broadinstitute/viral-assemble:2.1.16.1"
+    String        docker="quay.io/broadinstitute/viral-assemble:2.1.20.0"
   }
 
   command {

--- a/pipes/WDL/tasks/tasks_taxon_filter.wdl
+++ b/pipes/WDL/tasks/tasks_taxon_filter.wdl
@@ -14,7 +14,7 @@ task deplete_taxa {
 
     Int?         cpu=8
     Int?         machine_mem_gb
-    String       docker="quay.io/broadinstitute/viral-classify:2.1.16.0"
+    String       docker="quay.io/broadinstitute/viral-classify:2.1.20.0"
   }
 
   parameter_meta {
@@ -110,7 +110,7 @@ task filter_to_taxon {
     String?  neg_control_prefixes_space_separated = "neg water NTC"
 
     Int?     machine_mem_gb
-    String   docker="quay.io/broadinstitute/viral-classify:2.1.16.0"
+    String   docker="quay.io/broadinstitute/viral-classify:2.1.20.0"
   }
 
   # do this in two steps in case the input doesn't actually have "cleaned" in the name
@@ -166,7 +166,7 @@ task build_lastal_db {
     File    sequences_fasta
 
     Int?    machine_mem_gb
-    String  docker="quay.io/broadinstitute/viral-classify:2.1.16.0"
+    String  docker="quay.io/broadinstitute/viral-classify:2.1.20.0"
   }
 
   String  db_name = basename(sequences_fasta, ".fasta")
@@ -202,7 +202,7 @@ task merge_one_per_sample {
     Boolean?     rmdup=false
 
     Int?         machine_mem_gb
-    String       docker="quay.io/broadinstitute/viral-core:2.1.19"
+    String       docker="quay.io/broadinstitute/viral-core:2.1.20"
   }
 
   command {

--- a/requirements-modules.txt
+++ b/requirements-modules.txt
@@ -1,7 +1,7 @@
-broadinstitute/viral-core=2.1.19
-broadinstitute/viral-assemble=2.1.16.1
-broadinstitute/viral-classify=2.1.16.0
-broadinstitute/viral-phylo=2.1.19.1
+broadinstitute/viral-core=2.1.20
+broadinstitute/viral-assemble=2.1.20.0
+broadinstitute/viral-classify=2.1.20.0
+broadinstitute/viral-phylo=2.1.20.0
 broadinstitute/beast-beagle-cuda=1.10.5pre
 broadinstitute/ncbi-tools=2.10.7.1
 nextstrain/base=build-20210318T204019Z


### PR DESCRIPTION
bump viral-core, viral-phylo, viral-assemble, viral-classify docker image versions to incorporate updates to picard, samtools, pysam, zstandard.