### PR TITLE
rework biosample_load to not use todays date in ftp directory path

### DIFF
--- a/pipes/WDL/workflows/sarscov2_biosample_load.wdl
+++ b/pipes/WDL/workflows/sarscov2_biosample_load.wdl
@@ -32,7 +32,6 @@ workflow sarscov2_biosample_load {
 
     File meta_submit_tsv = select_first([biosample_submit_tsv, crsp_meta_etl.biosample_submit_tsv])
 
-    call utils.today
     call utils.md5sum {
         input:
             in_file = meta_submit_tsv
@@ -51,7 +50,7 @@ workflow sarscov2_biosample_load {
             input:
                 meta_submit_tsv = biosample_tsv_filter_preexisting.meta_unsubmitted_tsv,
                 config_js = ftp_config_js,
-                target_path = "/~{prod_test}/~{today.date}_~{md5sum.md5}/biosample"
+                target_path = "/~{prod_test}/biosample/~{basename(meta_submit_tsv, '.tsv')}/~{md5sum.md5}"
         }
     }
 


### PR DESCRIPTION
The biosample_load workflow had been using today's date (ISO format) to construct a target directory path on NCBI's FTP server for BioSample submissions. This is because the directory space on the FTP server never seems to clean up (and we don't have delete permissions) so we need to ensure a unique destination for our inputs.

Using today's date, however, results in cromwell call cache misses of the ftp biosample registration task when sarscov2_illumina_full workflow fail overnight and you need to re-run the next day. This PR removes today's date from the inputs of that task and instead constructs the target directory based on the name of the input tsv file plus its MD5 hash, which should all remain stable for the same inputs.
