### PR TITLE
small fixes and prep work

### DIFF
--- a/pipes/WDL/tasks/tasks_ncbi.wdl
+++ b/pipes/WDL/tasks/tasks_ncbi.wdl
@@ -388,6 +388,51 @@ task lookup_table_by_filename {
   }
 }
 
+task register_biosamples {
+  meta {
+    description: "This registers a table of metadata with NCBI BioSample. It accepts a TSV similar to the web UI input at submit.ncbi.nlm.nih.gov, but converts to an XML, submits via their FTP/XML API, awaits a response, and retrieves a resulting attributes table and returns that as a TSV. This task registers live data with the production NCBI database."
+  }
+  input {
+    File     sample_metadata_tsv
+    String?  comment
+    String?  embargo_date
+
+    String   org_name
+    String   org_type
+    String   spuid_namespace
+    String   account_name
+
+    File     ftp_config
+    Boolean  test=true
+
+    String   docker = "local/broad-tsv-converter"  # for dev/debug only
+  }
+  String meta_basename = basename(basename(sample_metadata_tsv, '.txt'), '.tsv')
+  command {
+    set -e -o pipefail
+
+    cp "~{sample_metadata_tsv}" files/input.tsv
+    # modify src/config.js
+
+    node src/main.js -i=input.tsv \
+      ~{'-c="' + comment + '"'} \
+      ~{'-d=' + embargo_date} \
+      -u="~{true='Test' false='Production' test}/~{meta_basename}"
+
+    # huh.. need to strip off empty entry at the end of xml....
+
+  }
+  output {
+    String value = read_string("OUTVAL")
+  }
+  runtime {
+    docker: docker
+    memory: "1 GB"
+    cpu: 1
+    dx_instance_type: "mem1_ssd1_v2_x2"
+  }
+}
+
 task sra_meta_prep {
   meta {
     description: "Prepare tables for submission to NCBI's SRA database. This only works on bam files produced by illumina.py illumina_demux --append_run_id in viral-core."

--- a/pipes/WDL/tasks/tasks_reports.wdl
+++ b/pipes/WDL/tasks/tasks_reports.wdl
@@ -448,11 +448,11 @@ task MultiQC {
   }
 
   runtime {
-    memory: "3 GB"
+    memory: "8 GB"
     cpu: 2
     docker: "${docker}"
     disks: "local-disk 375 LOCAL"
-    dx_instance_type: "mem1_ssd1_v2_x2"
+    dx_instance_type: "mem2_ssd1_v2_x2"
   }
 }
 

--- a/pipes/WDL/tasks/tasks_sarscov2.wdl
+++ b/pipes/WDL/tasks/tasks_sarscov2.wdl
@@ -168,7 +168,7 @@ task sequencing_report {
         String? voc_list
         String? voi_list
 
-        String  docker = "quay.io/broadinstitute/sc2-rmd:0.1.10"
+        String  docker = "quay.io/broadinstitute/sc2-rmd:0.1.11"
     }
     command {
         set -e

--- a/pipes/WDL/tasks/tasks_sarscov2.wdl
+++ b/pipes/WDL/tasks/tasks_sarscov2.wdl
@@ -182,7 +182,7 @@ task sequencing_report {
             ~{'--min_unambig=' + min_unambig} \
             ~{'--voc_list=' + voc_list} \
             ~{'--voi_list=' + voi_list}
-        zip all_reports.zip *.pdf *.xlsx
+        zip all_reports.zip *.pdf *.xlsx *.tsv
     }
     runtime {
         docker: docker
@@ -195,6 +195,7 @@ task sequencing_report {
         Array[File] reports = glob("*.pdf")
         Array[File] sheets  = glob("*.xlsx")
         File        all_zip = "all_reports.zip"
+        File        all_tsv = glob("report-*-everything-*.tsv")[0]
     }
 }
 

--- a/pipes/WDL/tasks/tasks_sarscov2.wdl
+++ b/pipes/WDL/tasks/tasks_sarscov2.wdl
@@ -238,9 +238,9 @@ task sc2_meta_final {
         drop_file_cols = ~{true='True' false='False' drop_file_cols}
 
         # read input files
-        df_assemblies = pd.read_csv(assemblies_tsv, sep='\t')
+        df_assemblies = pd.read_csv(assemblies_tsv, sep='\t').dropna(how='all')
         if collab_tsv and os.path.isfile(collab_tsv) and os.path.getsize(collab_tsv):
-            collab_ids = pd.read_csv(collab_tsv, sep='\t')
+            collab_ids = pd.read_csv(collab_tsv, sep='\t').dropna(how='all')
             if collab_addcols:
                 collab_ids = collab_ids[[collab_idcol] + collab_addcols]
             if collab_idcol != 'sample':

--- a/pipes/WDL/tasks/tasks_sarscov2.wdl
+++ b/pipes/WDL/tasks/tasks_sarscov2.wdl
@@ -252,7 +252,8 @@ task sc2_meta_final {
         if drop_file_cols:
             df_assemblies.drop(columns=[
                 'assembly_fasta','coverage_plot','aligned_bam','replicate_discordant_vcf',
-                'variants_from_ref_vcf','nextclade_tsv','pangolin_csv','vadr_tgz','vadr_alerts',
+                'variants_from_ref_vcf','nextclade_tsv','nextclade_json',
+                'pangolin_csv','vadr_tgz','vadr_alerts',
                 ], inplace=True)
 
         # format dates properly and remove all rows with missing or bad dates

--- a/pipes/WDL/tasks/tasks_sarscov2.wdl
+++ b/pipes/WDL/tasks/tasks_sarscov2.wdl
@@ -168,7 +168,7 @@ task sequencing_report {
         String? voc_list
         String? voi_list
 
-        String  docker = "quay.io/broadinstitute/sc2-rmd:0.1.11"
+        String  docker = "quay.io/broadinstitute/sc2-rmd:0.1.12"
     }
     command {
         set -e

--- a/pipes/WDL/tasks/tasks_sarscov2.wdl
+++ b/pipes/WDL/tasks/tasks_sarscov2.wdl
@@ -168,7 +168,7 @@ task sequencing_report {
         String? voc_list
         String? voi_list
 
-        String  docker = "quay.io/broadinstitute/sc2-rmd:0.1.12"
+        String  docker = "quay.io/broadinstitute/sc2-rmd:0.1.13"
     }
     command {
         set -e
@@ -251,11 +251,13 @@ task sc2_meta_final {
 
         # remove columns with File URIs if requested
         if drop_file_cols:
-            df_assemblies.drop(columns=[
+            cols_unwanted = [
                 'assembly_fasta','coverage_plot','aligned_bam','replicate_discordant_vcf',
                 'variants_from_ref_vcf','nextclade_tsv','nextclade_json',
                 'pangolin_csv','vadr_tgz','vadr_alerts',
-                ], inplace=True)
+            ]
+            cols_unwanted = list(c for c in cols_unwanted if c in df_assemblies.columns)
+            df_assemblies.drop(columns=cols_unwanted, inplace=True)
 
         # format dates properly and remove all rows with missing or bad dates
         df_assemblies = df_assemblies.loc[

--- a/pipes/WDL/workflows/sarscov2_illumina_full.wdl
+++ b/pipes/WDL/workflows/sarscov2_illumina_full.wdl
@@ -225,7 +225,8 @@ workflow sarscov2_illumina_full {
       input:
         assembly_stats_tsv = assembly_meta_tsv.combined,
         collab_ids_tsv = collab_ids_tsv,
-        drop_file_cols = true
+        drop_file_cols = true,
+        min_unambig = min_genome_bases
     }
     call read_utils.max as ntc_max {
       input:

--- a/pipes/WDL/workflows/sarscov2_sequencing_reports.wdl
+++ b/pipes/WDL/workflows/sarscov2_sequencing_reports.wdl
@@ -31,5 +31,6 @@ workflow sarscov2_sequencing_reports {
         Array[File] sequencing_reports_pdfs       = sequencing_report.reports
         Array[File] sequencing_reports_xlsxs      = sequencing_report.sheets
         File        sequencing_reports_zip        = sequencing_report.all_zip
+        File        sequencing_report_tsv         = sequencing_report.all_tsv
     }
 }


### PR DESCRIPTION
- sarscov2_illumina_full: for task `sc2_meta_final`, pin the min_unambig to the workflow's specified value
- `sc2_meta_final`: tolerate empty lines in either assembly_meta or collab_ids input tsvs (filter them out upon ingest)
- `sc2_meta_final`: drop `nextclade_json` from output (it's another gs uri)
- `MultiQC`: increase RAM to accommodate up to 768 input files
- `register_biosamples`: preparatory/skeleton work for future task (not yet fully implemented or incorporated into workflows)
- `sequencing_report`: make more resilient to empty rows in tsv inputs, update voc/voi lists for new pango lineages that are children of existing voc/vois, etc