### PR TITLE
Terra robustness

### DIFF
--- a/pipes/WDL/tasks/tasks_assembly.wdl
+++ b/pipes/WDL/tasks/tasks_assembly.wdl
@@ -275,6 +275,7 @@ task ivar_trim_stats {
         cpu: 1
         disks: "local-disk 50 HDD"
         dx_instance_type: "mem1_ssd1_v2_x2"
+        maxRetries: 2
     }
 }
 

--- a/pipes/WDL/tasks/tasks_demux.wdl
+++ b/pipes/WDL/tasks/tasks_demux.wdl
@@ -77,6 +77,7 @@ task samplesheet_rename_ids {
     cpu: 1
     disks: "local-disk 50 HDD"
     dx_instance_type: "mem1_ssd1_v2_x2"
+    maxRetries: 2
   }
 }
 
@@ -119,6 +120,7 @@ task revcomp_i5 {
     cpu:    1
     disks: "local-disk 50 HDD"
     dx_instance_type: "mem1_ssd1_v2_x2"
+    maxRetries: 2
   }
 }
 
@@ -426,6 +428,7 @@ task map_map_setdefault {
     cpu: 1
     disks: "local-disk 20 HDD"
     dx_instance_type: "mem1_ssd1_v2_x2"
+    maxRetries: 2
   }
 }
 
@@ -455,5 +458,6 @@ task merge_maps {
     cpu: 1
     disks: "local-disk 20 HDD"
     dx_instance_type: "mem1_ssd1_v2_x2"
+    maxRetries: 2
   }
 }

--- a/pipes/WDL/tasks/tasks_interhost.wdl
+++ b/pipes/WDL/tasks/tasks_interhost.wdl
@@ -41,6 +41,7 @@ task multi_align_mafft_ref {
     cpu: 8
     disks: "local-disk 200 HDD"
     dx_instance_type: "mem3_ssd1_v2_x8"
+    maxRetries: 2
   }
 }
 
@@ -83,6 +84,7 @@ task multi_align_mafft {
     cpu: 8
     disks: "local-disk 200 HDD"
     dx_instance_type: "mem2_ssd1_v2_x8"
+    maxRetries: 2
   }
 }
 
@@ -124,6 +126,7 @@ task beast {
     memory: "7 GB"
     cpu:    4
     disks: "local-disk 300 HDD"
+    maxRetries: 1
     bootDiskSizeGb: 50
     gpu:                 true                # dxWDL
     dx_timeout:          "40H"               # dxWDL
@@ -166,6 +169,7 @@ task index_ref {
     cpu: 2
     memory: select_first([machine_mem_gb, 4]) + " GB"
     disks: "local-disk 100 HDD"
+    maxRetries: 2
   }
 }
 
@@ -192,6 +196,7 @@ task trimal_clean_msa {
     cpu: 4
     disks: "local-disk 100 HDD"
     dx_instance_type: "mem1_ssd1_v2_x8"
+    maxRetries: 2
   }
 }
 
@@ -248,6 +253,7 @@ task merge_vcfs_bcftools {
     memory: select_first([machine_mem_gb, 3]) + " GB"
     cpu: 2
     dx_instance_type: "mem1_ssd1_v2_x2"
+    maxRetries: 2
   }
 }
 
@@ -309,5 +315,6 @@ task merge_vcfs_gatk {
     memory: select_first([machine_mem_gb, 3]) + " GB"
     cpu: 2
     dx_instance_type: "mem1_ssd1_v2_x2"
+    maxRetries: 2
   }
 }

--- a/pipes/WDL/tasks/tasks_intrahost.wdl
+++ b/pipes/WDL/tasks/tasks_intrahost.wdl
@@ -109,6 +109,7 @@ task polyphonia_detect_cross_contamination {
     memory: "13 GB"
     disks:  "local-disk 100 HDD"
     dx_instance_type: "mem1_ssd1_v2_x4"
+    maxRetries: 2
   }
 }
 
@@ -144,6 +145,7 @@ task lofreq {
     memory: "3 GB"
     disks:  "local-disk 200 HDD"
     dx_instance_type: "mem1_ssd1_v2_x2"
+    maxRetries: 2
   }
 }
 
