### PR TITLE
bump viral-core image and remove workaround

### DIFF
--- a/pipes/WDL/tasks/tasks_assembly.wdl
+++ b/pipes/WDL/tasks/tasks_assembly.wdl
@@ -294,7 +294,7 @@ task align_reads {
     Boolean? skip_mark_dupes = false
 
     Int?     machine_mem_gb
-    String   docker = "quay.io/broadinstitute/viral-core:2.1.32"
+    String   docker = "quay.io/broadinstitute/viral-core:2.1.33"
 
     String   sample_name = basename(basename(basename(reads_unmapped_bam, ".bam"), ".taxfilt"), ".clean")
   }
@@ -715,7 +715,7 @@ task run_discordance {
       String out_basename = "run"
       Int    min_coverage = 4
 
-      String docker = "quay.io/broadinstitute/viral-core:2.1.32"
+      String docker = "quay.io/broadinstitute/viral-core:2.1.33"
     }
 
     command {

--- a/pipes/WDL/tasks/tasks_demux.wdl
+++ b/pipes/WDL/tasks/tasks_demux.wdl
@@ -6,7 +6,7 @@ task merge_tarballs {
     String       out_filename
 
     Int?         machine_mem_gb
-    String       docker = "quay.io/broadinstitute/viral-core:2.1.32"
+    String       docker = "quay.io/broadinstitute/viral-core:2.1.33"
   }
 
   command {
@@ -143,7 +143,7 @@ task illumina_demux {
     Int?    maxRecordsInRam
 
     Int?    machine_mem_gb
-    String  docker = "quay.io/broadinstitute/viral-core:2.1.32"
+    String  docker = "quay.io/broadinstitute/viral-core:2.1.33"
   }
   parameter_meta {
       flowcell_tgz: {

--- a/pipes/WDL/tasks/tasks_interhost.wdl
+++ b/pipes/WDL/tasks/tasks_interhost.wdl
@@ -142,7 +142,7 @@ task index_ref {
     File?  novocraft_license
 
     Int?   machine_mem_gb
-    String docker = "quay.io/broadinstitute/viral-core:2.1.32"
+    String docker = "quay.io/broadinstitute/viral-core:2.1.33"
   }
 
   command {

--- a/pipes/WDL/tasks/tasks_ncbi.wdl
+++ b/pipes/WDL/tasks/tasks_ncbi.wdl
@@ -186,7 +186,7 @@ task structured_comments {
 
     File?  filter_to_ids
 
-    String docker = "quay.io/broadinstitute/viral-core:2.1.32"
+    String docker = "quay.io/broadinstitute/viral-core:2.1.33"
   }
   String out_base = basename(assembly_stats_tsv, '.txt')
   command <<<
@@ -264,7 +264,7 @@ task rename_fasta_header {
 
     String out_basename = basename(genome_fasta, ".fasta")
 
-    String docker = "quay.io/broadinstitute/viral-core:2.1.32"
+    String docker = "quay.io/broadinstitute/viral-core:2.1.33"
   }
   command {
     set -e
@@ -426,7 +426,7 @@ task sra_meta_prep {
     Boolean     paired
 
     String      out_name = "sra_metadata.tsv"
-    String      docker="quay.io/broadinstitute/viral-core:2.1.32"
+    String      docker="quay.io/broadinstitute/viral-core:2.1.33"
   }
   parameter_meta {
     cleaned_bam_filepaths: {

--- a/pipes/WDL/tasks/tasks_nextstrain.wdl
+++ b/pipes/WDL/tasks/tasks_nextstrain.wdl
@@ -251,7 +251,7 @@ task derived_cols {
         String?       lab_highlight_loc
         Array[File]   table_map = []
 
-        String        docker = "quay.io/broadinstitute/viral-core:2.1.32"
+        String        docker = "quay.io/broadinstitute/viral-core:2.1.33"
     }
     parameter_meta {
         lab_highlight_loc: {

--- a/pipes/WDL/tasks/tasks_read_utils.wdl
+++ b/pipes/WDL/tasks/tasks_read_utils.wdl
@@ -79,7 +79,7 @@ task get_sample_meta {
   input {
     Array[File] samplesheets_extended
 
-    String      docker = "quay.io/broadinstitute/viral-core:2.1.32"
+    String      docker = "quay.io/broadinstitute/viral-core:2.1.33"
   }
   command <<<
     python3 << CODE
@@ -137,7 +137,7 @@ task merge_and_reheader_bams {
       File?        reheader_table
       String       out_basename
 
-      String       docker = "quay.io/broadinstitute/viral-core:2.1.32"
+      String       docker = "quay.io/broadinstitute/viral-core:2.1.33"
     }
 
     command {
@@ -198,7 +198,7 @@ task rmdup_ubam {
     String  method = "mvicuna"
 
     Int?    machine_mem_gb
-    String? docker = "quay.io/broadinstitute/viral-core:2.1.32"
+    String? docker = "quay.io/broadinstitute/viral-core:2.1.33"
   }
 
   parameter_meta {
@@ -253,7 +253,7 @@ task downsample_bams {
     Boolean?     deduplicateAfter = false
 
     Int?         machine_mem_gb
-    String       docker = "quay.io/broadinstitute/viral-core:2.1.32"
+    String       docker = "quay.io/broadinstitute/viral-core:2.1.33"
   }
 
   command {
@@ -313,7 +313,7 @@ task FastqToUBAM {
     String? platform_name
     String? sequencing_center
 
-    String  docker = "quay.io/broadinstitute/viral-core:2.1.32"
+    String  docker = "quay.io/broadinstitute/viral-core:2.1.33"
   }
   parameter_meta {
     fastq_1: { description: "Unaligned read1 file in fastq format", patterns: ["*.fastq", "*.fastq.gz", "*.fq", "*.fq.gz"] }
@@ -360,7 +360,7 @@ task read_depths {
     File      aligned_bam
 
     String    out_basename = basename(aligned_bam, '.bam')
-    String    docker = "quay.io/broadinstitute/viral-core:2.1.32"
+    String    docker = "quay.io/broadinstitute/viral-core:2.1.33"
   }
   command <<<
     set -e -o pipefail

--- a/pipes/WDL/tasks/tasks_reports.wdl
+++ b/pipes/WDL/tasks/tasks_reports.wdl
@@ -7,7 +7,7 @@ task alignment_metrics {
     File?  primers_bed
 
     Int?   machine_mem_gb
-    String docker = "quay.io/broadinstitute/viral-core:2.1.32"
+    String docker = "quay.io/broadinstitute/viral-core:2.1.33"
   }
 
   String out_basename = basename(aligned_bam, ".bam")
@@ -17,11 +17,6 @@ task alignment_metrics {
     MEM_MB=$(free -m | head -2 | tail -1 | awk '{print $4}')
     XMX=$(echo "-Xmx"$MEM_MB"m")
     echo "Requesting $MEM_MB MB of RAM for Java"
-
-    # R fails unless you do this, CollectInsertSizeMetrics needs R
-    if [ ! -f /lib/x86_64-linux-gnu/libreadline.so.6 ]; then
-      ln -s /lib/x86_64-linux-gnu/libreadline.so.7 /lib/x86_64-linux-gnu/libreadline.so.6
-    fi
 
     # requisite Picard fasta indexing
     cp "~{ref_fasta}" reference.fasta
@@ -105,7 +100,7 @@ task plot_coverage {
     String? plotXLimits # of the form "min max" (ints, space between)
     String? plotYLimits # of the form "min max" (ints, space between)
 
-    String  docker = "quay.io/broadinstitute/viral-core:2.1.32"
+    String  docker = "quay.io/broadinstitute/viral-core:2.1.33"
   }
   
   command {
@@ -187,7 +182,7 @@ task coverage_report {
     Array[File]  mapped_bam_idx # optional.. speeds it up if you provide it, otherwise we auto-index
     String       out_report_name = "coverage_report.txt"
 
-    String       docker = "quay.io/broadinstitute/viral-core:2.1.32"
+    String       docker = "quay.io/broadinstitute/viral-core:2.1.33"
   }
 
   command {
@@ -248,7 +243,7 @@ task fastqc {
   input {
     File   reads_bam
 
-    String docker = "quay.io/broadinstitute/viral-core:2.1.32"
+    String docker = "quay.io/broadinstitute/viral-core:2.1.33"
   }
 
   String   reads_basename=basename(reads_bam, ".bam")
@@ -282,7 +277,7 @@ task align_and_count {
     Int    topNHits = 3
 
     Int?   machine_mem_gb
-    String docker = "quay.io/broadinstitute/viral-core:2.1.32"
+    String docker = "quay.io/broadinstitute/viral-core:2.1.33"
   }
 
   String  reads_basename=basename(reads_bam, ".bam")
@@ -328,7 +323,7 @@ task align_and_count_summary {
 
     String       output_prefix = "count_summary"
 
-    String       docker = "quay.io/broadinstitute/viral-core:2.1.32"
+    String       docker = "quay.io/broadinstitute/viral-core:2.1.33"
   }
 
   command {

--- a/pipes/WDL/tasks/tasks_taxon_filter.wdl
+++ b/pipes/WDL/tasks/tasks_taxon_filter.wdl
@@ -205,7 +205,7 @@ task merge_one_per_sample {
     Boolean?     rmdup = false
 
     Int?         machine_mem_gb
-    String       docker = "quay.io/broadinstitute/viral-core:2.1.32"
+    String       docker = "quay.io/broadinstitute/viral-core:2.1.33"
   }
 
   command {

--- a/pipes/WDL/tasks/tasks_utils.wdl
+++ b/pipes/WDL/tasks/tasks_utils.wdl
@@ -121,7 +121,7 @@ task zcat {
         cat /sys/fs/cgroup/memory/memory.max_usage_in_bytes > MEM_BYTES
     >>>
     runtime {
-        docker: "quay.io/broadinstitute/viral-core:2.1.32"
+        docker: "quay.io/broadinstitute/viral-core:2.1.33"
         memory: "1 GB"
         cpu:    cpus
         disks: "local-disk 375 LOCAL"
@@ -391,7 +391,7 @@ task tsv_stack {
   input {
     Array[File]+ input_tsvs
     String       out_basename
-    String       docker = "quay.io/broadinstitute/viral-core:2.1.32"
+    String       docker = "quay.io/broadinstitute/viral-core:2.1.33"
   }
 
   command {
@@ -516,7 +516,7 @@ task filter_sequences_by_length {
         File   sequences_fasta
         Int    min_non_N = 1
 
-        String docker = "quay.io/broadinstitute/viral-core:2.1.32"
+        String docker = "quay.io/broadinstitute/viral-core:2.1.33"
     }
     parameter_meta {
         sequences_fasta: {

--- a/requirements-modules.txt
+++ b/requirements-modules.txt
@@ -1,4 +1,4 @@
-broadinstitute/viral-core=2.1.32
+broadinstitute/viral-core=2.1.33
 broadinstitute/viral-assemble=2.1.16.1
 broadinstitute/viral-classify=2.1.16.0
 broadinstitute/viral-phylo=2.1.19.1


### PR DESCRIPTION
- upgrade viral-core from 2.1.32 to 2.1.33. Includes a fix to docker image that allows R to work properly
- remove R workaround from WDL task `alignment_metrics` in tasks_reports