### PR TITLE
update vadr

### DIFF
--- a/pipes/WDL/tasks/tasks_ncbi.wdl
+++ b/pipes/WDL/tasks/tasks_ncbi.wdl
@@ -924,7 +924,7 @@ task vadr {
     File   genome_fasta
     String vadr_opts = "--glsearch -s -r --nomisc --mkey sarscov2 --lowsim5seq 6 --lowsim3seq 6 --alt_fail lowscore,insertnn,deletinn"
 
-    String docker = "quay.io/staphb/vadr:1.3-models-1.3-2"
+    String docker = "quay.io/staphb/vadr:1.4-models-1.3-2"
     Int    minlen = 50
     Int    maxlen = 30000
   }


### PR DESCRIPTION
From Eric N:
>We’ve updated the SARS-CoV-2 processing pipeline at GenBank to use a new version of our annotation tool, VADR v1.4. The models file has not changed, it is still version 1.3-2 (vadr-models-sarscov2-1.3-2).
The main improvement should be less sequences failing that should pass, especially omicron sequences. In vadr 1.3, these sequences failed with LOW_SIMILARITY or INDEFINITE_ANNOTATION_START/END errors often due to N-rich regions near indels with respect to the reference.
See https://github.com/ncbi/vadr/wiki/Coronavirus-annotation for more information and for instructions on running VADR locally on your own sequence data. Please let us know if you have any questions/problems.