### PR TITLE
pangolin v4

### DIFF
--- a/pipes/WDL/tasks/tasks_sarscov2.wdl
+++ b/pipes/WDL/tasks/tasks_sarscov2.wdl
@@ -29,7 +29,7 @@ task pangolin_one_sample {
         pangolin --all-versions | tr '\n' ';' | cut -f -5 -d ';' | tee VERSION_PANGOLIN_ALL
 
         pangolin "~{genome_fasta}" \
-            ~{true='--analysis-mode fast' false='--analysis-mode pangolearn' inference_usher} \
+            ~{true='' false='--analysis-mode pangolearn' inference_usher} \
             --outfile "~{basename}.pangolin_report.csv" \
             ~{"--min-length " + min_length} \
             ~{"--max-ambig " + max_ambig} \
@@ -111,7 +111,7 @@ task pangolin_many_samples {
         cat ~{sep=" " genome_fastas} > unaligned.fasta
         pangolin unaligned.fasta \
             --use-assignment-cache \
-            ~{true='--analysis-mode fast' false='--analysis-mode pangolearn' inference_usher} \
+            ~{true='' false='--analysis-mode pangolearn' inference_usher} \
             --outfile "~{basename}.pangolin_report.csv" \
             ~{"--min-length " + min_length} \
             ~{"--max-ambig " + max_ambig} \

--- a/pipes/WDL/tasks/tasks_sarscov2.wdl
+++ b/pipes/WDL/tasks/tasks_sarscov2.wdl
@@ -10,7 +10,7 @@ task pangolin_one_sample {
         Float?  max_ambig
         String? analysis_mode
         Boolean update_dbs_now=false
-        String  docker = "quay.io/staphb/pangolin:4.0.3-pdata-1.2.133"
+        String  docker = "quay.io/staphb/pangolin:4.0.4-pdata-1.2.133"
     }
     String basename = basename(genome_fasta, ".fasta")
     command <<<
@@ -91,7 +91,7 @@ task pangolin_many_samples {
         String?      analysis_mode
         Boolean      update_dbs_now=false
         String       basename
-        String       docker = "quay.io/staphb/pangolin:4.0.3-pdata-1.2.133"
+        String       docker = "quay.io/staphb/pangolin:4.0.4-pdata-1.2.133"
     }
     command <<<
         set -ex

--- a/pipes/WDL/tasks/tasks_sarscov2.wdl
+++ b/pipes/WDL/tasks/tasks_sarscov2.wdl
@@ -127,7 +127,7 @@ task pangolin_many_samples {
                     version=line["version"]
                     outf.write(f"pangolin {pangolin_version}; {version}")
                 break
-        out_maps = {'lineage':{}, 'conflict':{}, 'note':{}}
+        out_maps = {'lineage':{}, 'conflict':{}, 'note':{}, 'scorpio_call':{}, 'scorpio_notes':{}}
         with open("~{basename}.pangolin_report.csv", 'rt') as csv_file:
             with open('IDLIST', 'wt') as outf_ids:
                 for row in csv.DictReader(csv_file):

--- a/pipes/WDL/tasks/tasks_sarscov2.wdl
+++ b/pipes/WDL/tasks/tasks_sarscov2.wdl
@@ -10,7 +10,7 @@ task pangolin_one_sample {
         Float?  max_ambig
         Boolean inference_usher=true
         Boolean update_dbs_now=false
-        String  docker = "quay.io/staphb/pangolin:3.1.20-pangolearn-2022-02-28"
+        String  docker = "quay.io/staphb/pangolin:4.0.2-pdata-1.2.133"
     }
     String basename = basename(genome_fasta, ".fasta")
     command <<<
@@ -29,7 +29,7 @@ task pangolin_one_sample {
         pangolin --all-versions | tr '\n' ';' | cut -f -5 -d ';' | tee VERSION_PANGOLIN_ALL
 
         pangolin "~{genome_fasta}" \
-            ~{true='--usher' false='' inference_usher} \
+            ~{true='--analysis-mode fast' false='--analysis-mode pangolearn' inference_usher} \
             --outfile "~{basename}.pangolin_report.csv" \
             ~{"--min-length " + min_length} \
             ~{"--max-ambig " + max_ambig} \
@@ -91,7 +91,7 @@ task pangolin_many_samples {
         Boolean      inference_usher=true
         Boolean      update_dbs_now=false
         String       basename
-        String       docker = "quay.io/staphb/pangolin:3.1.20-pangolearn-2022-02-28"
+        String       docker = "quay.io/staphb/pangolin:4.0.2-pdata-1.2.133"
     }
     command <<<
         set -ex
@@ -110,7 +110,8 @@ task pangolin_many_samples {
 
         cat ~{sep=" " genome_fastas} > unaligned.fasta
         pangolin unaligned.fasta \
-            ~{true='--usher' false='' inference_usher} \
+            --use-assignment-cache \
+            ~{true='--analysis-mode fast' false='--analysis-mode pangolearn' inference_usher} \
             --outfile "~{basename}.pangolin_report.csv" \
             ~{"--min-length " + min_length} \
             ~{"--max-ambig " + max_ambig} \

--- a/pipes/WDL/tasks/tasks_sarscov2.wdl
+++ b/pipes/WDL/tasks/tasks_sarscov2.wdl
@@ -146,7 +146,6 @@ task pangolin_many_samples {
         # gather runtime metrics
         cat /proc/uptime | cut -f 1 -d ' ' > UPTIME_SEC
         cat /proc/loadavg > CPU_LOAD
-        cat /sys/fs/cgroup/memory/memory.max_usage_in_bytes > MEM_BYTES
     >>>
     runtime {
         docker: docker
@@ -170,7 +169,6 @@ task pangolin_many_samples {
         String             pangolearn_version     = read_string("VERSION_PANGOLEARN")
         File               pango_lineage_report   = "${basename}.pangolin_report.csv"
         File               msa_fasta              = "~{basename}.pangolin_msa.fasta"
-        Int                max_ram_gb             = ceil(read_float("MEM_BYTES")/1000000000)
         Int                runtime_sec            = ceil(read_float("UPTIME_SEC"))
         String             cpu_load               = read_string("CPU_LOAD")
     }

--- a/pipes/WDL/tasks/tasks_sarscov2.wdl
+++ b/pipes/WDL/tasks/tasks_sarscov2.wdl
@@ -50,6 +50,10 @@ task pangolin_one_sample {
                     outf.write(line["conflict"])
                 with open("PANGOLIN_NOTES", 'wt') as outf:
                     outf.write(line["note"])
+                with open("SCORPIO_CALL", 'wt') as outf:
+                    outf.write(line["scorpio_call"])
+                with open("SCORPIO_NOTES", 'wt') as outf:
+                    outf.write(line["scorpio_notes"])
                 break
         CODE
     >>>
@@ -66,6 +70,8 @@ task pangolin_one_sample {
         String     pango_lineage          = read_string("PANGO_LINEAGE")
         String     pangolin_conflicts     = read_string("PANGOLIN_CONFLICTS")
         String     pangolin_notes         = read_string("PANGOLIN_NOTES")
+        String     scorpio_call           = read_string("SCORPIO_CALL")
+        String     scorpio_notes          = read_string("SCORPIO_NOTES")
         String     pangolin_docker        = docker
         String     pangolin_versions      = read_string("VERSION_PANGOLIN_ALL")
         String     pangolin_assignment_version = read_string("PANGO_ASSIGNMENT_VERSION")
@@ -125,7 +131,7 @@ task pangolin_many_samples {
         with open("~{basename}.pangolin_report.csv", 'rt') as csv_file:
             with open('IDLIST', 'wt') as outf_ids:
                 for row in csv.DictReader(csv_file):
-                    for k in ('lineage','conflict','note'):
+                    for k in ('lineage','conflict','note','scorpio_call','scorpio_notes'):
                         out_maps[k][row['taxon']] = row[k]
                     outf_ids.write(row['taxon']+'\n')
         with open('PANGO_LINEAGE.json', 'wt') as outf:
@@ -134,6 +140,10 @@ task pangolin_many_samples {
             json.dump(out_maps['conflict'], outf)
         with open('PANGOLIN_NOTES.json', 'wt') as outf:
             json.dump(out_maps['note'], outf)
+        with open('SCORPIO_CALL.json', 'wt') as outf:
+            json.dump(out_maps['scorpio_call'], outf)
+        with open('SCORPIO_NOTES.json', 'wt') as outf:
+            json.dump(out_maps['scorpio_notes'], outf)
         CODE
 
         # gather runtime metrics
@@ -152,6 +162,8 @@ task pangolin_many_samples {
         Map[String,String] pango_lineage          = read_json("PANGO_LINEAGE.json")
         Map[String,String] pangolin_conflicts     = read_json("PANGOLIN_CONFLICTS.json")
         Map[String,String] pangolin_notes         = read_json("PANGOLIN_NOTES.json")
+        Map[String,String] scorpio_call           = read_json("SCORPIO_CALL.json")
+        Map[String,String] scorpio_notes          = read_json("SCORPIO_NOTES.json")
         Array[String]      genome_ids             = read_lines("IDLIST")
         String             date                   = read_string("DATE")
         String             pangolin_assignment_version = read_string("PANGO_ASSIGNMENT_VERSION")

--- a/pipes/WDL/tasks/tasks_sarscov2.wdl
+++ b/pipes/WDL/tasks/tasks_sarscov2.wdl
@@ -10,7 +10,7 @@ task pangolin_one_sample {
         Float?  max_ambig
         String? analysis_mode
         Boolean update_dbs_now=false
-        String  docker = "quay.io/staphb/pangolin:4.0.4-pdata-1.2.133"
+        String  docker = "quay.io/staphb/pangolin:4.0.3-pdata-1.2.133"
     }
     String basename = basename(genome_fasta, ".fasta")
     command <<<
@@ -23,7 +23,7 @@ task pangolin_one_sample {
             set -e
         fi
         date | tee DATE
-        { pangolin --all-versions && usher --version; } | tr '\n' ';'  | cut -f -6 -d ';' | tee VERSION_PANGOLIN_ALL
+        { pangolin --all-versions && usher --version; } | grep -v '\*\*\*\*' | grep -v "Pangolin running in" | tr '\n' ';'  | cut -f -6 -d ';' | tee VERSION_PANGOLIN_ALL
 
         pangolin "~{genome_fasta}" \
             ~{'--analysis-mode ' + analysis_mode} \
@@ -91,7 +91,7 @@ task pangolin_many_samples {
         String?      analysis_mode
         Boolean      update_dbs_now=false
         String       basename
-        String       docker = "quay.io/staphb/pangolin:4.0.4-pdata-1.2.133"
+        String       docker = "quay.io/staphb/pangolin:4.0.3-pdata-1.2.133"
     }
     command <<<
         set -ex
@@ -103,7 +103,7 @@ task pangolin_many_samples {
             set -e
         fi
         date | tee DATE
-        { pangolin --all-versions && usher --version; } | tr '\n' ';'  | cut -f -6 -d ';' | tee VERSION_PANGOLIN_ALL
+        { pangolin --all-versions && usher --version; } | grep -v '\*\*\*\*' | grep -v "Pangolin running in" | tr '\n' ';'  | cut -f -6 -d ';' | tee VERSION_PANGOLIN_ALL
 
         cat ~{sep=" " genome_fastas} > unaligned.fasta
         pangolin unaligned.fasta \

--- a/pipes/WDL/tasks/tasks_sarscov2.wdl
+++ b/pipes/WDL/tasks/tasks_sarscov2.wdl
@@ -37,7 +37,6 @@ task pangolin_one_sample {
             --threads $(nproc) \
             --verbose
 
-        cp sequences.aln.fasta "~{basename}.pangolin_msa.fasta"
         python3 <<CODE
         import csv
         #grab output values by column header
@@ -119,7 +118,6 @@ task pangolin_many_samples {
             --threads $(nproc) \
             --verbose
 
-        cp sequences.aln.fasta "~{basename}.pangolin_msa.fasta"
         python3 <<CODE
         import csv, json
         #grab output values by column header

--- a/pipes/WDL/tasks/tasks_sarscov2.wdl
+++ b/pipes/WDL/tasks/tasks_sarscov2.wdl
@@ -23,7 +23,7 @@ task pangolin_one_sample {
             set -e
         fi
         date | tee DATE
-        conda list -n pangolin | grep "usher" | awk -F ' +' '{print$1, $2}' | tee VERSION_PANGO_USHER
+        micromamba list -n pangolin | grep "usher" | awk -F ' +' '{print$2, $3}' | tee VERSION_PANGO_USHER
         pangolin -v | tee VERSION_PANGOLIN
         pangolin -pv | tee VERSION_PANGOLEARN
         pangolin --all-versions | tr '\n' ';' | cut -f -5 -d ';' | tee VERSION_PANGOLIN_ALL
@@ -103,7 +103,7 @@ task pangolin_many_samples {
             set -e
         fi
         date | tee DATE
-        conda list -n pangolin | grep "usher" | awk -F ' +' '{print$1, $2}' | tee VERSION_PANGO_USHER
+        micromamba list -n pangolin | grep "usher" | awk -F ' +' '{print$2, $3}' | tee VERSION_PANGO_USHER
         pangolin -v | tee VERSION_PANGOLIN
         pangolin -pv | tee VERSION_PANGOLEARN
         pangolin --all-versions | tr '\n' ';' | cut -f -5 -d ';' | tee VERSION_PANGOLIN_ALL

--- a/pipes/WDL/tasks/tasks_sarscov2.wdl
+++ b/pipes/WDL/tasks/tasks_sarscov2.wdl
@@ -37,6 +37,7 @@ task pangolin_one_sample {
             --threads $(nproc) \
             --verbose
 
+        cp alignment.fasta "~{basename}.pangolin_msa.fasta"
         python3 <<CODE
         import csv
         #grab output values by column header
@@ -118,6 +119,7 @@ task pangolin_many_samples {
             --threads $(nproc) \
             --verbose
 
+        cp alignment.fasta "~{basename}.pangolin_msa.fasta"
         python3 <<CODE
         import csv, json
         #grab output values by column header

--- a/pipes/WDL/workflows/sarscov2_batch_relineage.wdl
+++ b/pipes/WDL/workflows/sarscov2_batch_relineage.wdl
@@ -53,6 +53,7 @@ workflow sarscov2_batch_relineage {
         Array[String] metadata = [
             sample_sanitized,
             pangolin_many_samples.pango_lineage[sample_sanitized],
+            pangolin_many_samples.scorpio_call[sample_sanitized],
             nextclade_many_samples.nextclade_clade[sample_sanitized],
             nextclade_many_samples.aa_subs_csv[sample_sanitized],
             nextclade_many_samples.aa_dels_csv[sample_sanitized],
@@ -62,7 +63,8 @@ workflow sarscov2_batch_relineage {
     }
     Array[String] meta_header = [
         'sample_sanitized',
-        'pango_lineage', 'nextclade_clade', 'nextclade_aa_subs', 'nextclade_aa_dels',
+        'pango_lineage', 'scorpio_call',
+        'nextclade_clade', 'nextclade_aa_subs', 'nextclade_aa_dels',
         'pangolin_version', 'nextclade_version'
     ]
 

--- a/pipes/WDL/workflows/sarscov2_lineages.wdl
+++ b/pipes/WDL/workflows/sarscov2_lineages.wdl
@@ -33,11 +33,10 @@ workflow sarscov2_lineages {
         String pango_lineage      = pangolin_one_sample.pango_lineage
         String pangolin_conflicts = pangolin_one_sample.pangolin_conflicts
         String pangolin_notes     = pangolin_one_sample.pangolin_notes
+        String scorpio_call       = pangolin_one_sample.scorpio_call
+        String scorpio_notes      = pangolin_one_sample.scorpio_notes
         File   pango_lineage_report = pangolin_one_sample.pango_lineage_report
-        String pangolin_usher_version = pangolin_one_sample.pangolin_usher_version
         String pangolin_docker    = pangolin_one_sample.pangolin_docker
-        String pangolin_version   = pangolin_one_sample.pangolin_version
-        String pangolearn_version = pangolin_one_sample.pangolearn_version
         String pangolin_versions  = pangolin_one_sample.pangolin_versions
     }
 }

--- a/requirements-modules.txt
+++ b/requirements-modules.txt
@@ -7,5 +7,5 @@ broadinstitute/beast-beagle-cuda=1.10.5pre
 broadinstitute/ncbi-tools=2.10.7.10
 nextstrain/base=build-20211012T204409Z
 andersenlabapps/ivar=1.3.1
-quay.io/staphb/pangolin=4.0.3-pdata-1.2.133
+quay.io/staphb/pangolin=4.0.4-pdata-1.2.133
 nextstrain/nextclade=1.11.0

--- a/requirements-modules.txt
+++ b/requirements-modules.txt
@@ -7,5 +7,5 @@ broadinstitute/beast-beagle-cuda=1.10.5pre
 broadinstitute/ncbi-tools=2.10.7.10
 nextstrain/base=build-20211012T204409Z
 andersenlabapps/ivar=1.3.1
-quay.io/staphb/pangolin=4.0.2-pdata-1.2.133
+quay.io/staphb/pangolin=4.0.3-pdata-1.2.133
 nextstrain/nextclade=1.11.0

--- a/requirements-modules.txt
+++ b/requirements-modules.txt
@@ -7,5 +7,5 @@ broadinstitute/beast-beagle-cuda=1.10.5pre
 broadinstitute/ncbi-tools=2.10.7.10
 nextstrain/base=build-20211012T204409Z
 andersenlabapps/ivar=1.3.1
-quay.io/staphb/pangolin=3.1.20-pangolearn-2022-02-28
+quay.io/staphb/pangolin=4.0.2-pdata-1.2.133
 nextstrain/nextclade=1.11.0

--- a/requirements-modules.txt
+++ b/requirements-modules.txt
@@ -7,5 +7,5 @@ broadinstitute/beast-beagle-cuda=1.10.5pre
 broadinstitute/ncbi-tools=2.10.7.10
 nextstrain/base=build-20211012T204409Z
 andersenlabapps/ivar=1.3.1
-quay.io/staphb/pangolin=4.0.4-pdata-1.2.133
+quay.io/staphb/pangolin=4.0.3-pdata-1.2.133
 nextstrain/nextclade=1.11.0


### PR DESCRIPTION
New major release of pangolin v4.0.4 and new release of pangolin-data (1.2.133) now available, WDLs updated to use docker image `quay.io/staphb/pangolin:4.0.4-pdata-1.2.133`
- pangoLEARN and pango-designation dependencies replaced by pangolin-data (which includes pangoLEARN random-forest model, UShER tree, other dependencies)
- Version of pangolin-data now in sync with version of pango-designation (e.g. 1.2.133) for clarity
- Default inference engine/analysis mode is UShER
- To use pangolearn: pangolin --analysis-mode fast or pangolin --analysis-mode pangolearn
- :rotating_light: pangolearn mode consumes more RAM than before. Be aware when using this mode, you may hit errors like killed if it runs out of memory. I have seen failures on GH Actions runners w/ 7 GB of RAM. Not sure what the recommended amount is yet :rotating_light:
- assignment-cache is included in the docker image. Slow for low #'s of samples, but fast for large #'s of samples pangolin --use-assignment-cache many-genomes.fasta
- pango_lineage result: None is now Unassigned
- Adds many Omicron sublineages (Look at pango-designation [release notes from v1.2.127 to v1.2.133](https://github.com/cov-lineages/pango-designation/releases) for complete list)
- Adds a few Delta sublineages; withdrew AY.96
- Adds recombinant lineages XD, XE, XF

Pangolin documentation and release notes for more details:

- [Complete pangolin documentation](https://cov-lineages.org/resources/pangolin.html)
- [pangolin release notes](https://github.com/cov-lineages/pangolin/releases) (3.1.20 :arrow_right: 4.0.4)
- [pangoLEARN release notes](https://github.com/cov-lineages/pangoLEARN/releases) (2022-02-28 :arrow_right: replaced by pangolin-data)
- [pango-designation release notes](https://github.com/cov-lineages/pango-designation/releases) (1.2.132 :arrow_right: replaced by pangolin-data)
- [pangolin-data release notes](https://github.com/cov-lineages/pangolin-data/releases) (1.2.133, NEW)
- [scorpio release notes](https://github.com/cov-lineages/scorpio/releases) (0.3.16, no change)
- [constellations release notes](https://github.com/cov-lineages/constellations/releases) (0.1.4, no change)
- [UShER release notes](https://github.com/yatisht/usher/releases) (0.5.2 :arrow_right: 0.5.3)