### PR TITLE
Automated QC filters in sarscov2_illumina_full

### DIFF
--- a/pipes/WDL/tasks/tasks_assembly.wdl
+++ b/pipes/WDL/tasks/tasks_assembly.wdl
@@ -837,6 +837,7 @@ task filter_bad_ntc_batches {
             fail_meta[id] = 'failed_NTC'
           else:
             new_seqid_list.append(id)
+        seqid_list = new_seqid_list
 
         # write outputs
         with open('seqids.filtered.txt', 'wt') as outf:

--- a/pipes/WDL/tasks/tasks_assembly.wdl
+++ b/pipes/WDL/tasks/tasks_assembly.wdl
@@ -830,14 +830,14 @@ task filter_bad_ntc_batches {
 
         # filter samples from bad batches/lanes
         fail_meta = {}
-        new_seqid_list = []
-        for id in seqid_list:
+        fails = set()
+        for sample in assembly_meta:
+          id = sample['sample']
           if (demux_meta[id].get('batch_lib') in reject_batches) \
             or (demux_meta[id]['run'].split('.')[-1] in reject_lanes):
             fail_meta[id] = 'failed_NTC'
-          else:
-            new_seqid_list.append(id)
-        seqid_list = new_seqid_list
+            fails.add(id)
+        seqid_list = list(id for id in seqid_list if id not in fails)
 
         # write outputs
         with open('seqids.filtered.txt', 'wt') as outf:

--- a/pipes/WDL/tasks/tasks_assembly.wdl
+++ b/pipes/WDL/tasks/tasks_assembly.wdl
@@ -806,12 +806,12 @@ task filter_bad_ntc_batches {
         reject_lanes = set()
         reject_batches = set()
         for sample in assembly_meta:
-          if (demux_meta[sample['sample_original']].get('control') == 'NTC'):
+          if (demux_meta[sample['sample']].get('control') == 'NTC'):
             bad_ntc = sample['assembly_length_unambiguous'] \
               and (int(sample['assembly_length_unambiguous']) >= ntc_min_unambig)
-            id = sample['sample_original']
-            lane = demux_meta[sample['sample_original']]['run'].split('.')[-1]
-            batch = demux_meta[sample['sample_original']].get('batch_lib','')
+            id = sample['sample']
+            lane = demux_meta[sample['sample']]['run'].split('.')[-1]
+            batch = demux_meta[sample['sample']].get('batch_lib','')
             print(f"NTC:\t{id}\t{sample['assembly_length_unambiguous']}\t{bad_ntc}\t{lane}\t{batch}")
             if bad_ntc:
               if batch:

--- a/pipes/WDL/tasks/tasks_demux.wdl
+++ b/pipes/WDL/tasks/tasks_demux.wdl
@@ -111,7 +111,7 @@ task illumina_demux {
 
   String out_base = "~{basename(basename(basename(basename(flowcell_tgz, '.zst'), '.gz'), '.tar'), '.tgz')}-L~{lane}"
 
-  command {
+  command <<<
     set -ex -o pipefail
 
     # find N% memory
@@ -297,7 +297,7 @@ task illumina_demux {
     cat /proc/uptime | cut -f 1 -d ' ' > UPTIME_SEC
     cat /proc/loadavg | cut -f 3 -d ' ' > LOAD_15M
     cat /sys/fs/cgroup/memory/memory.max_usage_in_bytes > MEM_BYTES
-  }
+  >>>
 
   output {
     File        metrics                  = "~{out_base}-demux_metrics.txt"

--- a/pipes/WDL/tasks/tasks_nextstrain.wdl
+++ b/pipes/WDL/tasks/tasks_nextstrain.wdl
@@ -6,6 +6,7 @@ task nextmeta_prep {
     File   gisaid_meta
     File   assembly_meta
     String out_name
+    File?  filter_to_ids
   }
   command <<<
     python3 << CODE
@@ -24,6 +25,12 @@ task nextmeta_prep {
     with open('~{assembly_meta}', 'rt') as inf:
       for row in csv.DictReader(inf, delimiter='\t'):
         sample_to_assembly[row['sample']] = row
+    filter_to_ids = "~{default='' filter_to_ids}"
+    if filter_to_ids:
+        with open(filter_to_ids, 'rt') as inf:
+            keep_list = set(x.strip() for x in inf)
+    else:
+        keep_list = None
 
     # write outputs
     out_headers = ('strain', 'date', 'region', 'country', 'division', 'location', 'length', 'host', 'Nextstrain_clade', 'pango_lineage', 'originating_lab', 'submitting_lab', 'authors', 'purpose_of_sequencing')
@@ -33,23 +40,24 @@ task nextmeta_prep {
       writer.writeheader()
 
       for sample in samples:
-        geoloc = sample_to_gisaid[sample]['covv_location'].split(' / ')
-        writer.writerow({
-          'strain': sample,
-          'host': 'Human',
-          'length': sample_to_assembly[sample]['assembly_length_unambiguous'],
-          'Nextstrain_clade': sample_to_assembly[sample]['nextclade_clade'],
-          'pango_lineage': sample_to_assembly[sample]['pango_lineage'],
-          'region': geoloc[0],
-          'country': geoloc[1] if len(geoloc)>1 else '',
-          'division': geoloc[2] if len(geoloc)>2 else '',
-          'location': geoloc[3] if len(geoloc)>3 else '',
-          'date': sample_to_gisaid[sample]['covv_collection_date'],
-          'originating_lab': sample_to_gisaid[sample]['covv_orig_lab'],
-          'submitting_lab': sample_to_gisaid[sample]['covv_subm_lab'],
-          'authors': sample_to_gisaid[sample]['covv_authors'],
-          'purpose_of_sequencing': sample_to_gisaid[sample]['covv_add_host_info'],
-        })
+        if not filter_to_ids or sample in keep_list:
+            geoloc = sample_to_gisaid[sample]['covv_location'].split(' / ')
+            writer.writerow({
+            'strain': sample,
+            'host': 'Human',
+            'length': sample_to_assembly[sample]['assembly_length_unambiguous'],
+            'Nextstrain_clade': sample_to_assembly[sample]['nextclade_clade'],
+            'pango_lineage': sample_to_assembly[sample]['pango_lineage'],
+            'region': geoloc[0],
+            'country': geoloc[1] if len(geoloc)>1 else '',
+            'division': geoloc[2] if len(geoloc)>2 else '',
+            'location': geoloc[3] if len(geoloc)>3 else '',
+            'date': sample_to_gisaid[sample]['covv_collection_date'],
+            'originating_lab': sample_to_gisaid[sample]['covv_orig_lab'],
+            'submitting_lab': sample_to_gisaid[sample]['covv_subm_lab'],
+            'authors': sample_to_gisaid[sample]['covv_authors'],
+            'purpose_of_sequencing': sample_to_gisaid[sample]['covv_add_host_info'],
+            })
 
     CODE
   >>>

--- a/pipes/WDL/tasks/tasks_nextstrain.wdl
+++ b/pipes/WDL/tasks/tasks_nextstrain.wdl
@@ -539,6 +539,7 @@ task filter_sequences_to_list {
         File         sequences
         Array[File]? keep_list
 
+        String       out_fname = sub(sub(basename(sequences), ".vcf", ".filtered.vcf"), ".fasta$", ".filtered.fasta")
         String       docker = "nextstrain/base:build-20210318T204019Z"
     }
     parameter_meta {
@@ -551,7 +552,6 @@ task filter_sequences_to_list {
           patterns: ["*.txt", "*.tsv"]
         }
     }
-    String out_fname = sub(sub(basename(sequences), ".vcf", ".filtered.vcf"), ".fasta$", ".filtered.fasta")
     command <<<
         set -e
         KEEP_LISTS="~{sep=' ' select_first([keep_list, []])}"

--- a/pipes/WDL/tasks/tasks_sarscov2.wdl
+++ b/pipes/WDL/tasks/tasks_sarscov2.wdl
@@ -301,8 +301,8 @@ task sc2_meta_final {
 
         # derived column: genome_status
         df_assemblies.loc[:,'genome_status'] = list(
-                genome_status[df_assemblies.loc[id, 'sample']] if df_assemblies.loc[id, 'sample'] in genome_status
-                else 'failed_sequencing' if df_assemblies.loc[id, 'assembly_length_unambiguous'] < min_unambig
+                'failed_sequencing' if df_assemblies.loc[id, 'assembly_length_unambiguous'] < min_unambig
+                else genome_status[df_assemblies.loc[id, 'sample']] if df_assemblies.loc[id, 'sample'] in genome_status
                 else 'failed_annotation' if df_assemblies.loc[id, 'vadr_num_alerts'] > 0
                 else 'submittable'
                 for id in df_assemblies.index)

--- a/pipes/WDL/tasks/tasks_sarscov2.wdl
+++ b/pipes/WDL/tasks/tasks_sarscov2.wdl
@@ -225,6 +225,7 @@ task sc2_meta_final {
     command <<<
         set -e
         python3<<CODE
+        import json
         import os
         import datetime
         import epiweeks
@@ -309,6 +310,15 @@ task sc2_meta_final {
         df_assemblies.loc[:,'geo_state'] = list(g.split(': ')[1].split(', ')[0] if not pd.isna(g) else '' for g in df_assemblies.loc[:,'geo_loc_name'])
         df_assemblies.loc[:,'geo_locality'] = list(g.split(': ')[1].split(', ')[1] if not pd.isna(g) and ', ' in g else '' for g in df_assemblies.loc[:,'geo_loc_name'])
         df_assemblies.loc[:,'geo_state_abbr'] = list(s.split('/')[1].split('-')[0] for s in df_assemblies.loc[:,'sample'])
+
+        # derived columns: collection_epiweek, run_epiweek
+        df_assemblies.loc[:,'collection_epiweek'] = list(epiweeks.Week.fromdate(x) if not pd.isna(x) else x for x in df_assemblies.loc[:,'collection_date'])
+        df_assemblies.loc[:,'run_epiweek'] = list(epiweeks.Week.fromdate(x) if not pd.isna(x) else x for x in df_assemblies.loc[:,'run_date'])
+        df_assemblies.loc[:,'collection_epiweek_end'] = list(x.enddate().strftime('%Y-%m-%d') if not pd.isna(x) else '' for x in df_assemblies.loc[:,'collection_epiweek'])
+        df_assemblies.loc[:,'run_epiweek_end'] = list(x.enddate().strftime('%Y-%m-%d') if not pd.isna(x) else '' for x in df_assemblies.loc[:,'run_epiweek'])
+
+        # derived column: sample_age_at_runtime
+        df_assemblies.loc[:,'sample_age_at_runtime'] = list(x.days for x in df_assemblies.loc[:,'run_date'] - df_assemblies.loc[:,'collection_date'])
 
         # join column: collaborator_id
         df_assemblies = df_assemblies.merge(collab_ids, on='sample', how='left', validate='one_to_one')

--- a/pipes/WDL/tasks/tasks_sarscov2.wdl
+++ b/pipes/WDL/tasks/tasks_sarscov2.wdl
@@ -252,7 +252,9 @@ task sc2_meta_final {
         # read input files
         df_assemblies = pd.read_csv(assemblies_tsv, sep='\t').dropna(how='all')
         if collab_tsv and os.path.isfile(collab_tsv) and os.path.getsize(collab_tsv):
-            collab_ids = pd.read_csv(collab_tsv, sep='\t').dropna(how='all')
+            collab_ids = pd.read_csv(collab_tsv, sep='\t').dropna(how='all').dropna(how='all', axis='columns')
+            if 'collection_date' in collab_ids.columns:
+                collab_ids.drop(columns=['collection_date'], inplace=True)
             if collab_addcols:
                 collab_ids = collab_ids[[collab_idcol] + collab_addcols]
             if collab_idcol != 'sample':
@@ -299,9 +301,9 @@ task sc2_meta_final {
 
         # derived column: genome_status
         df_assemblies.loc[:,'genome_status'] = list(
-                'failed_sequencing' if df_assemblies.loc[id, 'assembly_length_unambiguous'] < min_unambig
+                genome_status[df_assemblies.loc[id, 'sample']] if df_assemblies.loc[id, 'sample'] in genome_status
+                else 'failed_sequencing' if df_assemblies.loc[id, 'assembly_length_unambiguous'] < min_unambig
                 else 'failed_annotation' if df_assemblies.loc[id, 'vadr_num_alerts'] > 0
-                else genome_status[id] if id in genome_status
                 else 'submittable'
                 for id in df_assemblies.index)
 

--- a/pipes/WDL/tasks/tasks_sarscov2.wdl
+++ b/pipes/WDL/tasks/tasks_sarscov2.wdl
@@ -309,7 +309,7 @@ task sc2_meta_final {
         df_assemblies.loc[:,'geo_country'] = list(g.split(': ')[0] if not pd.isna(g) else '' for g in df_assemblies.loc[:,'geo_loc_name'])
         df_assemblies.loc[:,'geo_state'] = list(g.split(': ')[1].split(', ')[0] if not pd.isna(g) else '' for g in df_assemblies.loc[:,'geo_loc_name'])
         df_assemblies.loc[:,'geo_locality'] = list(g.split(': ')[1].split(', ')[1] if not pd.isna(g) and ', ' in g else '' for g in df_assemblies.loc[:,'geo_loc_name'])
-        df_assemblies.loc[:,'geo_state_abbr'] = list(s.split('/')[1].split('-')[0] for s in df_assemblies.loc[:,'sample'])
+        df_assemblies.loc[:,'geo_state_abbr'] = list(s.split('/')[1].split('-')[0] if '/' in s and '-' in s.split('/')[1] else '' for s in df_assemblies.loc[:,'sample'])
 
         # derived columns: collection_epiweek, run_epiweek
         df_assemblies.loc[:,'collection_epiweek'] = list(epiweeks.Week.fromdate(x) if not pd.isna(x) else x for x in df_assemblies.loc[:,'collection_date'])
@@ -319,10 +319,8 @@ task sc2_meta_final {
 
         # derived column: sample_age_at_runtime
         df_assemblies.loc[:,'sample_age_at_runtime'] = list(
-            x.days
-            for x in (df_assemblies.loc[:,'run_date'] - df_assemblies.loc[:,'collection_date'])
-            if not pd.isna(x)
-            else pd.NA)
+            (x.days if not pd.isna(x) else pd.NA)
+            for x in (df_assemblies.loc[:,'run_date'] - df_assemblies.loc[:,'collection_date']))
 
         # join column: collaborator_id
         df_assemblies = df_assemblies.merge(collab_ids, on='sample', how='left', validate='one_to_one')

--- a/pipes/WDL/workflows/demux_deplete.wdl
+++ b/pipes/WDL/workflows/demux_deplete.wdl
@@ -51,6 +51,8 @@ workflow demux_deplete {
         }
     }
 
+    String  flowcell_id   = basename(basename(basename(basename(flowcell_tgz, ".gz"), ".zst"), ".tar"), ".tgz")
+
     #### demux each lane (rename samples if requested)
     scatter(lane_sheet in zip(range(length(samplesheets)), samplesheets)) {
         call demux.samplesheet_rename_ids {
@@ -113,7 +115,7 @@ workflow demux_deplete {
                 library_metadata      = samplesheet_rename_ids.new_sheet,
                 platform              = "ILLUMINA",
                 paired                = (illumina_demux.run_info[0]['indexes'] == '2'),
-                out_name              = "sra_metadata-~{basename(flowcell_tgz, '.tar.gz')}.tsv",
+                out_name              = "sra_metadata-~{flowcell_id}.tsv",
                 instrument_model      = select_first([instrument_model]),
                 title                 = select_first([sra_title])
         }

--- a/pipes/WDL/workflows/sarscov2_illumina_full.wdl
+++ b/pipes/WDL/workflows/sarscov2_illumina_full.wdl
@@ -278,7 +278,7 @@ workflow sarscov2_illumina_full {
     call nextstrain.filter_sequences_to_list as submittable_filter {
       input:
         sequences = passing_cat.filtered_fasta,
-        keep_list = select_all(submittable_id)
+        keep_list = write_lines(select_all(submittable_id))
     }
 
     ### prep genbank submission

--- a/pipes/WDL/workflows/sarscov2_illumina_full.wdl
+++ b/pipes/WDL/workflows/sarscov2_illumina_full.wdl
@@ -278,7 +278,7 @@ workflow sarscov2_illumina_full {
     call nextstrain.filter_sequences_to_list as submittable_filter {
       input:
         sequences = passing_cat.filtered_fasta,
-        keep_list = write_lines(select_all(submittable_id))
+        keep_list = [write_lines(select_all(submittable_id))]
     }
 
     ### prep genbank submission

--- a/pipes/WDL/workflows/sarscov2_illumina_full.wdl
+++ b/pipes/WDL/workflows/sarscov2_illumina_full.wdl
@@ -383,7 +383,7 @@ workflow sarscov2_illumina_full {
     if(defined(gcs_out_cdc)) {
         call terra.gcs_copy as gcs_cdc_dump {
             input:
-                infiles        = [assembly_meta_tsv.combined, sc2_meta_final.meta_tsv, passing_cat.filtered_fasta],
+                infiles        = [sc2_meta_final.meta_tsv, passing_cat.filtered_fasta],
                 gcs_uri_prefix = "~{gcs_out_cdc}/~{demux_deplete.run_date}/~{flowcell_id}/"
         }
         call terra.gcs_copy as gcs_cdc_dump_reads {
@@ -406,14 +406,14 @@ workflow sarscov2_illumina_full {
     }
 
     output {
-        Array[File]  raw_reads_unaligned_bams      = demux_deplete.raw_reads_unaligned_bams
-        Array[File]  cleaned_reads_unaligned_bams  = demux_deplete.cleaned_reads_unaligned_bams
-        Array[File]  cleaned_bams_tiny             = demux_deplete.cleaned_bams_tiny
+        Array[File]   raw_reads_unaligned_bams      = demux_deplete.raw_reads_unaligned_bams
+        Array[File]   cleaned_reads_unaligned_bams  = demux_deplete.cleaned_reads_unaligned_bams
+        Array[File]   cleaned_bams_tiny             = demux_deplete.cleaned_bams_tiny
         
-        File         meta_by_filename_json         = demux_deplete.meta_by_filename_json
+        File          meta_by_filename_json         = demux_deplete.meta_by_filename_json
         
-        Array[Int]   read_counts_raw               = demux_deplete.read_counts_raw
-        Array[Int]   read_counts_depleted          = demux_deplete.read_counts_depleted
+        Array[Int]    read_counts_raw               = demux_deplete.read_counts_raw
+        Array[Int]    read_counts_depleted          = demux_deplete.read_counts_depleted
         
         File          sra_metadata                 = select_first([demux_deplete.sra_metadata])
         File          cleaned_bam_uris             = select_first([demux_deplete.cleaned_bam_uris])

--- a/pipes/WDL/workflows/sarscov2_illumina_full.wdl
+++ b/pipes/WDL/workflows/sarscov2_illumina_full.wdl
@@ -419,8 +419,6 @@ workflow sarscov2_illumina_full {
         File          cleaned_bam_uris             = select_first([demux_deplete.cleaned_bam_uris])
         
         Array[File]   assemblies_fasta             = assemble_refbased.assembly_fasta
-        Array[File]   passing_assemblies_fasta     = select_all(passing_assemblies)
-        Array[File]   submittable_assemblies_fasta = select_all(submittable_genomes)
         
         Int           max_ntc_bases                = ntc_max.out
         Array[String] ntc_rejected_batches         = filter_bad_ntc_batches.reject_batches

--- a/pipes/WDL/workflows/sarscov2_illumina_full.wdl
+++ b/pipes/WDL/workflows/sarscov2_illumina_full.wdl
@@ -54,6 +54,7 @@ workflow sarscov2_illumina_full {
         File?         collab_ids_tsv
 
         String?       gcs_out_metrics
+        String?       gcs_out_reporting
         String?       gcs_out_cdc
         String?       gcs_out_sra
     }
@@ -378,6 +379,13 @@ workflow sarscov2_illumina_full {
             input:
               infiles        = flatten([[assembly_meta_tsv.combined, sc2_meta_final.meta_tsv, ivar_trim_stats.trim_stats_tsv, demux_deplete.multiqc_report_raw, demux_deplete.multiqc_report_cleaned, demux_deplete.spikein_counts, picard_wgs_merge.out_tsv, picard_alignment_merge.out_tsv, nextclade_many_samples.nextclade_json, nextclade_many_samples.nextclade_tsv], demux_deplete.demux_metrics]),
               gcs_uri_prefix = "~{gcs_out_metrics}/~{flowcell_id}/"
+        }
+    }
+    if(defined(gcs_out_reporting)) {
+        call terra.gcs_copy as gcs_reporting_dump {
+            input:
+              infiles        = [sc2_meta_final.meta_tsv, nextclade_many_samples.nextclade_json, nextclade_many_samples.nextclade_tsv],
+              gcs_uri_prefix = "~{gcs_out_reporting}/~{flowcell_id}/"
         }
     }
     if(defined(gcs_out_cdc)) {


### PR DESCRIPTION
In sarscov2_illumina_full, automate the rejection of assemblies associated with a contaminated NTC. `batch_lib` associations in the samplesheets will be used if available, otherwise, `lane` will be used.

Rejected samples will:
 - be removed from CDC delivery, Genbank and GISAID submission, and nextmeta prep
 - kept in SRA submissions
 - kept in assembly_meta and assembly_meta.final files (the latter will be marked with a `genome_status` of `failed_NTC`)

This PR additionally adds a few derived column calculations to `sc2_meta_final` (originally in the downstream Rmd report code).

[Testing in Terra](https://app.terra.bio/#workspaces/pathogen-genomic-surveillance/CDC_Viral_Sequencing_dev/job_history/f030563e-6bb5-4f29-98dc-ec57d31b0fd8) against six flowcells looks good.