### PR TITLE
consensus calling major_cutoff knobs and defaults

### DIFF
--- a/pipes/WDL/workflows/assemble_refbased.wdl
+++ b/pipes/WDL/workflows/assemble_refbased.wdl
@@ -45,6 +45,9 @@ workflow assemble_refbased {
         min_coverage: {
             description: "Minimum read coverage required to call a position unambiguous."
         }
+        major_cutoff: {
+            description: "If the major allele is present at a frequency higher than this cutoff, we will call an unambiguous base at that position.  If it is equal to or below this cutoff, we will call an ambiguous base representing all possible alleles at that position."
+        }
 
 
         assembly_fasta: { description: "The new assembly / consensus sequence for this sample" }
@@ -61,6 +64,7 @@ workflow assemble_refbased {
         String       aligner="minimap2"
         File?        novocraft_license
         Int          min_coverage=3
+        Float        major_cutoff=0.75
         Boolean      skip_mark_dupes=false
         File?        trim_coords_bed
     }
@@ -140,6 +144,7 @@ workflow assemble_refbased {
             reference_fasta   = reference_fasta,
             reads_aligned_bam = aligned_trimmed_bam,
             min_coverage      = min_coverage,
+            major_cutoff      = major_cutoff,
             sample_name       = sample_name
     }
 

--- a/pipes/WDL/workflows/sarscov2_illumina_full.wdl
+++ b/pipes/WDL/workflows/sarscov2_illumina_full.wdl
@@ -117,6 +117,7 @@ workflow sarscov2_illumina_full {
                 aligner             = "minimap2",
                 skip_mark_dupes     = ampseq,
                 trim_coords_bed     = trim_coords_bed,
+                major_cutoff        = 0.75,
                 min_coverage        = if ampseq then 50 else 3
         }
 


### PR DESCRIPTION
The `major_cutoff` parameter for consensus genome generation (ultimately implemented [here](https://github.com/broadinstitute/viral-assemble/blob/master/assembly.py#L944-L952)) produces IUPAC ambiguity bases in the output assembly at positions where there is significant read support for non-major alleles. The parameter (a value from 0.0 to 1.0) defines the threshold. If the major allele frequency (the frequency of the allele with highest count) is strictly above this threshold, then a single non-ambiguous base will be called at that position. If it is equal to or below the threshold, an appropriate IUPAC ambiguity base will be chosen that represents the possible set of (2 or more) alleles seen in the alignment.

 - Expose the `major_cutoff` knob to the outer levels of the `assemble_refbased` and `sarscov2_illumina_full` WDL workflows (they were previously only exposed at the task level).
 - Change the default value of `major_cutoff` for both workflows to 0.75 (for `sarscov2_illumina_full` since it is mostly governed by contractual requirements, and for `assemble_refbased` because it seems to be a more sensible value than the old default of 0.5, which only calls 2-allele ambiguity codes when *exact* 50-50 read support is observed).