### PR TITLE
bump pangolin docker

### DIFF
--- a/pipes/WDL/tasks/tasks_sarscov2.wdl
+++ b/pipes/WDL/tasks/tasks_sarscov2.wdl
@@ -10,7 +10,7 @@ task pangolin_one_sample {
         Float?  max_ambig
         String? analysis_mode
         Boolean update_dbs_now=false
-        String  docker = "quay.io/staphb/pangolin:4.0.6-pdata-1.8"
+        String  docker = "quay.io/staphb/pangolin:4.0.6-pdata-1.8-constellations-0.1.10"
     }
     String basename = basename(genome_fasta, ".fasta")
     command <<<
@@ -91,7 +91,7 @@ task pangolin_many_samples {
         String?      analysis_mode
         Boolean      update_dbs_now=false
         String       basename
-        String       docker = "quay.io/staphb/pangolin:4.0.6-pdata-1.8"
+        String       docker = "quay.io/staphb/pangolin:4.0.6-pdata-1.8-constellations-0.1.10"
     }
     command <<<
         set -ex

--- a/requirements-modules.txt
+++ b/requirements-modules.txt
@@ -7,5 +7,5 @@ broadinstitute/beast-beagle-cuda=1.10.5pre
 broadinstitute/ncbi-tools=2.10.7.10
 nextstrain/base=build-20211012T204409Z
 andersenlabapps/ivar=1.3.1
-quay.io/staphb/pangolin=4.0.6-pdata-1.8
+quay.io/staphb/pangolin=4.0.6-pdata-1.8-constellations-0.1.10
 nextstrain/nextclade=1.11.0


### PR DESCRIPTION
Small update to the StaPH-B docker image for pangolin v4.0.6 and pangolin-data v1.8. constellations has been [upgraded to v0.1.10](https://github.com/cov-lineages/constellations/releases) (previously v0.1.8). Samples previously assigned a lineage may change to Unassigned in the lineage field. More info in various GitHub issues [here](https://github.com/cov-lineages/pango-designation/issues/584), [here](https://github.com/cov-lineages/pangolin/issues/449), and [here](https://github.com/cov-lineages/pangolin/issues/451).

New docker: `quay.io/staphb/pangolin:4.0.6-pdata-1.8-constellations-0.1.10`

Pangolin documentation and release notes for more details:
- [Complete pangolin documentation](https://cov-lineages.org/resources/pangolin.html)
- [pangolin release notes](https://github.com/cov-lineages/pangolin/releases) (4.0.6, no change)
- [pangolin-data release notes](https://github.com/cov-lineages/pangolin-data/releases) (1.8, no change)
- [scorpio release notes](https://github.com/cov-lineages/scorpio/releases) (0.3.17, no change)
- [constellations release notes](https://github.com/cov-lineages/constellations/releases) (0.1.8 :arrow_right: 0.1.10)
- [UShER release notes](https://github.com/yatisht/usher/releases) (0.5.4, no change)