### PR TITLE
bump pangolin and pangolearn

### DIFF
--- a/pipes/WDL/tasks/tasks_sarscov2.wdl
+++ b/pipes/WDL/tasks/tasks_sarscov2.wdl
@@ -9,7 +9,7 @@ task pangolin_one_sample {
         Int?    min_length
         Float?  max_ambig
         Boolean inference_usher=true
-        String  docker = "quay.io/staphb/pangolin:3.1.14-pangolearn-2021-10-13"
+        String  docker = "quay.io/staphb/pangolin:3.1.16-pangolearn-2021-10-18"
     }
     String basename = basename(genome_fasta, ".fasta")
     command <<<
@@ -82,7 +82,7 @@ task pangolin_many_samples {
         Float?       max_ambig
         Boolean      inference_usher=true
         String       basename
-        String       docker = "quay.io/staphb/pangolin:3.1.14-pangolearn-2021-10-13"
+        String       docker = "quay.io/staphb/pangolin:3.1.16-pangolearn-2021-10-18"
     }
     command <<<
         date | tee DATE

--- a/requirements-modules.txt
+++ b/requirements-modules.txt
@@ -7,5 +7,5 @@ broadinstitute/beast-beagle-cuda=1.10.5pre
 broadinstitute/ncbi-tools=2.10.7.10
 nextstrain/base=build-20211012T204409Z
 andersenlabapps/ivar=1.3.1
-quay.io/staphb/pangolin=3.1.14-pangolearn-2021-10-13
+quay.io/staphb/pangolin=3.1.16-pangolearn-2021-10-18
 nextstrain/nextclade=1.4.0


### PR DESCRIPTION
- pangolin [release notes](https://github.com/cov-lineages/pangolin/releases) (3.1.14 :arrow_right: 3.1.16)
- pangoLEARN [release notes](https://github.com/cov-lineages/pangoLEARN/releases) (2021-10-13 :arrow_right: 2021-10-18)
- pango-designation [release notes](https://github.com/cov-lineages/pango-designation/releases) (1.2.88 :arrow_right: 1.2.91)
- scorpio [release notes](https://github.com/cov-lineages/scorpio/releases) (0.3.13 :arrow_right: 0.3.14)
- constellations [release notes](https://github.com/cov-lineages/constellations/releases) (0.0.20 :arrow_right: 0.0.21)
- UShER [release notes](https://github.com/yatisht/usher/releases) (0.4.8, no change)