### PR TITLE
slight speed optimizations

### DIFF
--- a/pipes/WDL/tasks/tasks_reports.wdl
+++ b/pipes/WDL/tasks/tasks_reports.wdl
@@ -339,10 +339,10 @@ task align_and_count_summary {
   }
 
   runtime {
-    memory: "3 GB"
-    cpu: 2
+    memory: "7 GB"
+    cpu: 8
     docker: "${docker}"
-    disks: "local-disk 50 HDD"
+    disks: "local-disk 100 HDD"
     dx_instance_type: "mem1_ssd1_v2_x2"
     maxRetries: 2
   }
@@ -485,7 +485,7 @@ task MultiQC {
 
   runtime {
     memory: "8 GB"
-    cpu: 2
+    cpu: 16
     docker: "${docker}"
     disks: "local-disk 375 LOCAL"
     dx_instance_type: "mem2_ssd1_v2_x2"


### PR DESCRIPTION
## assemble_refbased
remove both merge_bams steps when only one input file is supplied. In the context of sarscov2_illumina_full, this reduces total scatter count / burden on execution engine, but more importantly, it also reduces end-to-end DAG length by 30% within the highly scattered subworkflow.

For future consideration (not in this PR): it's worth considering descattering this in general and folding a lot of the plotting and metrics steps back into the alignment task (and the discordance into the consensus calling task), significantly reducing the total shard count of this step in sc2_illumina_full one day

## demux_deplete
update task MultiQC and task align_and_count_summary to increase core count / data localization speed, as this is currently a bottleneck