### PR TITLE
update pangolin docker

### DIFF
--- a/pipes/WDL/tasks/tasks_sarscov2.wdl
+++ b/pipes/WDL/tasks/tasks_sarscov2.wdl
@@ -9,7 +9,7 @@ task pangolin_one_sample {
         Int?    min_length
         Float?  max_ambig
         Boolean inference_usher=true
-        String  docker = "quay.io/staphb/pangolin:3.1.14-pangolearn-2021-09-28"
+        String  docker = "quay.io/staphb/pangolin:3.1.14-pangolearn-2021-10-13"
     }
     String basename = basename(genome_fasta, ".fasta")
     command <<<
@@ -81,7 +81,7 @@ task pangolin_many_samples {
         Float?       max_ambig
         Boolean      inference_usher=true
         String       basename
-        String       docker = "quay.io/staphb/pangolin:3.1.14-pangolearn-2021-09-28"
+        String       docker = "quay.io/staphb/pangolin:3.1.14-pangolearn-2021-10-13"
     }
     command <<<
         date | tee DATE

--- a/requirements-modules.txt
+++ b/requirements-modules.txt
@@ -7,5 +7,5 @@ broadinstitute/beast-beagle-cuda=1.10.5pre
 broadinstitute/ncbi-tools=2.10.7.10
 nextstrain/base=build-20210413T201712Z
 andersenlabapps/ivar=1.3.1
-quay.io/staphb/pangolin=3.1.14-pangolearn-2021-09-28
+quay.io/staphb/pangolin=3.1.14-pangolearn-2021-10-13
 nextstrain/nextclade=1.4.0


### PR DESCRIPTION
Update pangolin docker:
- bump pangolearn 2021-09-28 to 2021-10-13
- bump pango-designation 1.2.81 to 1.2.88
- bump scorpio 0.3.12 to 0.3.13
- bump constellations 0.0.16 -> 0.0.18

No changes to pangolin or usher versions