@@ -183,6 +185,7 @@ task isnvs_per_sample {
     docker: "${docker}"
     memory: select_first([machine_mem_gb, 7]) + " GB"
     dx_instance_type: "mem1_ssd1_v2_x8"
+    maxRetries: 2
   }
 }
 
@@ -260,6 +263,7 @@ task isnvs_vcf {
     docker: "${docker}"
     memory: select_first([machine_mem_gb, 4]) + " GB"
     dx_instance_type: "mem1_ssd1_v2_x4"
+    maxRetries: 2
   }
 }
 
@@ -351,5 +355,6 @@ task annotate_vcf_snpeff {
     memory: select_first([machine_mem_gb, 4]) + " GB"
     disks:  "local-disk 375 LOCAL"
     dx_instance_type: "mem1_ssd1_v2_x4"
+    maxRetries: 2
   }
 }

--- a/pipes/WDL/tasks/tasks_metagenomics.wdl
+++ b/pipes/WDL/tasks/tasks_metagenomics.wdl
@@ -120,6 +120,7 @@ task krakenuniq {
     disks: "local-disk 750 LOCAL"
     dx_instance_type: "mem3_ssd1_v2_x48"
     preemptible: 0
+    maxRetries: 2
   }
 }
 
@@ -186,6 +187,7 @@ task build_krakenuniq_db {
     cpu: 32
     dx_instance_type: "mem3_ssd1_v2_x32"
     preemptible: 0
+    maxRetries: 2
   }
 }
 
@@ -309,6 +311,7 @@ task kraken2 {
     disks: "local-disk 750 LOCAL"
     dx_instance_type: "mem3_ssd1_v2_x8"
     preemptible: 2
+    maxRetries: 2
   }
 }
 
@@ -458,6 +461,7 @@ task build_kraken2_db {
     cpu: 16
     dx_instance_type: "mem3_ssd1_v2_x16"
     preemptible: 0
+    maxRetries: 2
   }
 }
 
@@ -543,6 +547,7 @@ task blastx {
     disks: "local-disk 375 LOCAL"
     dx_instance_type: "mem1_ssd1_v2_x36"
     preemptible: 1
+    maxRetries: 2
   }
 }
 
@@ -613,6 +618,7 @@ task krona {
     cpu: 1
     disks: "local-disk 50 HDD"
     dx_instance_type: "mem1_ssd2_v2_x2"
+    maxRetries: 2
   }
 }
 
@@ -642,6 +648,7 @@ task krona_merge {
     cpu: 1
     disks: "local-disk 50 HDD"
     dx_instance_type: "mem1_ssd2_v2_x2"
+    maxRetries: 2
   }
 }
 
@@ -731,8 +738,8 @@ task filter_bam_to_taxa {
     disks: "local-disk 375 LOCAL"
     cpu: 4
     dx_instance_type: "mem3_ssd1_v2_x4"
+    maxRetries: 2
   }
-
 }
 
 task kaiju {
@@ -805,5 +812,6 @@ task kaiju {
     cpu: 16
     disks: "local-disk 375 LOCAL"
     dx_instance_type: "mem3_ssd1_v2_x16"
+    maxRetries: 2
   }
 }

--- a/pipes/WDL/tasks/tasks_ncbi.wdl
+++ b/pipes/WDL/tasks/tasks_ncbi.wdl
@@ -28,6 +28,7 @@ task download_fasta {
     memory: "7 GB"
     cpu: 2
     dx_instance_type: "mem2_ssd1_v2_x2"
+    maxRetries: 2
   }
 }
 
@@ -68,6 +69,7 @@ task download_annotations {
     memory: "7 GB"
     cpu: 2
     dx_instance_type: "mem2_ssd1_v2_x2"
+    maxRetries: 2
   }
 }
 
@@ -121,6 +123,7 @@ task annot_transfer {
     memory: "3 GB"
     cpu: 2
     dx_instance_type: "mem1_ssd1_v2_x2"
+    maxRetries: 2
   }
 }
 
