### PR TITLE
sarscov2: state public health reporting change

### DIFF
--- a/pipes/WDL/workflows/sarscov2_illumina_full.wdl
+++ b/pipes/WDL/workflows/sarscov2_illumina_full.wdl
@@ -55,7 +55,6 @@ workflow sarscov2_illumina_full {
         File?         collab_ids_tsv
 
         String?       gcs_out_metrics
-        String?       gcs_out_reporting
         String?       gcs_out_cdc
         String?       gcs_out_sra
     }
@@ -401,17 +400,6 @@ workflow sarscov2_illumina_full {
             input:
               infiles        = flatten([[assembly_meta_tsv.combined, sc2_meta_final.meta_tsv, ivar_trim_stats.trim_stats_tsv, demux_deplete.multiqc_report_raw, demux_deplete.multiqc_report_cleaned, demux_deplete.spikein_counts, picard_wgs_merge.out_tsv, picard_alignment_merge.out_tsv, picard_insertsize_merge.out_tsv, nextclade_many_samples.nextclade_json, nextclade_many_samples.nextclade_tsv], demux_deplete.demux_metrics]),
               gcs_uri_prefix = "~{gcs_out_metrics}/~{flowcell_id}/"
-        }
-    }
-    if(defined(gcs_out_reporting)) {
-        call utils.tsv_to_csv as meta_final_csv {
-          input:
-            tsv = sc2_meta_final.meta_tsv
-        }
-        call terra.gcs_copy as gcs_reporting_dump {
-            input:
-              infiles        = [meta_final_csv.csv],
-              gcs_uri_prefix = "~{gcs_out_reporting}/"
         }
     }
     if(defined(gcs_out_cdc)) {


### PR DESCRIPTION
Move state public health epi reporting from `sarscov2_illumina_full` to `sarscov2_data_release` -- the GCS bucket delivery triggers stateless cloud functions that deliver directly to several state PH entities -- repeated re-runs of sarscov2_illumina_full were causing repeat entries in state epi databases. Move this bucket delivery to the data release workflow that should only be run once per run.