### PR TITLE
lofreq task portability, misc other edits

### DIFF
--- a/pipes/WDL/tasks/tasks_intrahost.wdl
+++ b/pipes/WDL/tasks/tasks_intrahost.wdl
@@ -128,13 +128,16 @@ task lofreq {
 
     lofreq version | grep version | sed 's/.* \(.*\)/\1/g' | tee LOFREQ_VERSION
 
-    samtools faidx "~{reference_fasta}"
-    samtools index "~{aligned_bam}"
+    # make local copies because CWD is writeable but localization dir isn't always
+    cp "~{reference_fasta}" reference.fasta
+    cp "~{aligned_bam}" aligned.bam
+    samtools faidx reference.fasta
+    samtools index aligned.bam
 
     lofreq call \
-      -f "~{reference_fasta}" \
+      -f reference.fasta \
       -o "~{out_basename}.vcf" \
-      "~{aligned_bam}"
+      aligned.bam
   >>>
 
   output {

--- a/pipes/WDL/tasks/tasks_intrahost.wdl
+++ b/pipes/WDL/tasks/tasks_intrahost.wdl
@@ -131,9 +131,18 @@ task lofreq {
     # make local copies because CWD is writeable but localization dir isn't always
     cp "~{reference_fasta}" reference.fasta
     cp "~{aligned_bam}" aligned.bam
+
+    # samtools faidx fails if fasta is empty
+    if [ $(grep -v '^>' reference.fasta | tr -d '\nNn' | wc -c) == "0" ]; then
+      touch "~{out_basename}.vcf"
+      exit 0
+    fi
+
+    # index for lofreq
     samtools faidx reference.fasta
     samtools index aligned.bam
 
+    # lofreq
     lofreq call \
       -f reference.fasta \
       -o "~{out_basename}.vcf" \

--- a/pipes/WDL/tasks/tasks_ncbi.wdl
+++ b/pipes/WDL/tasks/tasks_ncbi.wdl
@@ -846,7 +846,7 @@ task prepare_genbank {
   }
 }
 
-task package_genbank_ftp_submission {
+task package_sc2_genbank_ftp_submission {
   meta {
     description: "Prepares a zip and xml file for FTP-based NCBI Genbank submission according to instructions at https://www.ncbi.nlm.nih.gov/viewvc/v1/trunk/submit/public-docs/genbank/SARS-CoV-2/."
   }

--- a/pipes/WDL/workflows/metagenomic_denovo.wdl
+++ b/pipes/WDL/workflows/metagenomic_denovo.wdl
@@ -188,6 +188,7 @@ workflow metagenomic_denovo {
     input:
       contigs_fasta           = assemble.contigs_fasta,
       reads_bam               = dehosted_bam,
+      sample_name             = sample_name,
       reference_genome_fasta  = reference_genome_fasta
   }
 

--- a/pipes/WDL/workflows/sarscov2_genbank.wdl
+++ b/pipes/WDL/workflows/sarscov2_genbank.wdl
@@ -123,7 +123,7 @@ workflow sarscov2_genbank {
             defaults_yaml = author_sbt_defaults_yaml,
             j2_template   = author_sbt_j2_template
     }
-    call ncbi.package_genbank_ftp_submission as passing_package_genbank {
+    call ncbi.package_sc2_genbank_ftp_submission as passing_package_genbank {
       input:
         sequences_fasta          = passing_fasta.combined,
         source_modifier_table    = passing_source_modifiers.genbank_source_modifier_table,
@@ -159,7 +159,7 @@ workflow sarscov2_genbank {
         assembly_stats_tsv = assembly_stats_tsv,
         filter_to_ids      = weird_ids.ids_txt
     }
-    call ncbi.package_genbank_ftp_submission as weird_package_genbank {
+    call ncbi.package_sc2_genbank_ftp_submission as weird_package_genbank {
       input:
         sequences_fasta          = weird_fasta.combined,
         source_modifier_table    = weird_source_modifiers.genbank_source_modifier_table,

--- a/pipes/WDL/workflows/sarscov2_illumina_full.wdl
+++ b/pipes/WDL/workflows/sarscov2_illumina_full.wdl
@@ -330,7 +330,7 @@ workflow sarscov2_illumina_full {
         sequences = submittable_filter.filtered_fasta,
         keep_list = [biosample_to_genbank.sample_ids]
     }
-    call ncbi.package_sc2_genbank_ftp_submission {
+    call ncbi.package_sc2_genbank_ftp_submission as package_genbank_ftp_submission {
       input:
         sequences_fasta          = submit_genomes.filtered_fasta,
         source_modifier_table    = biosample_to_genbank.genbank_source_modifier_table,
@@ -465,9 +465,9 @@ workflow sarscov2_illumina_full {
         File          assembly_stats_relineage_tsv = sarscov2_batch_relineage.assembly_stats_relineage_tsv
         File          assembly_stats_final_relineage_tsv = sc2_meta_final.meta_tsv
 
-        File          submission_zip               = package_sc2_genbank_ftp_submission.submission_zip
-        File          submission_xml               = package_sc2_genbank_ftp_submission.submission_xml
-        File          submit_ready                 = package_sc2_genbank_ftp_submission.submit_ready
+        File          submission_zip               = package_genbank_ftp_submission.submission_zip
+        File          submission_xml               = package_genbank_ftp_submission.submission_xml
+        File          submit_ready                 = package_genbank_ftp_submission.submit_ready
         Array[File]   vadr_outputs                 = select_all(vadr.outputs_tgz)
         File          genbank_source_table         = biosample_to_genbank.genbank_source_modifier_table
         

--- a/pipes/WDL/workflows/sarscov2_illumina_full.wdl
+++ b/pipes/WDL/workflows/sarscov2_illumina_full.wdl
@@ -329,7 +329,7 @@ workflow sarscov2_illumina_full {
         sequences = submittable_filter.filtered_fasta,
         keep_list = [biosample_to_genbank.sample_ids]
     }
-    call ncbi.package_genbank_ftp_submission {
+    call ncbi.package_sc2_genbank_ftp_submission {
       input:
         sequences_fasta          = submit_genomes.filtered_fasta,
         source_modifier_table    = biosample_to_genbank.genbank_source_modifier_table,
@@ -464,9 +464,9 @@ workflow sarscov2_illumina_full {
         File          assembly_stats_relineage_tsv = sarscov2_batch_relineage.assembly_stats_relineage_tsv
         File          assembly_stats_final_relineage_tsv = sc2_meta_final.meta_tsv
 
-        File          submission_zip               = package_genbank_ftp_submission.submission_zip
-        File          submission_xml               = package_genbank_ftp_submission.submission_xml
-        File          submit_ready                 = package_genbank_ftp_submission.submit_ready
+        File          submission_zip               = package_sc2_genbank_ftp_submission.submission_zip
+        File          submission_xml               = package_sc2_genbank_ftp_submission.submission_xml
+        File          submit_ready                 = package_sc2_genbank_ftp_submission.submit_ready
         Array[File]   vadr_outputs                 = select_all(vadr.outputs_tgz)
         File          genbank_source_table         = biosample_to_genbank.genbank_source_modifier_table
         

--- a/pipes/WDL/workflows/sarscov2_sra_to_genbank.wdl
+++ b/pipes/WDL/workflows/sarscov2_sra_to_genbank.wdl
@@ -199,7 +199,7 @@ workflow sarscov2_sra_to_genbank {
         assembly_stats_tsv = write_tsv(flatten([[['SeqID','Assembly Method','Coverage','Sequencing Technology']],select_all(assembly_cmt)])),
         filter_to_ids      = write_lines(select_all(submittable_id))
     }
-    call ncbi.package_genbank_ftp_submission {
+    call ncbi.package_sc2_genbank_ftp_submission as package_genbank_ftp_submission {
       input:
         sequences_fasta          = submit_genomes.combined,
         source_modifier_table    = biosample_to_genbank.genbank_source_modifier_table,


### PR DESCRIPTION
This PR introduces 3 small unrelated improvements:
1. `task lofreq` was written in a way that presumed writability of new files in the localization directory. This fails in execution environments that mount input files into the container as read only. Change WDL task behavior to make local copies before indexing.
2. Rename WDL task ncbi.package_genbank_ftp_submission to ncbi.package_sc2_genbank_ftp_submission, since the format of the zip package produced is not universally accepted for all species at Genbank yet.
3. `assemble_denovo`: percolate sample_name to scaffolding input so that output fasta files are named properly.