### PR TITLE
update pangolin to pdata 1.9

### DIFF
--- a/pipes/WDL/tasks/tasks_sarscov2.wdl
+++ b/pipes/WDL/tasks/tasks_sarscov2.wdl
@@ -10,7 +10,7 @@ task pangolin_one_sample {
         Float?  max_ambig
         String? analysis_mode
         Boolean update_dbs_now=false
-        String  docker = "quay.io/staphb/pangolin:4.0.6-pdata-1.8-constellations-0.1.10"
+        String  docker = "quay.io/staphb/pangolin:4.0.6-pdata-1.9"
     }
     String basename = basename(genome_fasta, ".fasta")
     command <<<
@@ -91,7 +91,7 @@ task pangolin_many_samples {
         String?      analysis_mode
         Boolean      update_dbs_now=false
         String       basename
-        String       docker = "quay.io/staphb/pangolin:4.0.6-pdata-1.8-constellations-0.1.10"
+        String       docker = "quay.io/staphb/pangolin:4.0.6-pdata-1.9"
     }
     command <<<
         set -ex

--- a/requirements-modules.txt
+++ b/requirements-modules.txt
@@ -7,5 +7,5 @@ broadinstitute/beast-beagle-cuda=1.10.5pre
 broadinstitute/ncbi-tools=2.10.7.10
 nextstrain/base=build-20211012T204409Z
 andersenlabapps/ivar=1.3.1
-quay.io/staphb/pangolin=4.0.6-pdata-1.8-constellations-0.1.10
+quay.io/staphb/pangolin=4.0.6-pdata-1.9
 nextstrain/nextclade=1.11.0


### PR DESCRIPTION
Update default pangolin docker to latest from staphb [Quay](https://quay.io/repository/staphb/pangolin?tab=tags) `staphb/pangolin:4.0.6-pdata-1.9`.

What to expect:
 - adds new BA.2 sublineages and 2 new recombinant lineages:
BA.2.10.2
BA.2.23.1
BA.2.35
BA.2.36
BA.2.37
BA.2.38
BA.2.39
BA.2.40
BA.2.40.1
BA.2.41
XV
XW
 - Withdrew lineage BA.2.3.3
 - :rotating_light: pangolearn consumes even more RAM than before, we have found that at least 19GB of RAM is required to avoid out-of-memory-errors :rotating_light:

Check out the Pangolin documentation and release notes for more details:
- [Complete pangolin documentation](https://cov-lineages.org/resources/pangolin.html)
- [pangolin release notes](https://github.com/cov-lineages/pangolin/releases) (4.0.6, no change)
- [pangolin-data release notes](https://github.com/cov-lineages/pangolin-data/releases) (1.8 :arrow_right: 1.9)
- [scorpio release notes](https://github.com/cov-lineages/scorpio/releases) (0.3.17, no change)
- [constellations release notes](https://github.com/cov-lineages/constellations/releases) (0.1.10, no change)
- [UShER release notes](https://github.com/yatisht/usher/releases) (0.5.4, no change)