### PR TITLE
pangolin docker update: pdata-1.8

### DIFF
--- a/pipes/WDL/tasks/tasks_sarscov2.wdl
+++ b/pipes/WDL/tasks/tasks_sarscov2.wdl
@@ -10,7 +10,7 @@ task pangolin_one_sample {
         Float?  max_ambig
         String? analysis_mode
         Boolean update_dbs_now=false
-        String  docker = "quay.io/staphb/pangolin:4.0.6-pdata-1.6"
+        String  docker = "quay.io/staphb/pangolin:4.0.6-pdata-1.8"
     }
     String basename = basename(genome_fasta, ".fasta")
     command <<<
@@ -91,7 +91,7 @@ task pangolin_many_samples {
         String?      analysis_mode
         Boolean      update_dbs_now=false
         String       basename
-        String       docker = "quay.io/staphb/pangolin:4.0.6-pdata-1.6"
+        String       docker = "quay.io/staphb/pangolin:4.0.6-pdata-1.8"
     }
     command <<<
         set -ex

--- a/requirements-modules.txt
+++ b/requirements-modules.txt
@@ -7,5 +7,5 @@ broadinstitute/beast-beagle-cuda=1.10.5pre
 broadinstitute/ncbi-tools=2.10.7.10
 nextstrain/base=build-20211012T204409Z
 andersenlabapps/ivar=1.3.1
-quay.io/staphb/pangolin=4.0.6-pdata-1.6
+quay.io/staphb/pangolin=4.0.6-pdata-1.8
 nextstrain/nextclade=1.11.0


### PR DESCRIPTION
Update pangolin docker image to `quay.io/staphb/pangolin:4.0.6-pdata-1.8` (pdata 1.6 to 1.8)

- Can detect various new Delta and (primarily) Omicron sublineages. Look at comment below and pango-designation [release notes from v1.6 to v1.8](https://github.com/cov-lineages/pango-designation/releases) for complete list
- Can detect recombinant lineages up through XU
- :rotating_light: pangolearn analysis mode requires even more RAM than previously. I've found the minimum is roughly 16.5GB RAM :rotating_light:
- This docker image has swelled in size, despite our best attempts to keep it small. Docker image was 873MB, now is 2.59GB (compressed)

I recommend you check out the Pangolin documentation and release notes for more details:

- [Complete pangolin documentation](https://cov-lineages.org/resources/pangolin.html)
- [pangolin release notes](https://github.com/cov-lineages/pangolin/releases) (4.0.6, no change)
- [pangolin-data release notes](https://github.com/cov-lineages/pangolin-data/releases) (1.6 :arrow_right: 1.8)
- [scorpio release notes](https://github.com/cov-lineages/scorpio/releases) (0.3.17, no change)
- [constellations release notes](https://github.com/cov-lineages/constellations/releases) (0.1.8, no change)
- [UShER release notes](https://github.com/yatisht/usher/releases) (0.5.3 :arrow_right: 0.5.4)