### PR TITLE
use WDL value for submitting_lab_name in gisaid_meta_prep python body…

### DIFF
--- a/pipes/WDL/tasks/tasks_ncbi.wdl
+++ b/pipes/WDL/tasks/tasks_ncbi.wdl
@@ -307,7 +307,7 @@ task gisaid_meta_prep {
     # institutional mappings
     address_map = json.loads('~{address_map}')
     authors_map = json.loads('~{authors_map}')
-    assert "~{submitting_lab_name}" in address_map, f"error: institution '{submitting_lab_name}' not found in address_map"
+    assert "~{submitting_lab_name}" in address_map, f"error: institution '~{submitting_lab_name}' not found in address_map"
 
     # lookup table files to dicts
     sample_to_cmt = {}


### PR DESCRIPTION
The python body of the gisaid_meta_prep task includes an assertion to verify the submitting_lab_name value is in the address map json file, and emits an error if not. This fixes an issue where the error text python f-string fails to evaluate because it is looking for the variable in python scope rather than using a string pre-substituted by the WDL executor before running the python block.