### PR TITLE
use viral-core with picard 2.25.4

### DIFF
--- a/pipes/WDL/tasks/tasks_assembly.wdl
+++ b/pipes/WDL/tasks/tasks_assembly.wdl
@@ -291,7 +291,7 @@ task align_reads {
     Boolean? skip_mark_dupes = false
 
     Int?     machine_mem_gb
-    String   docker = "quay.io/broadinstitute/viral-core:2.1.28"
+    String   docker = "quay.io/broadinstitute/viral-core:ct-bump-to-picard-2.25.4"
 
     String   sample_name = basename(basename(basename(reads_unmapped_bam, ".bam"), ".taxfilt"), ".clean")
   }
@@ -708,7 +708,7 @@ task run_discordance {
       String out_basename = "run"
       Int    min_coverage = 4
 
-      String docker = "quay.io/broadinstitute/viral-core:2.1.28"
+      String docker = "quay.io/broadinstitute/viral-core:ct-bump-to-picard-2.25.4"
     }
 
     command {

--- a/pipes/WDL/tasks/tasks_demux.wdl
+++ b/pipes/WDL/tasks/tasks_demux.wdl
@@ -6,7 +6,7 @@ task merge_tarballs {
     String       out_filename
 
     Int?         machine_mem_gb
-    String       docker = "quay.io/broadinstitute/viral-core:2.1.28"
+    String       docker = "quay.io/broadinstitute/viral-core:ct-bump-to-picard-2.25.4"
   }
 
   command {
@@ -142,7 +142,7 @@ task illumina_demux {
     Int?    maxRecordsInRam
 
     Int?    machine_mem_gb
-    String  docker = "quay.io/broadinstitute/viral-core:2.1.28"
+    String  docker = "quay.io/broadinstitute/viral-core:ct-bump-to-picard-2.25.4"
   }
   parameter_meta {
       flowcell_tgz: {

--- a/pipes/WDL/tasks/tasks_interhost.wdl
+++ b/pipes/WDL/tasks/tasks_interhost.wdl
@@ -142,7 +142,7 @@ task index_ref {
     File?  novocraft_license
 
     Int?   machine_mem_gb
-    String docker = "quay.io/broadinstitute/viral-core:2.1.28"
+    String docker = "quay.io/broadinstitute/viral-core:ct-bump-to-picard-2.25.4"
   }
 
   command {

--- a/pipes/WDL/tasks/tasks_ncbi.wdl
+++ b/pipes/WDL/tasks/tasks_ncbi.wdl
@@ -186,7 +186,7 @@ task structured_comments {
 
     File?  filter_to_ids
 
-    String docker = "quay.io/broadinstitute/viral-core:2.1.28"
+    String docker = "quay.io/broadinstitute/viral-core:ct-bump-to-picard-2.25.4"
   }
   String out_base = basename(assembly_stats_tsv, '.txt')
   command <<<
@@ -264,7 +264,7 @@ task rename_fasta_header {
 
     String out_basename = basename(genome_fasta, ".fasta")
 
-    String docker = "quay.io/broadinstitute/viral-core:2.1.28"
+    String docker = "quay.io/broadinstitute/viral-core:ct-bump-to-picard-2.25.4"
   }
   command {
     set -e
@@ -445,7 +445,7 @@ task sra_meta_prep {
     Boolean     paired
 
     String      out_name = "sra_metadata.tsv"
-    String      docker="quay.io/broadinstitute/viral-core:2.1.28"
+    String      docker="quay.io/broadinstitute/viral-core:ct-bump-to-picard-2.25.4"
   }
   parameter_meta {
     cleaned_bam_filepaths: {

--- a/pipes/WDL/tasks/tasks_nextstrain.wdl
+++ b/pipes/WDL/tasks/tasks_nextstrain.wdl
@@ -81,7 +81,7 @@ task derived_cols {
         String?       lab_highlight_loc
         Array[File]   table_map = []
 
-        String        docker = "quay.io/broadinstitute/viral-core:2.1.28"
+        String        docker = "quay.io/broadinstitute/viral-core:ct-bump-to-picard-2.25.4"
     }
     parameter_meta {
         lab_highlight_loc: {
@@ -480,7 +480,7 @@ task filter_sequences_by_length {
         File   sequences_fasta
         Int    min_non_N = 1
 
-        String docker = "quay.io/broadinstitute/viral-core:2.1.28"
+        String docker = "quay.io/broadinstitute/viral-core:ct-bump-to-picard-2.25.4"
     }
     parameter_meta {
         sequences_fasta: {

--- a/pipes/WDL/tasks/tasks_read_utils.wdl
+++ b/pipes/WDL/tasks/tasks_read_utils.wdl
@@ -79,7 +79,7 @@ task get_sample_meta {
   input {
     Array[File] samplesheets_extended
 
-    String      docker = "quay.io/broadinstitute/viral-core:2.1.28"
+    String      docker = "quay.io/broadinstitute/viral-core:ct-bump-to-picard-2.25.4"
   }
   command <<<
     python3 << CODE
@@ -137,7 +137,7 @@ task merge_and_reheader_bams {
       File?        reheader_table
       String       out_basename
 
-      String       docker = "quay.io/broadinstitute/viral-core:2.1.28"
+      String       docker = "quay.io/broadinstitute/viral-core:ct-bump-to-picard-2.25.4"
     }
 
     command {
@@ -197,7 +197,7 @@ task rmdup_ubam {
     String  method = "mvicuna"
 
     Int?    machine_mem_gb
-    String? docker = "quay.io/broadinstitute/viral-core:2.1.28"
+    String? docker = "quay.io/broadinstitute/viral-core:ct-bump-to-picard-2.25.4"
   }
 
   parameter_meta {
@@ -251,7 +251,7 @@ task downsample_bams {
     Boolean?     deduplicateAfter = false
 
     Int?         machine_mem_gb
-    String       docker = "quay.io/broadinstitute/viral-core:2.1.28"
+    String       docker = "quay.io/broadinstitute/viral-core:ct-bump-to-picard-2.25.4"
   }
 
   command {
@@ -310,7 +310,7 @@ task FastqToUBAM {
     String? platform_name
     String? sequencing_center
 
-    String  docker = "quay.io/broadinstitute/viral-core:2.1.28"
+    String  docker = "quay.io/broadinstitute/viral-core:ct-bump-to-picard-2.25.4"
   }
   parameter_meta {
     fastq_1: { description: "Unaligned read1 file in fastq format", patterns: ["*.fastq", "*.fastq.gz", "*.fq", "*.fq.gz"] }

--- a/pipes/WDL/tasks/tasks_reports.wdl
+++ b/pipes/WDL/tasks/tasks_reports.wdl
@@ -7,7 +7,7 @@ task alignment_metrics {
     File?  primers_bed
 
     Int?   machine_mem_gb
-    String docker = "quay.io/broadinstitute/viral-core:2.1.28"
+    String docker = "quay.io/broadinstitute/viral-core:ct-bump-to-picard-2.25.4"
   }
 
   String out_basename = basename(aligned_bam, ".bam")
@@ -93,7 +93,7 @@ task plot_coverage {
     Boolean bin_large_plots = false
     String? binning_summary_statistic = "max" # max or min
 
-    String  docker = "quay.io/broadinstitute/viral-core:2.1.28"
+    String  docker = "quay.io/broadinstitute/viral-core:ct-bump-to-picard-2.25.4"
   }
   
   command {
@@ -168,7 +168,7 @@ task coverage_report {
     Array[File]  mapped_bam_idx # optional.. speeds it up if you provide it, otherwise we auto-index
     String       out_report_name = "coverage_report.txt"
 
-    String       docker = "quay.io/broadinstitute/viral-core:2.1.28"
+    String       docker = "quay.io/broadinstitute/viral-core:ct-bump-to-picard-2.25.4"
   }
 
   command {
@@ -227,7 +227,7 @@ task fastqc {
   input {
     File   reads_bam
 
-    String docker = "quay.io/broadinstitute/viral-core:2.1.28"
+    String docker = "quay.io/broadinstitute/viral-core:ct-bump-to-picard-2.25.4"
   }
 
   String   reads_basename=basename(reads_bam, ".bam")
@@ -260,7 +260,7 @@ task align_and_count {
     Int    topNHits = 3
 
     Int?   machine_mem_gb
-    String docker = "quay.io/broadinstitute/viral-core:2.1.28"
+    String docker = "quay.io/broadinstitute/viral-core:ct-bump-to-picard-2.25.4"
   }
 
   String  reads_basename=basename(reads_bam, ".bam")
@@ -305,7 +305,7 @@ task align_and_count_summary {
 
     String       output_prefix = "count_summary"
 
-    String       docker = "quay.io/broadinstitute/viral-core:2.1.28"
+    String       docker = "quay.io/broadinstitute/viral-core:ct-bump-to-picard-2.25.4"
   }
 
   command {

--- a/pipes/WDL/tasks/tasks_taxon_filter.wdl
+++ b/pipes/WDL/tasks/tasks_taxon_filter.wdl
@@ -202,7 +202,7 @@ task merge_one_per_sample {
     Boolean?     rmdup = false
 
     Int?         machine_mem_gb
-    String       docker = "quay.io/broadinstitute/viral-core:2.1.28"
+    String       docker = "quay.io/broadinstitute/viral-core:ct-bump-to-picard-2.25.4"
   }
 
   command {

--- a/pipes/WDL/tasks/tasks_utils.wdl
+++ b/pipes/WDL/tasks/tasks_utils.wdl
@@ -241,7 +241,7 @@ task tsv_stack {
   input {
     Array[File]+ input_tsvs
     String       out_basename
-    String       docker = "quay.io/broadinstitute/viral-core:2.1.28"
+    String       docker = "quay.io/broadinstitute/viral-core:ct-bump-to-picard-2.25.4"
   }
 
   command {

--- a/requirements-modules.txt
+++ b/requirements-modules.txt
@@ -1,4 +1,4 @@
-broadinstitute/viral-core=2.1.28
+broadinstitute/viral-core=ct-bump-to-picard-2.25.4
 broadinstitute/viral-assemble=2.1.16.1
 broadinstitute/viral-classify=2.1.16.0
 broadinstitute/viral-phylo=2.1.19.1


### PR DESCRIPTION
WIP pulling viral-core from a branch until picard 2.25.4 is known working and pinning in the requirements on the main branch of viral-core