### PR TITLE
update pangolin container

### DIFF
--- a/pipes/WDL/tasks/tasks_sarscov2.wdl
+++ b/pipes/WDL/tasks/tasks_sarscov2.wdl
@@ -10,7 +10,7 @@ task pangolin_one_sample {
         Float?  max_ambig
         Boolean inference_usher=true
         Boolean update_dbs_now=false
-        String  docker = "quay.io/staphb/pangolin:3.1.19-pangolearn-2022-01-20"
+        String  docker = "quay.io/staphb/pangolin:3.1.20-pangolearn-2022-02-02"
     }
     String basename = basename(genome_fasta, ".fasta")
     command <<<
@@ -88,7 +88,7 @@ task pangolin_many_samples {
         Boolean      inference_usher=true
         Boolean      update_dbs_now=false
         String       basename
-        String       docker = "quay.io/staphb/pangolin:3.1.19-pangolearn-2022-01-20"
+        String       docker = "quay.io/staphb/pangolin:3.1.20-pangolearn-2022-02-02"
     }
     command <<<
         set -ex

--- a/requirements-modules.txt
+++ b/requirements-modules.txt
@@ -7,5 +7,5 @@ broadinstitute/beast-beagle-cuda=1.10.5pre
 broadinstitute/ncbi-tools=2.10.7.10
 nextstrain/base=build-20211012T204409Z
 andersenlabapps/ivar=1.3.1
-quay.io/staphb/pangolin=3.1.19-pangolearn-2022-01-20
+quay.io/staphb/pangolin=3.1.20-pangolearn-2022-02-02
 nextstrain/nextclade=1.10.0


### PR DESCRIPTION
Update to latest staphb docker image `quay.io/staphb/pangolin:3.1.20-pangolearn-2022-02-02`

- Users may notice less BA.1.1 assignments (pangolin update includes code to "fix false positive Omicron BA.1.1 calls")
- pangoLEARN model & pUShER protobuf tree updated to pango-designation release v1.2.124
- constellations mutations & rules updated for B.1.1.529, BA.1, BA.2, BA.3, and C.37. [See changes here](https://github.com/cov-lineages/constellations/compare/v0.1.2...v0.1.3)

I recommend you check out the release notes for more details:

- [pangolin release notes](https://github.com/cov-lineages/pangolin/releases) (3.1.19 :arrow_right: 3.1.20)
- [pangoLEARN release notes](https://github.com/cov-lineages/pangoLEARN/releases) (2022-01-20 :arrow_right: 2022-02-02)
- [pango-designation release notes](https://github.com/cov-lineages/pango-designation/releases) (1.2.123 :arrow_right: 1.2.127)
- [scorpio release notes](https://github.com/cov-lineages/scorpio/releases) (0.3.16, no change)
- [constellations release notes](https://github.com/cov-lineages/constellations/releases) (0.1.2 :arrow_right: 0.1.3)
- [UShER release notes](https://github.com/yatisht/usher/releases) (0.5.2, no change)