@@ -177,6 +180,7 @@ task align_and_annot_transfer_single {
     cpu: 4
     dx_instance_type: "mem2_ssd1_v2_x4"
     preemptible: 1
+    maxRetries: 2
   }
 }
 
@@ -226,6 +230,7 @@ task structured_comments {
     memory: "1 GB"
     cpu: 1
     dx_instance_type: "mem1_ssd1_v2_x2"
+    maxRetries: 2
   }
 }
 
@@ -254,6 +259,7 @@ task prefix_fasta_header {
     memory: "1 GB"
     cpu: 1
     dx_instance_type: "mem1_ssd1_v2_x2"
+    maxRetries: 2
   }
 }
 
@@ -279,6 +285,7 @@ task rename_fasta_header {
     memory: "1 GB"
     cpu: 1
     dx_instance_type: "mem1_ssd1_v2_x2"
+    maxRetries: 2
   }
 }
 
@@ -386,6 +393,7 @@ task gisaid_meta_prep {
     memory: "1 GB"
     cpu: 1
     dx_instance_type: "mem1_ssd1_v2_x2"
+    maxRetries: 2
   }
 }
 
@@ -409,6 +417,7 @@ task lookup_table_by_filename {
     memory: "1 GB"
     cpu: 1
     dx_instance_type: "mem1_ssd1_v2_x2"
+    maxRetries: 2
   }
 }
 
@@ -537,6 +546,7 @@ task sra_meta_prep {
     cpu: 1
     disks: "local-disk 100 HDD"
     dx_instance_type: "mem1_ssd1_v2_x2"
+    maxRetries: 2
   }
 }
 
@@ -581,6 +591,7 @@ task biosample_to_genbank {
     memory: "1 GB"
     cpu: 1
     dx_instance_type: "mem1_ssd1_v2_x2"
+    maxRetries: 2
   }
 }
 
@@ -693,6 +704,7 @@ task generate_author_sbt_file {
     memory: "1 GB"
     cpu: 1
     dx_instance_type: "mem1_ssd1_v2_x2"
+    maxRetries: 2
   }
 }
 
@@ -830,6 +842,7 @@ task prepare_genbank {
     memory: select_first([machine_mem_gb, 3]) + " GB"
     cpu: 2
     dx_instance_type: "mem1_ssd1_v2_x2"
+    maxRetries: 2
   }
 }
 
@@ -899,6 +912,7 @@ task package_genbank_ftp_submission {
     memory: "1 GB"
     cpu: 1
     dx_instance_type: "mem1_ssd1_v2_x2"
+    maxRetries: 2
   }
 }
 
@@ -954,6 +968,7 @@ task vadr {
     memory: "2 GB"
     cpu: 1
     dx_instance_type: "mem1_ssd1_v2_x2"
+    maxRetries: 2
   }
 }
 

--- a/pipes/WDL/tasks/tasks_ncbi_tools.wdl
+++ b/pipes/WDL/tasks/tasks_ncbi_tools.wdl
@@ -141,6 +141,7 @@ task Fetch_SRA_to_BAM {
         disks:   "local-disk 750 LOCAL"
         dx_instance_type: "mem2_ssd1_v2_x2"
         docker:  docker
+        maxRetries: 2
     }
 }
 
@@ -200,6 +201,7 @@ task biosample_tsv_filter_preexisting {
         disks:   "local-disk 50 HDD"
         dx_instance_type: "mem2_ssd1_v2_x2"
         docker:  docker
+        maxRetries: 2
     }
 }
 
@@ -229,6 +231,7 @@ task fetch_biosamples {
         disks:   "local-disk 50 HDD"
         dx_instance_type: "mem2_ssd1_v2_x2"
         docker:  docker
+        maxRetries: 2
     }
 }
 
@@ -275,6 +278,7 @@ task ncbi_sftp_upload {
         disks:   "local-disk 100 HDD"
         dx_instance_type: "mem2_ssd1_v2_x2"
         docker:  docker
+        maxRetries: 0
     }
 }
 
