### PR TITLE
add task nextstrain_deduplicate_sequences; include in sarscov2_nextstrain workflows

### DIFF
--- a/pipes/WDL/tasks/tasks_nextstrain.wdl
+++ b/pipes/WDL/tasks/tasks_nextstrain.wdl
@@ -400,6 +400,7 @@ task nextstrain_deduplicate_sequences {
     }
 
     String out_basename = basename(basename(basename(basename(sequences_fasta, '.xz'), '.gz'), '.tar'), '.fasta')
+    String out_filename = "~{out_basename}_sequences_deduplicated.fasta.xz"
     command {
         set -e
         ncov_path_prefix="/nextstrain/ncov"
@@ -410,7 +411,7 @@ task nextstrain_deduplicate_sequences {
         python3 "$ncov_path_prefix/scripts/sanitize_sequences.py" \
         --sequences "~{sequences_fasta}" \
         ${true="--error-on-duplicate-strains" false="" error_on_seq_diff} \
-        --output "~{out_basename}_sequences_deduplicated.fasta.gz"
+        --output "~{out_filename}"
     }
     runtime {
         docker: docker
@@ -420,7 +421,7 @@ task nextstrain_deduplicate_sequences {
         dx_instance_type: "mem2_ssd1_v2_x2"
     }
     output {
-        File sequences_deduplicated_fasta = "~{out_basename}_sequences_deduplicated.fasta.gz"
+        File sequences_deduplicated_fasta = "~{out_filename}"
     }
 }
 

--- a/pipes/WDL/tasks/tasks_nextstrain.wdl
+++ b/pipes/WDL/tasks/tasks_nextstrain.wdl
@@ -400,7 +400,7 @@ task nextstrain_deduplicate_sequences {
     }
 
     String out_basename = basename(basename(basename(basename(sequences_fasta, '.xz'), '.gz'), '.tar'), '.fasta')
-    String out_filename = "~{out_basename}_sequences_deduplicated.fasta.xz"
+    String out_filename = "~{out_basename}_sequences_deduplicated.fasta"
     command {
         set -e
         ncov_path_prefix="/nextstrain/ncov"

--- a/pipes/WDL/tasks/tasks_nextstrain.wdl
+++ b/pipes/WDL/tasks/tasks_nextstrain.wdl
@@ -376,6 +376,54 @@ task nextstrain_ncov_defaults {
     }
 }
 
+task nextstrain_deduplicate_sequences {
+    meta {
+        description: "This uses the Nextstrain sanitize_sequences.py script to deduplicate sequences by sequence ID. If the sequences themselves differ, and error is optionally raised. See: https://github.com/nextstrain/ncov/blob/c4747c1f53cd84baaeacdbd044390604d1af2cfc/scripts/sanitize_sequences.py"
+    }
+
+    input {
+        File sequences_fasta
+        Boolean error_on_seq_diff = false
+
+        String nextstrain_ncov_repo_commit = "99ccfc5c6601e78468e7db193ee453128ba593ff"
+        String docker                      = "nextstrain/base:build-20210413T201712Z"
+    }
+
+    parameter_meta {
+        sequences_fasta: {
+          description: "FASTA file with multiple sequences",
+          patterns: ["*.fasta","*.fasta.xz","*.fasta.gz"]
+        }
+        error_on_seq_diff: {
+            description: "If error_on_seq_diff=true, an error will be raised if duplicate sequence IDs exist but have different sequences. By default, use the first occurrence of each duplicated sequence."
+        }
+    }
+
+    String out_basename = basename(basename(basename(basename(sequences_fasta, '.xz'), '.gz'), '.tar'), '.fasta')
+    command {
+        set -e
+        ncov_path_prefix="/nextstrain/ncov"
+        wget -q "https://github.com/nextstrain/ncov/archive/~{nextstrain_ncov_repo_commit}.tar.gz"
+        mkdir -p "$ncov_path_prefix"
+        tar -xf "~{nextstrain_ncov_repo_commit}.tar.gz" --strip-components=1 -C "$ncov_path_prefix"
+
+        python3 "$ncov_path_prefix/scripts/sanitize_sequences.py" \
+        --sequences "~{sequences_fasta}" \
+        ${true="--error-on-duplicate-strains" false="" error_on_seq_diff} \
+        --output "~{out_basename}_sequences_deduplicated.fasta.gz"
+    }
+    runtime {
+        docker: docker
+        memory: "7 GB"
+        cpu:   1
+        disks:  "local-disk 375 LOCAL"
+        dx_instance_type: "mem2_ssd1_v2_x2"
+    }
+    output {
+        File sequences_deduplicated_fasta = "~{out_basename}_sequences_deduplicated.fasta.gz"
+    }
+}
+
 task nextstrain_ncov_sanitize_gisaid_data {
     meta {
         description: "Sanitize data downloaded from GISAID for use in Nextstrain/augur. See: https://nextstrain.github.io/ncov/data-prep#curate-data-from-the-full-gisaid-database"

--- a/pipes/WDL/workflows/sarscov2_nextstrain.wdl
+++ b/pipes/WDL/workflows/sarscov2_nextstrain.wdl
@@ -58,9 +58,14 @@ workflow sarscov2_nextstrain {
             output_name = "all_samples_combined_assembly.fasta"
     }
 
+    call nextstrain.nextstrain_deduplicate_sequences as dedup_seqs {
+        input:
+            sequences_fasta = zcat.combined
+    }
+
     call nextstrain.filter_sequences_by_length {
         input:
-            sequences_fasta = zcat.combined,
+            sequences_fasta = dedup_seqs.sequences_deduplicated_fasta,
             min_non_N       = min_unambig_genome
     }
 

--- a/pipes/WDL/workflows/sarscov2_nextstrain_aligned_input.wdl
+++ b/pipes/WDL/workflows/sarscov2_nextstrain_aligned_input.wdl
@@ -73,10 +73,15 @@ workflow sarscov2_nextstrain_aligned_input {
     }
 
 
+    call nextstrain.nextstrain_deduplicate_sequences as dedup_seqs {
+        input:
+            sequences_fasta = zcat.combined
+    }
+
     #### subsample sequences with nextstrain yaml file
     call nextstrain.nextstrain_build_subsample as subsample {
         input:
-            alignment_msa_fasta = zcat.combined,
+            alignment_msa_fasta = dedup_seqs.sequences_deduplicated_fasta,
             sample_metadata_tsv = derived_cols.derived_metadata,
             build_name          = build_name,
             builds_yaml         = builds_yaml


### PR DESCRIPTION
add WDL task `nextstrain_deduplicate_sequences`, relying on the Nextstrain script [`sanitize_sequences.py`](https://github.com/nextstrain/ncov/blob/c4747c1f53cd84baaeacdbd044390604d1af2cfc/scripts/sanitize_sequences.py); include in `sarscov2_nextstrain*` workflows