### PR TITLE
nextstrain subsample updates

### DIFF
--- a/pipes/WDL/tasks/tasks_nextstrain.wdl
+++ b/pipes/WDL/tasks/tasks_nextstrain.wdl
@@ -362,7 +362,7 @@ task nextstrain_build_subsample {
         # seed input data (skip some upstream steps in the DAG)
         # strip away anything after a space (esp in fasta headers--they break priorities.py)
         mkdir -p results
-        cut -f 1 -d ' ' "~{alignment_msa_fasta}" > results/filtered.fasta
+        cut -f 1 -d ' ' "~{alignment_msa_fasta}" > results/masked.fasta
 
         # execute snakemake on pre-iqtree target
         RAM_MB=$(cat /proc/meminfo | grep MemTotal | perl -lape 's/MemTotal:\s+(\d+)\d\d\d\s+kB/$1/')

--- a/pipes/WDL/tasks/tasks_nextstrain.wdl
+++ b/pipes/WDL/tasks/tasks_nextstrain.wdl
@@ -309,6 +309,7 @@ task nextstrain_build_subsample {
         String   build_name
         File?    builds_yaml
         File?    parameters_yaml
+        File?    keep_list
 
         Int?     machine_mem_gb
         String   docker = "nextstrain/base:build-20210318T204019Z"
@@ -353,11 +354,19 @@ task nextstrain_build_subsample {
         config:
           - sequences=~{alignment_msa_fasta}
           - metadata=~{sample_metadata_tsv}
+        filter:
+          - min_length=100
         printshellcmds: True
         show-failed-logs: True
         reason: True
         stats: stats.json
         CONFIG
+
+        # hard inclusion list
+        KEEP_LIST="~{default='' keep_list}"
+        if [ -n "$KEEP_LIST" ]; then
+            cat $KEEP_LIST >> defaults/include.txt
+        fi
 
         # seed input data (skip some upstream steps in the DAG)
         # strip away anything after a space (esp in fasta headers--they break priorities.py)

--- a/pipes/WDL/tasks/tasks_nextstrain.wdl
+++ b/pipes/WDL/tasks/tasks_nextstrain.wdl
@@ -352,10 +352,10 @@ task nextstrain_build_subsample {
           - ~{default="defaults/parameters.yaml" parameters_yaml}
           - ~{default="my_profiles/example/builds.yaml" builds_yaml}
         config:
-          - sequences=~{alignment_msa_fasta}
-          - metadata=~{sample_metadata_tsv}
-        filter:
-          - min_length=100
+          sequences: "~{alignment_msa_fasta}"
+          metadata: "~{sample_metadata_tsv}"
+          filter:
+            min_length: 100
         printshellcmds: True
         show-failed-logs: True
         reason: True

--- a/pipes/WDL/tasks/tasks_nextstrain.wdl
+++ b/pipes/WDL/tasks/tasks_nextstrain.wdl
@@ -312,7 +312,7 @@ task nextstrain_build_subsample {
 
         Int?     machine_mem_gb
         String   docker = "nextstrain/base:build-20210318T204019Z"
-        String   nextstrain_ncov_repo_commit = "0e935c42ec4407a4f437c092352181cf3cca1a41"
+        String   nextstrain_ncov_repo_commit = "0f30b1c801384fbf871f644ca241336a1d8fa04a"
     }
     parameter_meta {
         alignment_msa_fasta: {

--- a/pipes/WDL/tasks/tasks_nextstrain.wdl
+++ b/pipes/WDL/tasks/tasks_nextstrain.wdl
@@ -362,7 +362,7 @@ task nextstrain_build_subsample {
         # seed input data (skip some upstream steps in the DAG)
         # strip away anything after a space (esp in fasta headers--they break priorities.py)
         mkdir -p results
-        cut -f 1 -d ' ' "~{alignment_msa_fasta}" > results/masked.fasta
+        cut -f 1 -d ' ' "~{alignment_msa_fasta}" > results/aligned.fasta
 
         # execute snakemake on pre-iqtree target
         RAM_MB=$(cat /proc/meminfo | grep MemTotal | perl -lape 's/MemTotal:\s+(\d+)\d\d\d\s+kB/$1/')

--- a/pipes/WDL/tasks/tasks_nextstrain.wdl
+++ b/pipes/WDL/tasks/tasks_nextstrain.wdl
@@ -352,10 +352,8 @@ task nextstrain_build_subsample {
           - ~{default="defaults/parameters.yaml" parameters_yaml}
           - ~{default="my_profiles/example/builds.yaml" builds_yaml}
         config:
-          sequences: "~{alignment_msa_fasta}"
-          metadata: "~{sample_metadata_tsv}"
-          filter:
-            min_length: 100
+          - sequences="~{alignment_msa_fasta}"
+          - metadata="~{sample_metadata_tsv}"
         printshellcmds: True
         show-failed-logs: True
         reason: True


### PR DESCRIPTION
Updates to task `nextstrain_build_subsample`:
 - update git commit of nextstrain/ncov repo
 - defend against whitespace in input filenames
 - add optional `keep_list` file input that always retains named sample IDs
 - execute some additional upstream DAG steps in the nextstrain/ncov snakemake rule set: site masking, diagnostics, and pre-filtering of sequences (including their custom excludes list, sample dates out of bounds, <27kb genomes, and categorically bad metadata).