### PR TITLE
pangolin container update

### DIFF
--- a/pipes/WDL/tasks/tasks_sarscov2.wdl
+++ b/pipes/WDL/tasks/tasks_sarscov2.wdl
@@ -10,7 +10,7 @@ task pangolin_one_sample {
         Float?  max_ambig
         Boolean inference_usher=true
         Boolean update_dbs_now=false
-        String  docker = "quay.io/staphb/pangolin:3.1.17-pangolearn-2022-01-05"
+        String  docker = "quay.io/staphb/pangolin:3.1.18-pangolearn-2022-01-20"
     }
     String basename = basename(genome_fasta, ".fasta")
     command <<<
@@ -88,7 +88,7 @@ task pangolin_many_samples {
         Boolean      inference_usher=true
         Boolean      update_dbs_now=false
         String       basename
-        String       docker = "quay.io/staphb/pangolin:3.1.17-pangolearn-2022-01-05"
+        String       docker = "quay.io/staphb/pangolin:3.1.18-pangolearn-2022-01-20"
     }
     command <<<
         set -ex

--- a/pipes/WDL/tasks/tasks_sarscov2.wdl
+++ b/pipes/WDL/tasks/tasks_sarscov2.wdl
@@ -10,7 +10,7 @@ task pangolin_one_sample {
         Float?  max_ambig
         Boolean inference_usher=true
         Boolean update_dbs_now=false
-        String  docker = "quay.io/staphb/pangolin:3.1.18-pangolearn-2022-01-20"
+        String  docker = "quay.io/staphb/pangolin:3.1.19-pangolearn-2022-01-20"
     }
     String basename = basename(genome_fasta, ".fasta")
     command <<<
@@ -88,7 +88,7 @@ task pangolin_many_samples {
         Boolean      inference_usher=true
         Boolean      update_dbs_now=false
         String       basename
-        String       docker = "quay.io/staphb/pangolin:3.1.18-pangolearn-2022-01-20"
+        String       docker = "quay.io/staphb/pangolin:3.1.19-pangolearn-2022-01-20"
     }
     command <<<
         set -ex

--- a/requirements-modules.txt
+++ b/requirements-modules.txt
@@ -7,5 +7,5 @@ broadinstitute/beast-beagle-cuda=1.10.5pre
 broadinstitute/ncbi-tools=2.10.7.10
 nextstrain/base=build-20211012T204409Z
 andersenlabapps/ivar=1.3.1
-quay.io/staphb/pangolin=3.1.17-pangolearn-2022-01-05
+quay.io/staphb/pangolin=3.1.18-pangolearn-2022-01-20
 nextstrain/nextclade=1.10.0

--- a/requirements-modules.txt
+++ b/requirements-modules.txt
@@ -7,5 +7,5 @@ broadinstitute/beast-beagle-cuda=1.10.5pre
 broadinstitute/ncbi-tools=2.10.7.10
 nextstrain/base=build-20211012T204409Z
 andersenlabapps/ivar=1.3.1
-quay.io/staphb/pangolin=3.1.18-pangolearn-2022-01-20
+quay.io/staphb/pangolin=3.1.19-pangolearn-2022-01-20
 nextstrain/nextclade=1.10.0


### PR DESCRIPTION
Update staphb/pangolin container. Release notes below:

Docker image for new release of pangolin v3.1.19 and new release of pangoLEARN (release 2022-01-20) now available on DockerHub and Quay `staphb/pangolin:latest` and `staphb/pangolin:3.1.19-pangolearn-2022-01-20`

- This will allow for the detection of BA.1.1
- You will no longer see sequences assigned B.1.1.529, assignments will be BA.x of some kind. GISAID has refreshed all lineages to reflect this
- `constellations` update: "_Lower quality samples that could be classified as sublineages BA.* get a "Probable Omicron (BA.*-like)" call instead of a parent call. Make the parent "Omicron (Unclassified)" and remove mrca_lineage field from it so that pangolin does not call lineage B.1.1.529 (there are no designated sequences)_"

I recommend you check out the release notes for more details:
- pangolin [release notes](https://github.com/cov-lineages/pangolin/releases) (3.1.17 :arrow_right: 3.1.19)
- pangoLEARN [release notes ](https://github.com/cov-lineages/pangoLEARN/releases)(2022-01-05 :arrow_right: 2022-01-20)
- pango-designation [release notes](https://github.com/cov-lineages/pango-designation/releases) (1.2.122 :arrow_right: 1.2.123)
- scorpio [release notes](https://github.com/cov-lineages/scorpio/releases) (0.3.16, no change)
- constellations [release notes](https://github.com/cov-lineages/constellations/releases) (0.1.1 :arrow_right: 0.1.2)
- UShER [release notes](https://github.com/yatisht/usher/releases) (0.5.1 :arrow_right: 0.5.2)