### PR TITLE
rename detect_cross_contamination task to polyphonia_detect_cross_contamination

### DIFF
--- a/pipes/WDL/tasks/tasks_intrahost.wdl
+++ b/pipes/WDL/tasks/tasks_intrahost.wdl
@@ -1,6 +1,6 @@
 version 1.0
 
-task detect_cross_contamination {
+task polyphonia_detect_cross_contamination {
   input {
     Array[File]  lofreq_vcfs
     Array[File]  genome_fastas

--- a/pipes/WDL/workflows/detect_cross_contamination.wdl
+++ b/pipes/WDL/workflows/detect_cross_contamination.wdl
@@ -58,7 +58,7 @@ workflow detect_cross_contamination {
     }
 
     Array[Array[File]] vcfs_and_genomes = transpose(vcf_genome_read_depth_triplets)
-    call intrahost.detect_cross_contamination as detect_cross_contam {
+    call intrahost.polyphonia_detect_cross_contamination as detect_cross_contam {
         # take scatter-gathered array of [(vcf1,fasta1),(vcf2,fasta2),(vcf3,fasta3)]
         # and transpose to [[vcf1,vcf2,vcf3],[fasta1,fasta2,fasta3]]
         input:

--- a/pipes/WDL/workflows/detect_cross_contamination_precalled_vcfs.wdl
+++ b/pipes/WDL/workflows/detect_cross_contamination_precalled_vcfs.wdl
@@ -31,7 +31,7 @@ workflow detect_cross_contamination_precalled_vcfs {
         File         reference_fasta
     }
 
-    call intrahost.detect_cross_contamination as detect_cross_contam {
+    call intrahost.polyphonia_detect_cross_contamination as detect_cross_contam {
         input:
             lofreq_vcfs     = lofreq_vcfs,
             genome_fastas   = genome_fastas,


### PR DESCRIPTION
This renames the `detect_cross_contamination` task to `polyphonia_detect_cross_contamination` so the `detect_cross_contamination` workflow and the task it calls are named differently.

This is intended to address a build failure with dxWDL ("`detect_cross_contamination appears with two different callable definitions`").