### PR TITLE
update voc/voi list and fix terra table tasks

### DIFF
--- a/pipes/WDL/tasks/tasks_sarscov2.wdl
+++ b/pipes/WDL/tasks/tasks_sarscov2.wdl
@@ -168,7 +168,7 @@ task sequencing_report {
         String?        voc_list
         String?        voi_list
 
-        String  docker = "quay.io/broadinstitute/sc2-rmd:0.1.8"
+        String  docker = "quay.io/broadinstitute/sc2-rmd:0.1.9"
     }
     command {
         set -e

--- a/pipes/WDL/tasks/tasks_terra.wdl
+++ b/pipes/WDL/tasks/tasks_terra.wdl
@@ -57,7 +57,7 @@ task download_entities_tsv {
     workspace_name = '~{workspace_name}'
     table_name = '~{table_name}'
     out_fname = '~{outname}'
-    nop_string = '~{default="" nop_input_string}'
+    nop_string = '''~{default="" nop_input_string}'''
 
     # load terra table and convert to list of dicts
     # I've found that fapi.get_entities_tsv produces malformed outputs if funky chars are in any of the cells of the table

--- a/pipes/WDL/workflows/sarscov2_illumina_full.wdl
+++ b/pipes/WDL/workflows/sarscov2_illumina_full.wdl
@@ -301,7 +301,7 @@ workflow sarscov2_illumina_full {
           workspace_name = select_first([workspace_name]),
           terra_project = select_first([terra_project]),
           table_name = 'assemblies',
-          nop_input_string = data_tables.status
+          nop_input_string = data_tables.tables[0]
       }
 
       call sarscov2.sequencing_report {
@@ -386,6 +386,6 @@ workflow sarscov2_illumina_full {
 
         File?         sequencing_reports = sequencing_report.all_zip
 
-        String?       data_table_status = data_tables.status
+        Array[String] data_tables_out = select_first([data_tables.tables, []])
     }
 }

--- a/pipes/WDL/workflows/terra_update_assemblies.wdl
+++ b/pipes/WDL/workflows/terra_update_assemblies.wdl
@@ -12,6 +12,6 @@ workflow update_data_tables {
     call terra.upload_entities_tsv
 
     output {
-        String status_message = upload_entities_tsv.status
+        Array[String] tables = upload_entities_tsv.tables
     }
 }


### PR DESCRIPTION
- update upload_entities_tsv to output the list of tables touched (instead of a generic message with newline characters)
- update sc2-rmd docker to use include more sublineages of vocs/vois