### PR TITLE
update pangolin container

### DIFF
--- a/pipes/WDL/tasks/tasks_sarscov2.wdl
+++ b/pipes/WDL/tasks/tasks_sarscov2.wdl
@@ -10,7 +10,7 @@ task pangolin_one_sample {
         Float?  max_ambig
         Boolean inference_usher=true
         Boolean update_dbs_now=false
-        String  docker = "quay.io/staphb/pangolin:3.1.17-pangolearn-2021-11-25"
+        String  docker = "quay.io/staphb/pangolin:3.1.17-pangolearn-2021-12-06"
     }
     String basename = basename(genome_fasta, ".fasta")
     command <<<
@@ -88,7 +88,7 @@ task pangolin_many_samples {
         Boolean      inference_usher=true
         Boolean      update_dbs_now=false
         String       basename
-        String       docker = "quay.io/staphb/pangolin:3.1.17-pangolearn-2021-11-25"
+        String       docker = "quay.io/staphb/pangolin:3.1.17-pangolearn-2021-12-06"
     }
     command <<<
         set -ex

--- a/requirements-modules.txt
+++ b/requirements-modules.txt
@@ -7,5 +7,5 @@ broadinstitute/beast-beagle-cuda=1.10.5pre
 broadinstitute/ncbi-tools=2.10.7.10
 nextstrain/base=build-20211012T204409Z
 andersenlabapps/ivar=1.3.1
-quay.io/staphb/pangolin=3.1.17-pangolearn-2021-11-25
+quay.io/staphb/pangolin=3.1.17-pangolearn-2021-12-06
 nextstrain/nextclade=1.7.0


### PR DESCRIPTION
This update will allow for the detection of lineage BA.3

See release notes for more details:
- pangolin [release notes](https://github.com/cov-lineages/pangolin/releases) (3.1.17, no change)
- pangoLEARN [release notes](https://github.com/cov-lineages/pangoLEARN/releases) (2021-11-25 :arrow_right: 2021-12-06)
- pango-designation [release notes](https://github.com/cov-lineages/pango-designation/releases) (1.2.108 :arrow_right: 1.2.112)
- scorpio [release notes](https://github.com/cov-lineages/scorpio/releases) (0.3.15 :arrow_right: 0.3.16)
- constellations [release notes](https://github.com/cov-lineages/constellations/releases) (0.0.28 :arrow_right: 0.1.0)
- UShER [release notes](https://github.com/yatisht/usher/releases) (0.5.1, no change)