### PR TITLE
sarscov2_batch_relineage: speed up localization

### DIFF
--- a/pipes/WDL/tasks/tasks_utils.wdl
+++ b/pipes/WDL/tasks/tasks_utils.wdl
@@ -7,6 +7,7 @@ task concatenate {
     input {
         Array[File] infiles
         String      output_name
+        Int         cpus = 4
     }
     command {
         cat ~{sep=" " infiles} > "~{output_name}"
@@ -14,7 +15,7 @@ task concatenate {
     runtime {
         docker: "ubuntu"
         memory: "1 GB"
-        cpu:    1
+        cpu:    cpus
         disks: "local-disk 375 LOCAL"
         dx_instance_type: "mem1_ssd1_v2_x2"
     }

--- a/pipes/WDL/workflows/sarscov2_batch_relineage.wdl
+++ b/pipes/WDL/workflows/sarscov2_batch_relineage.wdl
@@ -17,16 +17,16 @@ workflow sarscov2_batch_relineage {
         Int         min_genome_bases = 24000
     }
 
-    call utils.zcat {
+    call utils.concatenate {
         input:
             infiles     = genomes_fasta,
             output_name = "all-genomes.fasta",
-            cpus        = 8
+            cpus        = 16
     }
 
     call utils.filter_sequences_by_length {
         input:
-            sequences_fasta = zcat.combined,
+            sequences_fasta = concatenate.combined,
             min_non_N       = min_genome_bases
     }
 


### PR DESCRIPTION
The majority of time spent in sarscov2_batch_relinage is localization of fasta files in the zcat step. Replace with a normal concatenate step (no need to deal with compression) and increase cpus to speed up data localization.