### PR TITLE
allow one retry for gisaid upload

### DIFF
--- a/pipes/WDL/tasks/tasks_sarscov2.wdl
+++ b/pipes/WDL/tasks/tasks_sarscov2.wdl
@@ -560,6 +560,6 @@ task gisaid_uploader {
     memory: "2 GB"
     cpu: 2
     disks: "local-disk 100 HDD"
-    maxRetries: 0
+    maxRetries: 1
   }
 }


### PR DESCRIPTION
gisaid_uploader this past week has been succeeding on about 99% of samples (ie, failing on almost every batch submission). allow for one cromwell retry so that at least, if it fails, maybe all of it eventually gets through the second time.