### PR TITLE
bump vadr docker (new models for sc2)

### DIFF
--- a/pipes/WDL/tasks/tasks_ncbi.wdl
+++ b/pipes/WDL/tasks/tasks_ncbi.wdl
@@ -924,7 +924,7 @@ task vadr {
     File   genome_fasta
     String vadr_opts = "--glsearch -s -r --nomisc --mkey sarscov2 --lowsim5seq 6 --lowsim3seq 6 --alt_fail lowscore,insertnn,deletinn"
 
-    String docker = "quay.io/staphb/vadr:1.3"
+    String docker = "quay.io/staphb/vadr:1.3-models-1.3-2"
     Int    minlen = 50
     Int    maxlen = 30000
   }


### PR DESCRIPTION
From Eric Nawrocki:
>NCBI submissions - we’ve updated the VADR model set for processing SARS-CoV-2 sequence submissions to GenBank.
If you run VADR locally, you can update your models as explained in step 2 here:
https://github.com/ncbi/vadr/wiki/Coronavirus-annotation#howto
The new model file contains a single model based on the NC_045512 RefSeq. We have *not* updated the VADR software and are still using VADR v1.3, which we’ve been using since August 2021.
Please let us know if you have any questions or problems.