### PR TITLE
dnanexus build fixes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -279,7 +279,7 @@ jobs:
 
   deploy_dnanexus:
     #if: ${{ github.event.ref == 'dnanexus' }}
-    if: github.event_name == 'release' || (github.base_ref == 'master' && github.event_name == 'pull_request' && github.event.pull_request.merged == true)
+    if: github.event_name == 'release' || github.ref == 'refs/heads/master'
     needs:
       - validate_wdl_womtool
       - validate_wdl_miniwdl

--- a/pipes/WDL/workflows/sarscov2_nextstrain.wdl
+++ b/pipes/WDL/workflows/sarscov2_nextstrain.wdl
@@ -1,4 +1,5 @@
 version 1.0
+#DX_SKIP_WORKFLOW
 
 import "../tasks/tasks_nextstrain.wdl" as nextstrain
 import "../tasks/tasks_utils.wdl" as utils

--- a/pipes/WDL/workflows/sarscov2_nextstrain_aligned_input.wdl
+++ b/pipes/WDL/workflows/sarscov2_nextstrain_aligned_input.wdl
@@ -1,4 +1,5 @@
 version 1.0
+#DX_SKIP_WORKFLOW
 
 import "../tasks/tasks_nextstrain.wdl" as nextstrain
 import "../tasks/tasks_utils.wdl" as utils


### PR DESCRIPTION
- skip two workflows (sarscov2_nextstrain*) on dnanexus builds, due to default File inputs being set to incompatible values (GCS bucket strings)
- attempt to re-enable dnanexus builds on default branch in github actions