### PR TITLE
update purpose_of_sequencing to new gisaid field

### DIFF
--- a/pipes/WDL/tasks/tasks_ncbi.wdl
+++ b/pipes/WDL/tasks/tasks_ncbi.wdl
@@ -362,7 +362,7 @@ task gisaid_meta_prep {
             'submitter'           : "~{default='REQUIRED' username}",
             'fn'                  : "~{default='REQUIRED' fasta_filename}",
 
-            'covv_add_host_info'  : row.get('note',''),
+            'covv_sampling_strategy'  : row.get('note',''),
           })
 
     CODE


### PR DESCRIPTION
GISAID now has a `covv_sampling_strategy` field where we can put the `purpose_of_sequencing` value.. we used to shoehorn this into `covv_add_host_info` but it never really was appropriate there.