### PR TITLE
tsv_join order of preference

### DIFF
--- a/pipes/WDL/workflows/sarscov2_sequencing_reports.wdl
+++ b/pipes/WDL/workflows/sarscov2_sequencing_reports.wdl
@@ -21,7 +21,8 @@ workflow sarscov2_sequencing_reports {
         input:
             input_tsvs   = assembly_stats_tsvs,
             id_col       = 'sample',
-            out_basename = 'assembly_stats-cumulative-~{report_date}'
+            out_basename = 'assembly_stats-cumulative-~{report_date}',
+            prefer_first = false  # always prefer later sequencing results over earlier ones
     }
 
     call sarscov2.sequencing_report {


### PR DESCRIPTION
1. Add a Boolean input to utils.tsv_join that allows the caller to specify the order of preference when non-null data is present in multiple inputs (prefer earliest or prefer latest). Defaults to original behavior.
2. Switch sarscov2_sequencing_reports to prefer latest inputs when merging final files: if some samples are sequenced more than once, we should always prefer the latest results over the earlier ones.