### PR TITLE
more nextstrain task/VM memory

### DIFF
--- a/pipes/WDL/tasks/tasks_nextstrain.wdl
+++ b/pipes/WDL/tasks/tasks_nextstrain.wdl
@@ -1224,10 +1224,10 @@ task ancestral_traits {
     }
     runtime {
         docker: docker
-        memory: "7 GB"
-        cpu :   2
-        disks:  "local-disk 50 HDD"
-        dx_instance_type: "mem1_ssd1_v2_x2"
+        memory: "32 GB"
+        cpu :   4
+        disks:  "local-disk 100 HDD"
+        dx_instance_type: "mem3_ssd1_v2_x4"
         preemptible: 1
         maxRetries: 2
     }
@@ -1588,10 +1588,10 @@ task export_auspice_json {
     }
     runtime {
         docker: docker
-        memory: "13 GB"
-        cpu :   2
+        memory: "32 GB"
+        cpu :   4
         disks:  "local-disk 100 HDD"
-        dx_instance_type: "mem1_ssd1_v2_x2"
+        dx_instance_type: "mem3_ssd1_v2_x4"
         preemptible: 0
         maxRetries: 2
     }


### PR DESCRIPTION
Based on recent runs, increase default RAM for
 - task `ancestral_traits`
 - task `export_auspice_json`