### PR TITLE
nextclade 1.7.0 to 1.10.0

### DIFF
--- a/pipes/WDL/tasks/tasks_nextstrain.wdl
+++ b/pipes/WDL/tasks/tasks_nextstrain.wdl
@@ -35,7 +35,7 @@ task nextclade_one_sample {
         CODE1
         fi
 
-        nextclade \
+        nextclade run \
             --input-fasta "~{genome_fasta}" \
             --input-root-seq ~{default="reference.fasta" root_sequence} \
             --input-tree ~{default="tree.json" auspice_reference_tree_json} \
@@ -113,7 +113,7 @@ task nextclade_many_samples {
         fi
 
         cat ~{sep=" " genome_fastas} > genomes.fasta
-        nextclade \
+        nextclade run \
             --input-fasta genomes.fasta \
             --input-root-seq ~{default="reference.fasta" root_sequence} \
             --input-tree ~{default="tree.json" auspice_reference_tree_json} \

--- a/pipes/WDL/tasks/tasks_nextstrain.wdl
+++ b/pipes/WDL/tasks/tasks_nextstrain.wdl
@@ -12,7 +12,7 @@ task nextclade_one_sample {
         File? gene_annotations_json
         File? pcr_primers_csv
         String? dataset_name
-        String docker = "nextstrain/nextclade:1.7.0"
+        String docker = "nextstrain/nextclade:1.10.0"
     }
     String basename = basename(genome_fasta, ".fasta")
     command {
@@ -90,7 +90,7 @@ task nextclade_many_samples {
         File?        pcr_primers_csv
         String?      dataset_name
         String       basename
-        String       docker = "nextstrain/nextclade:1.7.0"
+        String       docker = "nextstrain/nextclade:1.10.0"
     }
     command <<<
         set -e

--- a/pipes/WDL/tasks/tasks_nextstrain.wdl
+++ b/pipes/WDL/tasks/tasks_nextstrain.wdl
@@ -11,6 +11,7 @@ task nextclade_one_sample {
         File? qc_config_json
         File? gene_annotations_json
         File? pcr_primers_csv
+        File? virus_properties
         String? dataset_name
         String docker = "nextstrain/nextclade:1.10.0"
     }
@@ -42,6 +43,7 @@ task nextclade_one_sample {
             --input-qc-config ~{default="qc.json" qc_config_json} \
             --input-gene-map ~{default="genemap.gff" gene_annotations_json} \
             --input-pcr-primers ~{default="primers.csv" pcr_primers_csv} \
+            --input-virus-properties ~{default="virus_properties.json" virus_properties}  \
             --output-json "~{basename}".nextclade.json \
             --output-tsv  "~{basename}".nextclade.tsv \
             --output-tree "~{basename}".nextclade.auspice.json
@@ -88,6 +90,7 @@ task nextclade_many_samples {
         File?        qc_config_json
         File?        gene_annotations_json
         File?        pcr_primers_csv
+        File?        virus_properties
         String?      dataset_name
         String       basename
         String       docker = "nextstrain/nextclade:1.10.0"
@@ -120,6 +123,7 @@ task nextclade_many_samples {
             --input-qc-config ~{default="qc.json" qc_config_json} \
             --input-gene-map ~{default="genemap.gff" gene_annotations_json} \
             --input-pcr-primers ~{default="primers.csv" pcr_primers_csv} \
+            --input-virus-properties ~{default="virus_properties.json" virus_properties}  \
             --output-json "~{basename}".nextclade.json \
             --output-tsv  "~{basename}".nextclade.tsv \
             --output-tree "~{basename}".nextclade.auspice.json

--- a/requirements-modules.txt
+++ b/requirements-modules.txt
@@ -8,4 +8,4 @@ broadinstitute/ncbi-tools=2.10.7.10
 nextstrain/base=build-20211012T204409Z
 andersenlabapps/ivar=1.3.1
 quay.io/staphb/pangolin=3.1.17-pangolearn-2022-01-05
-nextstrain/nextclade=1.7.0
+nextstrain/nextclade=1.10.0


### PR DESCRIPTION
Update nextclade docker from 1.7.0 to 1.10.0, announcement blurb follows:

New features ([changelog](https://github.com/nextstrain/nextclade/blob/release/CHANGELOG.md)):
 :white_check_mark: Private mutations (those extra wrt nearest reference tree node) split into:
a) reversions to reference
b) potential contamination/coinfection/recombination (common genotypes)
c) neither a) nor b)
Allowing more sensitive and specific QC rules -> e.g. “Deltacrons” are reliably detected as problematic (see screenshots)
 :white_check_mark: Insertions now also reported as amino acids (oft-requested feature)
 :white_check_mark: Updated SARS-CoV-2 dataset to match requirements of new release (data [changelog](https://github.com/nextstrain/nextclade_data/blob/release/CHANGELOG.md)) [new release requires new datasets!]