### PR TITLE
run snp_sites only on subsampled msa

### DIFF
--- a/pipes/WDL/workflows/sarscov2_nextstrain.wdl
+++ b/pipes/WDL/workflows/sarscov2_nextstrain.wdl
@@ -73,10 +73,6 @@ workflow sarscov2_nextstrain {
             ref_fasta = select_first([ref_fasta, nextstrain_ncov_defaults.reference_fasta]),
             basename  = "all_samples_aligned.fasta"
     }
-    call nextstrain.snp_sites {
-        input:
-            msa_fasta = mafft.aligned_sequences
-    }
 
 
     #### merge metadata, compute derived cols
@@ -105,6 +101,10 @@ workflow sarscov2_nextstrain {
     call nextstrain.fasta_to_ids {
         input:
             sequences_fasta = subsample.subsampled_msa
+    }
+    call nextstrain.snp_sites {
+        input:
+            msa_fasta = subsample.subsampled_msa
     }
 
 


### PR DESCRIPTION
Previously, snp-sites was running on the full msa output from mafft. As the SARS-CoV-2 input these days approaches 1M genomes, this is both computationally laborious and also practically/scientifically useless (the VCF becomes much bigger than the FASTA now that the population size is > 30x the genome size.. VCFs were intended for pop size << genome size).

This PR changes the input to snp-sites from the full msa to the subsampled msa.