### PR TITLE
update pangolin and vadr containers

### DIFF
--- a/pipes/WDL/tasks/tasks_ncbi.wdl
+++ b/pipes/WDL/tasks/tasks_ncbi.wdl
@@ -924,7 +924,7 @@ task vadr {
     File   genome_fasta
     String vadr_opts = "--glsearch -s -r --nomisc --mkey sarscov2 --lowsim5seq 6 --lowsim3seq 6 --alt_fail lowscore,insertnn,deletinn"
 
-    String docker = "quay.io/staphb/vadr:1.4-models-1.3-2"
+    String docker = "quay.io/staphb/vadr:1.4.1-models-1.3-2"
     Int    minlen = 50
     Int    maxlen = 30000
   }

--- a/pipes/WDL/tasks/tasks_sarscov2.wdl
+++ b/pipes/WDL/tasks/tasks_sarscov2.wdl
@@ -10,7 +10,7 @@ task pangolin_one_sample {
         Float?  max_ambig
         Boolean inference_usher=true
         Boolean update_dbs_now=false
-        String  docker = "quay.io/staphb/pangolin:3.1.17-pangolearn-2021-12-06"
+        String  docker = "quay.io/staphb/pangolin:3.1.17-pangolearn-2022-01-05"
     }
     String basename = basename(genome_fasta, ".fasta")
     command <<<
@@ -88,7 +88,7 @@ task pangolin_many_samples {
         Boolean      inference_usher=true
         Boolean      update_dbs_now=false
         String       basename
-        String       docker = "quay.io/staphb/pangolin:3.1.17-pangolearn-2021-12-06"
+        String       docker = "quay.io/staphb/pangolin:3.1.17-pangolearn-2022-01-05"
     }
     command <<<
         set -ex

--- a/pipes/WDL/workflows/sarscov2_illumina_full.wdl
+++ b/pipes/WDL/workflows/sarscov2_illumina_full.wdl
@@ -229,7 +229,7 @@ workflow sarscov2_illumina_full {
     call sarscov2_batch_relineage.sarscov2_batch_relineage {
       input:
         flowcell_id = flowcell_id,
-        genomes_fasta = assemble_refbased.assembly_fasta,
+        genomes_fasta = assemble_refbased.assembly_fasta, # TO DO: can this just be [passing_cat_prefilter.combined]?
         metadata_annotated_tsv = assembly_meta_tsv.combined,
         metadata_raw_tsv = assembly_meta_tsv.combined,
         min_genome_bases = min_genome_bases

--- a/requirements-modules.txt
+++ b/requirements-modules.txt
@@ -7,5 +7,5 @@ broadinstitute/beast-beagle-cuda=1.10.5pre
 broadinstitute/ncbi-tools=2.10.7.10
 nextstrain/base=build-20211012T204409Z
 andersenlabapps/ivar=1.3.1
-quay.io/staphb/pangolin=3.1.17-pangolearn-2021-12-06
+quay.io/staphb/pangolin:3.1.17-pangolearn-2022-01-05
 nextstrain/nextclade=1.7.0

--- a/requirements-modules.txt
+++ b/requirements-modules.txt
@@ -7,5 +7,5 @@ broadinstitute/beast-beagle-cuda=1.10.5pre
 broadinstitute/ncbi-tools=2.10.7.10
 nextstrain/base=build-20211012T204409Z
 andersenlabapps/ivar=1.3.1
-quay.io/staphb/pangolin:3.1.17-pangolearn-2022-01-05
+quay.io/staphb/pangolin=3.1.17-pangolearn-2022-01-05
 nextstrain/nextclade=1.7.0


### PR DESCRIPTION
## Updates to pangolin container:
This new version includes new lineages - mostly Delta sublineages, one Gamma sublineage, and a few other uncommon lineages. This will not allow for the detection of BA.1.1 (have to wait for the next pangoLEARN release).
I recommend you check out the release notes for more details:

- pangolin [release notes](https://github.com/cov-lineages/pangolin/releases) (3.1.17, no change)
- pangoLEARN [release notes](https://github.com/cov-lineages/pangoLEARN/releases) (2021-12-06 :arrow_right: 2022-01-05)
- pango-designation [release notes](https://github.com/cov-lineages/pango-designation/releases) (1.2.112 :arrow_right: 1.2.122)
- scorpio [release notes](https://github.com/cov-lineages/scorpio/releases) (0.3.16, no change)
- constellations [release notes](https://github.com/cov-lineages/constellations/releases) (0.1.0 :arrow_right: 0.1.1)
- UShER [release notes](https://github.com/yatisht/usher/releases) (0.5.1, no change)

## Updates to VADR container:
NCBI submissions: We’ve updated the SARS-CoV-2 processing pipeline at GenBank to use a new version of VADR (v1.4.1) that fixes a bug in v1.4 that in rare cases allowed sequences with short duplicated regions in non-coding regions to ‘pass’. The new version correctly reports a DUPLICATE_REGIONS error for these sequences and prevents them from being automatically deposited in GenBank via the submission portal. Full release notes are here:
https://github.com/ncbi/vadr/blob/master/RELEASE-NOTES.md
Please see https://github.com/ncbi/vadr/wiki/Coronavirus-annotation for more information and for instructions on running VADR locally on your own sequence data. Please let us know if you have any questions/problems