@@ -311,6 +315,7 @@ task sra_tsv_to_xml {
         disks:   "local-disk 50 HDD"
         dx_instance_type: "mem2_ssd1_v2_x2"
         docker:  docker
+        maxRetries: 2
     }
 }
 
@@ -345,6 +350,7 @@ task biosample_submit_tsv_to_xml {
         disks:   "local-disk 50 HDD"
         dx_instance_type: "mem2_ssd1_v2_x2"
         docker:  docker
+        maxRetries: 2
     }
 }
 
@@ -383,6 +389,7 @@ task biosample_submit_tsv_ftp_upload {
         disks:   "local-disk 100 HDD"
         dx_instance_type: "mem2_ssd1_v2_x2"
         docker:  docker
+        maxRetries: 0
     }
 }
 
@@ -418,6 +425,7 @@ task biosample_xml_response_to_tsv {
         disks:   "local-disk 100 HDD"
         dx_instance_type: "mem2_ssd1_v2_x2"
         docker:  docker
+        maxRetries: 2
     }
 }
 
@@ -506,6 +514,7 @@ task group_sra_bams_by_biosample {
     cpu: 1
     disks: "local-disk 100 HDD"
     dx_instance_type: "mem1_ssd1_v2_x2"
+    maxRetries: 2
   }
 }
 

