### PR TITLE
bump sc2-rmd docker

### DIFF
--- a/pipes/WDL/tasks/tasks_sarscov2.wdl
+++ b/pipes/WDL/tasks/tasks_sarscov2.wdl
@@ -187,7 +187,7 @@ task sequencing_report {
         String? voc_list
         String? voi_list
 
-        String  docker = "quay.io/broadinstitute/sc2-rmd:0.1.20"
+        String  docker = "quay.io/broadinstitute/sc2-rmd:0.1.21"
     }
     command {
         set -e


### PR DESCRIPTION
Update sc2-rmd docker to reflect new CDC VOC/VOI definitions (B.1.427/429 demotes to VOI)