### PR TITLE
turn on allowNestedInputs for subworkflows

### DIFF
--- a/pipes/WDL/workflows/assemble_refbased.wdl
+++ b/pipes/WDL/workflows/assemble_refbased.wdl
@@ -10,6 +10,7 @@ workflow assemble_refbased {
         description: "Reference-based microbial consensus calling. Aligns NGS reads to a singular reference genome, calls a new consensus sequence, and emits: new assembly, reads aligned to provided reference, reads aligned to new assembly, various figures of merit, plots, and QC metrics. The user may provide unaligned reads spread across multiple input files and this workflow will parallelize alignment per input file before merging results prior to consensus calling."
         author: "Broad Viral Genomics"
         email:  "viral-ngs@broadinstitute.org"
+        allowNestedInputs: true
     }
 
     parameter_meta {

--- a/pipes/WDL/workflows/augur_from_assemblies.wdl
+++ b/pipes/WDL/workflows/augur_from_assemblies.wdl
@@ -9,6 +9,7 @@ workflow augur_from_assemblies {
         description: "Align assemblies, build trees, and convert to json representation suitable for Nextstrain visualization. See https://nextstrain.org/docs/getting-started/ and https://nextstrain-augur.readthedocs.io/en/stable/"
         author: "Broad Viral Genomics"
         email:  "viral-ngs@broadinstitute.org"
+        allowNestedInputs: true
     }
 
     input {

--- a/pipes/WDL/workflows/augur_from_msa.wdl
+++ b/pipes/WDL/workflows/augur_from_msa.wdl
@@ -9,6 +9,7 @@ workflow augur_from_msa {
         description: "Build trees, and convert to json representation suitable for Nextstrain visualization. See https://nextstrain.org/docs/getting-started/ and https://nextstrain-augur.readthedocs.io/en/stable/"
         author: "Broad Viral Genomics"
         email:  "viral-ngs@broadinstitute.org"
+        allowNestedInputs: true
     }
 
     input {

--- a/pipes/WDL/workflows/demux_deplete.wdl
+++ b/pipes/WDL/workflows/demux_deplete.wdl
@@ -10,6 +10,7 @@ workflow demux_deplete {
         description: "Picard-based demultiplexing and basecalling from a tarball of a raw BCL directory, followed by QC metrics, depletion, and SRA submission prep."
         author: "Broad Viral Genomics"
         email:  "viral-ngs@broadinstitute.org"
+        allowNestedInputs: true
     }
 
     input {

--- a/pipes/WDL/workflows/sarscov2_batch_relineage.wdl
+++ b/pipes/WDL/workflows/sarscov2_batch_relineage.wdl
@@ -7,6 +7,7 @@ import "../tasks/tasks_utils.wdl" as utils
 workflow sarscov2_batch_relineage {
     meta {
         description: "Re-call Nextclade and Pangolin lineages on a flowcell's worth of SARS-CoV-2 genomes"
+        allowNestedInputs: true
     }
 
     input {

--- a/pipes/WDL/workflows/sarscov2_biosample_load.wdl
+++ b/pipes/WDL/workflows/sarscov2_biosample_load.wdl
@@ -10,6 +10,7 @@ workflow sarscov2_biosample_load {
         description: "Load Broad CRSP metadata and register samples with NCBI BioSample. Return attributes table, id map, etc."
         author: "Broad Viral Genomics"
         email:  "viral-ngs@broadinstitute.org"
+        allowNestedInputs: true
     }
 
     input {

--- a/pipes/WDL/workflows/sarscov2_data_release.wdl
+++ b/pipes/WDL/workflows/sarscov2_data_release.wdl
@@ -10,6 +10,7 @@ workflow sarscov2_data_release {
         description: "Submit data bundles to databases and repositories"
         author: "Broad Viral Genomics"
         email:  "viral-ngs@broadinstitute.org"
+        allowNestedInputs: true
     }
 
     input {

--- a/pipes/WDL/workflows/sarscov2_illumina_full.wdl
+++ b/pipes/WDL/workflows/sarscov2_illumina_full.wdl
@@ -18,6 +18,7 @@ workflow sarscov2_illumina_full {
         description: "Full SARS-CoV-2 analysis workflow starting from raw Illumina flowcell (tar.gz) and metadata and performing assembly, spike-in analysis, qc, lineage assignment, and packaging for data release."
         author: "Broad Viral Genomics"
         email:  "viral-ngs@broadinstitute.org"
+        allowNestedInputs: true
     }
 
     parameter_meta {

--- a/pipes/WDL/workflows/sarscov2_nextstrain.wdl
+++ b/pipes/WDL/workflows/sarscov2_nextstrain.wdl
@@ -11,6 +11,7 @@ workflow sarscov2_nextstrain {
         description: "Align assemblies, build trees, and convert to json representation suitable for Nextstrain visualization. See https://nextstrain.org/docs/getting-started/ and https://nextstrain-augur.readthedocs.io/en/stable/"
         author: "Broad Viral Genomics"
         email:  "viral-ngs@broadinstitute.org"
+        allowNestedInputs: true
     }
 
     input {

--- a/pipes/WDL/workflows/sarscov2_nextstrain_aligned_input.wdl
+++ b/pipes/WDL/workflows/sarscov2_nextstrain_aligned_input.wdl
@@ -9,6 +9,7 @@ workflow sarscov2_nextstrain_aligned_input {
         description: "Take aligned assemblies, build trees, and convert to json representation suitable for Nextstrain visualization. See https://nextstrain.org/docs/getting-started/ and https://nextstrain-augur.readthedocs.io/en/stable/"
         author: "Broad Viral Genomics"
         email:  "viral-ngs@broadinstitute.org"
+        allowNestedInputs: true
     }
 
     input {

--- a/pipes/WDL/workflows/sarscov2_sra_to_genbank.wdl
+++ b/pipes/WDL/workflows/sarscov2_sra_to_genbank.wdl
@@ -13,6 +13,7 @@ workflow sarscov2_sra_to_genbank {
         description: "Full SARS-CoV-2 analysis workflow starting from SRA data and metadata and performing assembly, spike-in analysis, qc, lineage assignment, and packaging assemblies for data release."
         author: "Broad Viral Genomics"
         email:  "viral-ngs@broadinstitute.org"
+        allowNestedInputs: true
     }
 
     parameter_meta {


### PR DESCRIPTION
Apparently [this feature](https://github.com/openwdl/wdl/blob/main/versions/1.1/SPEC.md#computing-call-inputs) has been supported by Cromwell & Terra for a while now! This allows users the ability to turn knobs on all task level inputs in subworkflows that haven't otherwise been bound by the encapsulating workflow's call. Verified to work in Terra:

Terra workflow launch page for `sarscov2_illumina_full` before PR:
![image](https://user-images.githubusercontent.com/8513746/141844995-92f88557-3b3e-4e13-b62e-54c909c784d9.png)

Terra workflow launch page after PR:
![image](https://user-images.githubusercontent.com/8513746/141845062-89a5192b-544c-4bc0-a7e5-f39a386e5484.png)
