### PR TITLE
nextstrain subsampling keep_list bug fix

### DIFF
--- a/pipes/WDL/tasks/tasks_nextstrain.wdl
+++ b/pipes/WDL/tasks/tasks_nextstrain.wdl
@@ -295,7 +295,8 @@ task nextstrain_build_subsample {
         # hard inclusion list
         KEEP_LIST="~{default='' keep_list}"
         if [ -n "$KEEP_LIST" ]; then
-            cat $KEEP_LIST >> defaults/include.txt
+            for i in $(cat defaults/include.txt); do echo $i; done > include-ncov-default-cleannewlines.txt
+            cat include-ncov-default-cleannewlines.txt $KEEP_LIST > defaults/include.txt
         fi
 
         # seed input data (skip some upstream steps in the DAG)


### PR DESCRIPTION
Bug fix for nextstrain subsampling where `keep_list` is provided as input: If keep_list was provided, the first line was typically lost to a concatenation error with the default ncov file that didn't have a newline on the last line. This fix allows for scenarios where the upstream github repo either has a newline or not on the last line.