### PR TITLE
multiple misc fixes

### DIFF
--- a/pipes/WDL/tasks/tasks_interhost.wdl
+++ b/pipes/WDL/tasks/tasks_interhost.wdl
@@ -213,10 +213,15 @@ task merge_vcfs_bcftools {
 
   command {
 
+    # copy files to CWD (required for tabix indexing)
+    INFILES=~{write_lines(in_vcfs_gz)}
+    ln -s $(cat $INFILES) .
+    for FN in $(cat $INFILES); do basename $FN; done > vcf_filenames.txt
+
     # tabix index input vcfs (must be gzipped)
-    parallel -I ,, \
-      "tabix -p vcf ,," \
-      ::: "${sep=' ' in_vcfs_gz}"
+    for FN in $(cat vcf_filenames.txt); do
+      tabix -p vcf $FN
+    done
 
     # see: https://samtools.github.io/bcftools/bcftools.html#merge
     # --merge snps allows snps to be merged to multi-allelic (multi-ALT) records, all other records are listed separately
@@ -227,7 +232,7 @@ task merge_vcfs_bcftools {
     --output ${output_prefix}.vcf.gz \
     --output-type z \
     --threads "$(nproc --all)" \
-    ${sep=' ' in_vcfs_gz}
+    --file-list vcf_filenames.txt
 
     # tabix index the vcf to create .tbi file
     tabix -p vcf ${output_prefix}.vcf.gz

--- a/pipes/WDL/tasks/tasks_ncbi.wdl
+++ b/pipes/WDL/tasks/tasks_ncbi.wdl
@@ -388,49 +388,6 @@ task lookup_table_by_filename {
   }
 }
 
-task register_biosamples {
-  meta {
-    description: "This registers a table of metadata with NCBI BioSample. It accepts a TSV similar to the web UI input at submit.ncbi.nlm.nih.gov, but converts to an XML, submits via their FTP/XML API, awaits a response, and retrieves a resulting attributes table and returns that as a TSV. This task registers live data with the production NCBI database."
-  }
-  input {
-    File     sample_metadata_tsv
-    String?  comment
-    String?  embargo_date
-
-    String   org_name
-    String   org_type
-    String   spuid_namespace
-    String   account_name
-
-    File     ftp_config
-    Boolean  test=true
-
-    String   docker = "local/broad-tsv-converter"  # for dev/debug only
-  }
-  String meta_basename = basename(basename(sample_metadata_tsv, '.txt'), '.tsv')
-  command {
-    set -e -o pipefail
-
-    cp "~{sample_metadata_tsv}" files/input.tsv
-    # modify src/config.js
-
-    node src/main.js -i=input.tsv \
-      ~{'-c="' + comment + '"'} \
-      ~{'-d=' + embargo_date} \
-      -u="/~{true='Test' false='Production' test}/~{meta_basename}"
-
-  }
-  output {
-    String value = read_string("OUTVAL")
-  }
-  runtime {
-    docker: docker
-    memory: "1 GB"
-    cpu: 1
-    dx_instance_type: "mem1_ssd1_v2_x2"
-  }
-}
-
 task sra_meta_prep {
   meta {
     description: "Prepare tables for submission to NCBI's SRA database. This only works on bam files produced by illumina.py illumina_demux --append_run_id in viral-core."

--- a/pipes/WDL/tasks/tasks_ncbi_tools.wdl
+++ b/pipes/WDL/tasks/tasks_ncbi_tools.wdl
@@ -9,6 +9,11 @@ task Fetch_SRA_to_BAM {
         String  docker = "quay.io/broadinstitute/ncbi-tools:2.10.7.8"
     }
 
+    meta {
+        description: "This searches NCBI SRA for accessions using the Entrez interface, collects associated metadata, and returns read sets as unaligned BAM files with metadata loaded in. Useful metadata from BioSample is also output from this task directly. This has been tested with both SRA and ENA accessions. This queries the NCBI production database, and as such, the output of this task is non-deterministic given the same input.",
+        volatile: true
+    }
+
     command <<<
         set -e
         # fetch SRA metadata on this record
@@ -139,6 +144,39 @@ task Fetch_SRA_to_BAM {
     }
 }
 
+task biosample_tsv_filter_preexisting {
+    input {
+        File           meta_submit_tsv
+
+        String         out_basename = "biosample_attributes"
+        String         docker = "quay.io/broadinstitute/ncbi-tools:2.10.7.8"
+    }
+    meta {
+        description: "This task takes a metadata TSV for submission to NCBI BioSample and filters out entries that have already been submitted to NCBI. This queries the NCBI production database, and as such, the output of this task is non-deterministic given the same input.",
+        volatile: true
+    }
+    command <<<
+        set -e
+
+        echo "TO DO!"
+        exit 1
+
+        /opt/docker/scripts/biosample-fetch_attributes.py \
+            $(cat samplenames) "~{out_basename}"
+    >>>
+    output {
+        File    meta_unsubmitted_tsv = ""
+        File    biosample_attributes_tsv  = "~{out_basename}.tsv"
+    }
+    runtime {
+        cpu:     2
+        memory:  "3 GB"
+        disks:   "local-disk 50 HDD"
+        dx_instance_type: "mem2_ssd1_v2_x2"
+        docker:  docker
+    }
+}
+
 task fetch_biosamples {
     input {
         Array[String]  biosample_ids
@@ -147,6 +185,7 @@ task fetch_biosamples {
         String         docker = "quay.io/broadinstitute/ncbi-tools:2.10.7.8"
     }
     meta {
+        description: "This searches NCBI BioSample for accessions or keywords using the Entrez interface and returns any hits in the form of a BioSample attributes TSV. This queries the NCBI production database, and as such, the output of this task is non-deterministic given the same input.",
         volatile: true
     }
     command <<<
@@ -256,6 +295,9 @@ task biosample_submit_tsv_to_xml {
 
         String   docker = "quay.io/broadinstitute/ncbi-tools:2.10.7.8"
     }
+    meta {
+        description: "This converts a web portal submission TSV for NCBI BioSample into an ftp-appropriate XML submission for NCBI BioSample. It does not connect to NCBI, and does not submit or fetch any data."
+    }
     command <<<
         set -e
         cd /opt/converter
@@ -289,6 +331,9 @@ task biosample_submit_tsv_ftp_upload {
         String   docker = "quay.io/broadinstitute/ncbi-tools:2.10.7.8"
     }
     String base=basename(meta_submit_tsv, '.tsv')
+    meta {
+        description: "This registers a table of metadata with NCBI BioSample. It accepts a TSV similar to the web UI input at submit.ncbi.nlm.nih.gov, but converts to an XML, submits via their FTP/XML API, awaits a response, and retrieves a resulting attributes table and returns that as a TSV. This task registers live data with the production NCBI database."
+    }
     command <<<
         set -e
         cd /opt/converter
@@ -323,6 +368,9 @@ task biosample_xml_response_to_tsv {
         String   docker = "quay.io/broadinstitute/ncbi-tools:2.10.7.8"
     }
     String out_name = "~{basename(meta_submit_tsv, '.tsv')}-attributes.tsv"
+    meta {
+        description: "This converts an FTP-based XML response from BioSample into a web-portal-style attributes.tsv file with metadata and accessions. This task does not communicate with NCBI, it only parses pre-retrieved responses."
+    }
     command <<<
         set -e
         cd /opt/converter

--- a/pipes/WDL/tasks/tasks_ncbi_tools.wdl
+++ b/pipes/WDL/tasks/tasks_ncbi_tools.wdl
@@ -10,7 +10,7 @@ task Fetch_SRA_to_BAM {
     }
 
     meta {
-        description: "This searches NCBI SRA for accessions using the Entrez interface, collects associated metadata, and returns read sets as unaligned BAM files with metadata loaded in. Useful metadata from BioSample is also output from this task directly. This has been tested with both SRA and ENA accessions. This queries the NCBI production database, and as such, the output of this task is non-deterministic given the same input.",
+        description: "This searches NCBI SRA for accessions using the Entrez interface, collects associated metadata, and returns read sets as unaligned BAM files with metadata loaded in. Useful metadata from BioSample is also output from this task directly. This has been tested with both SRA and ENA accessions. This queries the NCBI production database, and as such, the output of this task is non-deterministic given the same input."
         volatile: true
     }
 
@@ -152,7 +152,7 @@ task biosample_tsv_filter_preexisting {
         String         docker = "quay.io/broadinstitute/ncbi-tools:2.10.7.8"
     }
     meta {
-        description: "This task takes a metadata TSV for submission to NCBI BioSample and filters out entries that have already been submitted to NCBI. This queries the NCBI production database, and as such, the output of this task is non-deterministic given the same input.",
+        description: "This task takes a metadata TSV for submission to NCBI BioSample and filters out entries that have already been submitted to NCBI. This queries the NCBI production database, and as such, the output of this task is non-deterministic given the same input."
         volatile: true
     }
     command <<<
@@ -185,7 +185,7 @@ task fetch_biosamples {
         String         docker = "quay.io/broadinstitute/ncbi-tools:2.10.7.8"
     }
     meta {
-        description: "This searches NCBI BioSample for accessions or keywords using the Entrez interface and returns any hits in the form of a BioSample attributes TSV. This queries the NCBI production database, and as such, the output of this task is non-deterministic given the same input.",
+        description: "This searches NCBI BioSample for accessions or keywords using the Entrez interface and returns any hits in the form of a BioSample attributes TSV. This queries the NCBI production database, and as such, the output of this task is non-deterministic given the same input."
         volatile: true
     }
     command <<<

--- a/pipes/WDL/workflows/sarscov2_biosample_load.wdl
+++ b/pipes/WDL/workflows/sarscov2_biosample_load.wdl
@@ -29,9 +29,13 @@ workflow sarscov2_biosample_load {
         }
     }
 
+    File meta_submit_tsv = select_first([biosample_submit_tsv, crsp_meta_etl.biosample_submit_tsv])
+
+    #call ncbi_tools.fetch_biosamples
+
     call ncbi_tools.biosample_submit_tsv_ftp_upload {
         input:
-            meta_submit_tsv = select_first([biosample_submit_tsv, crsp_meta_etl.biosample_submit_tsv]),
+            meta_submit_tsv = meta_submit_tsv,
             config_js = ftp_config_js,
             target_path = ftp_target_path
     } 

--- a/pipes/WDL/workflows/sarscov2_illumina_full.wdl
+++ b/pipes/WDL/workflows/sarscov2_illumina_full.wdl
@@ -505,6 +505,7 @@ workflow sarscov2_illumina_full {
         Int           num_samples                  = length(group_bams_by_sample.sample_names)
         
         String        run_date                     = demux_deplete.run_date
+        String        run_id                       = demux_deplete.run_id
         
         File?         sequencing_reports           = sequencing_report.all_zip
         


### PR DESCRIPTION
- some fixes in `tasks_interhost.merge_vcfs_bcftools`: task command block was calling `parallel` which didn't exist in docker image, task was attempting to tabix index files in a read-only file system.
- remove unused/vestigal `tasks_ncbi.register_biosamples` in favor of `tasks_ncbi_tools.biosample_submit_tsv_ftp_upload` which replaced it
- add `run_id` as workflow level output to `sarscov2_illumina_full` (requested by DSP)
- add more `meta` `description` documentation to more tasks
- add `meta` `volatile:true` to tasks that retrieve live data from NCBI
- begin initial work on `tasks_ncbi_tools.biosample_tsv_filter_preexisting` (WiP, not ready yet)