### PR TITLE
update sc2-rmd docker

### DIFF
--- a/pipes/WDL/tasks/tasks_sarscov2.wdl
+++ b/pipes/WDL/tasks/tasks_sarscov2.wdl
@@ -215,7 +215,7 @@ task sequencing_report {
         String? voc_list
         String? voi_list
 
-        String  docker = "quay.io/broadinstitute/sc2-rmd:0.1.24"
+        String  docker = "quay.io/broadinstitute/sc2-rmd:0.1.25"
     }
     command {
         set -e


### PR DESCRIPTION
Update public health R-markdown PDF reports to use Nextclade instead of PANGO for: 1) VoC/VoI definition lists and 2) tabular PDF outputs.