### PR TITLE
expose exclude/drop list input for nextstrain_build_subsample task

### DIFF
--- a/pipes/WDL/tasks/tasks_nextstrain.wdl
+++ b/pipes/WDL/tasks/tasks_nextstrain.wdl
@@ -421,6 +421,7 @@ task nextstrain_build_subsample {
         File?  builds_yaml
         File?  parameters_yaml
         File?  keep_list
+        File?  drop_list
 
         Int?   machine_mem_gb
         String docker = "nextstrain/base:build-20211012T204409Z"
@@ -485,10 +486,25 @@ task nextstrain_build_subsample {
         fi
 
         # hard inclusion list
+        # This prepares the "defaults/include.txt" file expected by the subsample Snakemake rule 
+        # operating with the default configuration
         KEEP_LIST="~{default='' keep_list}"
         if [ -n "$KEEP_LIST" ]; then
             for i in $(cat defaults/include.txt); do echo $i; done > include-ncov-default-cleannewlines.txt
             cat include-ncov-default-cleannewlines.txt $KEEP_LIST > defaults/include.txt
+        fi
+
+        # hard exclusion list
+        # This prepares the "defaults/exclude.txt" file expected by the subsample Snakemake rule 
+        # operating with the default configuration
+        #
+        # See:
+        #   https://github.com/nextstrain/ncov/blob/7b8e74d80772641fc656310cd2b83d2f11dde76a/workflow/snakemake_rules/main_workflow.smk#L292
+        #   https://github.com/nextstrain/ncov/blob/638470f64b980b60e7bb766866b7faa8b7a7c5aa/defaults/parameters.yaml#L57
+        DROP_LIST="~{default='' drop_list}"
+        if [ -n "$DROP_LIST" ]; then
+            for i in $(cat defaults/exclude.txt); do echo $i; done > exclude-ncov-default-cleannewlines.txt
+            cat exclude-ncov-default-cleannewlines.txt $DROP_LIST > defaults/exclude.txt
         fi
 
         # seed input data (skip some upstream steps in the DAG)


### PR DESCRIPTION
expose exclude/drop list file input for the nextstrain_build_subsample task, which passes the contained sequence IDs to the Nextstrain subsample Snakemake task via the default filename it expects