### PR TITLE
update pangolin and nextclade docker images

### DIFF
--- a/pipes/WDL/tasks/tasks_nextstrain.wdl
+++ b/pipes/WDL/tasks/tasks_nextstrain.wdl
@@ -13,7 +13,7 @@ task nextclade_one_sample {
         File? pcr_primers_csv
         File? virus_properties
         String? dataset_name
-        String docker = "nextstrain/nextclade:1.10.0"
+        String docker = "nextstrain/nextclade:1.11.0"
     }
     String basename = basename(genome_fasta, ".fasta")
     command {
@@ -93,7 +93,7 @@ task nextclade_many_samples {
         File?        virus_properties
         String?      dataset_name
         String       basename
-        String       docker = "nextstrain/nextclade:1.10.0"
+        String       docker = "nextstrain/nextclade:1.11.0"
     }
     command <<<
         set -e

--- a/pipes/WDL/tasks/tasks_sarscov2.wdl
+++ b/pipes/WDL/tasks/tasks_sarscov2.wdl
@@ -10,7 +10,7 @@ task pangolin_one_sample {
         Float?  max_ambig
         Boolean inference_usher=true
         Boolean update_dbs_now=false
-        String  docker = "quay.io/staphb/pangolin:3.1.20-pangolearn-2022-02-02"
+        String  docker = "quay.io/staphb/pangolin:3.1.20-pangolearn-2022-02-28"
     }
     String basename = basename(genome_fasta, ".fasta")
     command <<<
@@ -88,7 +88,7 @@ task pangolin_many_samples {
         Boolean      inference_usher=true
         Boolean      update_dbs_now=false
         String       basename
-        String       docker = "quay.io/staphb/pangolin:3.1.20-pangolearn-2022-02-02"
+        String       docker = "quay.io/staphb/pangolin:3.1.20-pangolearn-2022-02-28"
     }
     command <<<
         set -ex

--- a/requirements-modules.txt
+++ b/requirements-modules.txt
@@ -8,4 +8,4 @@ broadinstitute/ncbi-tools=2.10.7.10
 nextstrain/base=build-20211012T204409Z
 andersenlabapps/ivar=1.3.1
 quay.io/staphb/pangolin=3.1.20-pangolearn-2022-02-28
-nextstrain/nextclade=1.10.0
+nextstrain/nextclade=1.11.0

--- a/requirements-modules.txt
+++ b/requirements-modules.txt
@@ -7,5 +7,5 @@ broadinstitute/beast-beagle-cuda=1.10.5pre
 broadinstitute/ncbi-tools=2.10.7.10
 nextstrain/base=build-20211012T204409Z
 andersenlabapps/ivar=1.3.1
-quay.io/staphb/pangolin=3.1.20-pangolearn-2022-02-02
+quay.io/staphb/pangolin=3.1.20-pangolearn-2022-02-28
 nextstrain/nextclade=1.10.0


### PR DESCRIPTION
### Pangolin container update

Update docker image for pangolin to `quay.io/staphb/pangolin:3.1.20-pangolearn-2022-02-28`:
- Expect to see newly designated Delta sub-lineages (see pango-designation release notes for list; adds those from v1.2.125 to v1.2.127)
- pangoLEARN model trained on pango-designation release v1.2.127
- UShER protobuf tree trained on pango-designation release v1.2.128 (this was an accident)
- Due to this discrepancy ^ users can expect to see newer Omicron sublineage assignments (BA.1.2 - BA.1.15, BA.1.13.1, BA.1.15.1) when using `pangolin --usher` mode and in contrast the default pangoLEARN mode will result in one of three Omicron sublineages (BA.1, BA.1.1, BA.2), none of the newer sublineages.
- :rotating_light: NOTE: the base docker image is now `mambaorg/micromamba:0.22.0` to reduce the image size. Previously ~1GB, now 750MB :tada:. Every bit helps (pun definitely intended). The old `ubuntu:xenial` base image is no longer in use. Please let us know if you encounter any bugs or difficulties with this change.

I recommend you check out the release notes for more details:

- [pangolin release notes](https://github.com/cov-lineages/pangolin/releases) (3.1.20, no change)
- [pangoLEARN release notes](https://github.com/cov-lineages/pangoLEARN/releases) (2022-02-02 :arrow_right: 2022-02-28)
- [pango-designation release notes](https://github.com/cov-lineages/pango-designation/releases) (1.2.127 :arrow_right: 1.2.132)
- [scorpio release notes](https://github.com/cov-lineages/scorpio/releases) (0.3.16, no change)
- [constellations release notes](https://github.com/cov-lineages/constellations/releases) (0.1.3 :arrow_right: 0.1.4)
- [UShER release notes](https://github.com/yatisht/usher/releases) (0.5.2, no change)

### Nextclade container update
**Nextclade docker updated to 1.11.0.** New features ([changelog](https://github.com/nextstrain/nextclade/blob/release/CHANGELOG.md)):
- Nextclade now also assigns a Pango lineage to SC2 sequences, called `Nextclade_pango` in tsv/csv output
- :warning: Nextclade pango calls are produced independently of `pangolin` and hence are not necessarily identical to `pangoLEARN` and/or `UShER` mode pango lineage calls
- You can read more about how Nextclade assigns pango lineages here: https://docs.nextstrain.org/projects/nextclade/en/latest/user/algorithm/nextclade-pango.html
- Accuracy for recent (<12m) sequences should be comparable to pangoLEARN but worse than UShER, though exact measurements of accuracy are hard due to lack of good ground truth
- Don’t use `Nextclade_pango` calls for early pandemic lineage assignments. To keep the tree size manageable, rare early lineages are not included and can thus not be assigned at all.
- New dataset contains lineages up to pango-designation release v1.32.0. Some recently designated lineages can thus be assigned by `Nextclade` but not yet by `pangolin` (currently up to v1.27.0)
- You may see new Omicron lineages like `BA.1.2-BA.1.17`, `BA.1.1.2-BA.1.1.16`, `BA.2.1-BA.2.3` that are not yet assigned by pangolin

Recombinants (`XA`,`XB`,`XC`) are not yet part of the Nextclade reference tree but this is the next thing on the roadmap.