--- a/pipes/WDL/tasks/tasks_nextstrain.wdl
+++ b/pipes/WDL/tasks/tasks_nextstrain.wdl
@@ -64,6 +64,7 @@ task nextclade_one_sample {
         cpu:    2
         disks: "local-disk 50 HDD"
         dx_instance_type: "mem1_ssd1_v2_x2"
+        maxRetries: 2
     }
     output {
         String nextclade_version = read_string("VERSION")
@@ -154,6 +155,7 @@ task nextclade_many_samples {
         cpu:    4
         disks: "local-disk 100 HDD"
         dx_instance_type: "mem1_ssd1_v2_x4"
+        maxRetries: 2
     }
     output {
         Map[String,String] nextclade_clade   = read_json("NEXTCLADE_CLADE.json")
@@ -239,6 +241,7 @@ task nextmeta_prep {
     memory: "1 GB"
     cpu: 1
     dx_instance_type: "mem1_ssd1_v2_x2"
+    maxRetries: 2
   }
 }
 
@@ -350,6 +353,7 @@ task derived_cols {
         cpu:    1
         disks: "local-disk 50 HDD"
         dx_instance_type: "mem1_ssd1_v2_x2"
+        maxRetries: 2
     }
     output {
         File derived_metadata = "~{basename}.derived_cols.txt"
@@ -395,6 +399,7 @@ task filter_segments {
         cpu:    1
         disks: "local-disk 375 LOCAL"
         dx_instance_type: "mem1_ssd1_v2_x2"
+        maxRetries: 2
     }
     output {
         File assembly_of_segment = stdout()
@@ -554,6 +559,7 @@ task nextstrain_ncov_defaults {
         cpu:   1
         disks:  "local-disk 50 HDD"
         dx_instance_type: "mem1_ssd1_v2_x2"
+        maxRetries: 2
     }
     output {
         File clades_tsv      = "defaults/clades.tsv"
@@ -609,6 +615,7 @@ task nextstrain_deduplicate_sequences {
         cpu:   1
         disks:  "local-disk 375 LOCAL"
         dx_instance_type: "mem2_ssd1_v2_x2"
+        maxRetries: 2
     }
     output {
         File sequences_deduplicated_fasta = "~{out_filename}"
@@ -670,6 +677,7 @@ task nextstrain_ncov_sanitize_gisaid_data {
         cpu:   1
         disks:  "local-disk 375 LOCAL"
         dx_instance_type: "mem2_ssd1_v2_x2"
+        maxRetries: 2
     }
     output {
         File sequences_gisaid_sanitized_fasta = "~{out_basename}_sequences_sanitized_for_nextstrain.fasta.gz"
@@ -1126,6 +1134,7 @@ task snp_sites {
         disks:  "local-disk 100 HDD"
         preemptible: 0
         dx_instance_type: "mem3_ssd1_v2_x4"
+        maxRetries: 2
     }
     output {
         File   snps_vcf          = "~{out_basename}.vcf"

--- a/pipes/WDL/tasks/tasks_read_utils.wdl
+++ b/pipes/WDL/tasks/tasks_read_utils.wdl
@@ -20,6 +20,7 @@ task max {
     cpu: 1
     disks: "local-disk 10 HDD"
     dx_instance_type: "mem1_ssd1_v2_x2"
+    maxRetries: 2
   }
 }
 
@@ -72,6 +73,7 @@ task group_bams_by_sample {
     cpu: 1
     disks: "local-disk 100 HDD"
     dx_instance_type: "mem1_ssd1_v2_x2"
+    maxRetries: 2
   }
 }
 
@@ -122,6 +124,7 @@ task get_sample_meta {
     cpu: 1
     disks: "local-disk 50 HDD"
     dx_instance_type: "mem1_ssd1_v2_x2"
+    maxRetries: 2
   }
 }
 
@@ -377,5 +380,6 @@ task read_depths {
     memory: "3 GB"
     disks:  "local-disk 200 HDD"
     dx_instance_type: "mem1_ssd1_v2_x2"
+    maxRetries: 2
   }
 }

--- a/pipes/WDL/tasks/tasks_sarscov2.wdl
+++ b/pipes/WDL/tasks/tasks_sarscov2.wdl
@@ -54,6 +54,7 @@ task pangolin_one_sample {
         cpu:    2
         disks: "local-disk 50 HDD"
         dx_instance_type: "mem1_ssd1_v2_x2"
+        maxRetries: 2
     }
     output {
         String     date                   = read_string("DATE")
@@ -138,6 +139,7 @@ task pangolin_many_samples {
         cpu:    16
         disks: "local-disk 100 HDD"
         dx_instance_type: "mem1_ssd1_v2_x16"
+        maxRetries: 2
     }
     output {
         Map[String,String] pango_lineage          = read_json("PANGO_LINEAGE.json")
@@ -197,6 +199,7 @@ task sequencing_report {
         cpu:    2
         disks: "local-disk 50 HDD"
         dx_instance_type: "mem1_ssd1_v2_x2"
+        maxRetries: 2
     }
     output {
         Array[File] reports = glob("*.pdf")
@@ -343,6 +346,7 @@ task sc2_meta_final {
         cpu:    2
         disks: "local-disk 50 HDD"
         dx_instance_type: "mem1_ssd1_v2_x2"
+        maxRetries: 2
     }
     output {
         File meta_tsv = "~{out_basename}.final.tsv"
@@ -510,6 +514,7 @@ task crsp_meta_etl {
         cpu:    2
         disks: "local-disk 50 HDD"
         dx_instance_type: "mem1_ssd1_v2_x2"
+        maxRetries: 2
     }
     output {
         File          biosample_submit_tsv = "biosample_meta_submit-~{out_basename}.tsv"
@@ -545,5 +550,6 @@ task gisaid_uploader {
     memory: "2 GB"
     cpu: 2
     disks: "local-disk 100 HDD"
+    maxRetries: 0
   }
 }

--- a/pipes/WDL/tasks/tasks_terra.wdl
+++ b/pipes/WDL/tasks/tasks_terra.wdl
@@ -26,6 +26,7 @@ task gcs_copy {
     docker: "quay.io/broadinstitute/viral-baseimage:0.1.20"
     memory: "1 GB"
     cpu: 1
+    maxRetries: 1
   }
 }
 
@@ -57,6 +58,7 @@ task upload_entities_tsv {
     docker: docker
     memory: "2 GB"
     cpu: 1
+    maxRetries: 0
   }
   output {
     Array[String] tables = read_lines('TABLES_MODIFIED')
@@ -118,6 +120,7 @@ task download_entities_tsv {
     docker: docker
     memory: "2 GB"
     cpu: 1
+    maxRetries: 2
   }
   output {
     File tsv_file = '~{outname}'

--- a/pipes/WDL/tasks/tasks_utils.wdl
+++ b/pipes/WDL/tasks/tasks_utils.wdl
@@ -18,6 +18,7 @@ task concatenate {
         cpu:    cpus
         disks: "local-disk 375 LOCAL"
         dx_instance_type: "mem1_ssd1_v2_x2"
+        maxRetries: 2
     }
     output {
         File combined = "${output_name}"
@@ -104,6 +105,7 @@ task zcat {
         cpu:    cpus
         disks: "local-disk 375 LOCAL"
         dx_instance_type: "mem1_ssd1_v2_x2"
+        maxRetries: 2
     }
     output {
         File    combined     = "${output_name}"
@@ -130,6 +132,7 @@ task fasta_to_ids {
         cpu:    1
         disks: "local-disk 375 LOCAL"
         dx_instance_type: "mem1_ssd1_v2_x2"
+        maxRetries: 2
     }
     output {
         File ids_txt = "~{basename}.txt"
@@ -152,6 +155,7 @@ task md5sum {
     cpu: 1
     disks: "local-disk 100 HDD"
     dx_instance_type: "mem1_ssd2_v2_x2"
+    maxRetries: 2
   }
 }
 
@@ -188,6 +192,7 @@ task fetch_row_from_tsv {
     cpu: 1
     disks: "local-disk 50 HDD"
     dx_instance_type: "mem1_ssd1_v2_x2"
+    maxRetries: 2
   }
 }
 
@@ -225,6 +230,7 @@ task fetch_col_from_tsv {
     cpu: 1
     disks: "local-disk 50 HDD"
     dx_instance_type: "mem1_ssd1_v2_x2"
+    maxRetries: 2
   }
 }
 
@@ -378,6 +384,7 @@ task tsv_to_csv {
     docker: "python:slim"
     disks: "local-disk 50 HDD"
     dx_instance_type: "mem1_ssd1_v2_x2"
+    maxRetries: 2
   }
 }
 
@@ -410,6 +417,7 @@ task tsv_drop_cols {
         cpu:    1
         disks: "local-disk 50 HDD"
         dx_instance_type: "mem1_ssd1_v2_x2"
+        maxRetries: 2
     }
     output {
         File out_tsv = "~{out_filename}"
@@ -441,6 +449,7 @@ task tsv_stack {
     docker: "${docker}"
     disks: "local-disk 50 HDD"
     dx_instance_type: "mem1_ssd1_v2_x2"
+    maxRetries: 2
   }
 }
 
@@ -460,6 +469,7 @@ task make_empty_file {
     docker: "ubuntu"
     disks: "local-disk 10 HDD"
     dx_instance_type: "mem1_ssd1_v2_x2"
+    maxRetries: 2
   }
 }
 
@@ -480,6 +490,7 @@ task rename_file {
     docker: "ubuntu"
     disks: "local-disk 100 HDD"
     dx_instance_type: "mem1_ssd1_v2_x2"
+    maxRetries: 2
   }
 }
 
@@ -503,6 +514,7 @@ task today {
     docker: "quay.io/broadinstitute/viral-baseimage:0.1.20"
     disks: "local-disk 10 HDD"
     dx_instance_type: "mem1_ssd1_v2_x2"
+    maxRetries: 2
   }
 }
 
@@ -535,6 +547,7 @@ task s3_copy {
     memory: "2 GB"
     cpu: 2
     disks: "local-disk 1000 HDD"
+    maxRetries: 2
   }
 }
 
@@ -588,6 +601,7 @@ task filter_sequences_by_length {
         cpu :   1
         disks:  "local-disk 300 HDD"
         dx_instance_type: "mem1_ssd1_v2_x2"
+        maxRetries: 2
     }
     output {
         File filtered_fasta    = out_fname


### PR DESCRIPTION
This PR adds a `maxRetries` definition to the runtime block of all remaining WDL tasks in viral-pipelines that did not already have it defined. This value was first added to take advantage of Terra's recent retry-with-more-memory feature, but it turns out that even without that option enabled at launch time, Terra will use this same value to retry various forms of non-deterministic job failures. The hope is to reduce the number of non-deterministic infrastructural failures on widely-scattered workflows for most non-9 PAPI error codes.