### PR TITLE
nextclade 2.0 updates

### DIFF
--- a/pipes/WDL/tasks/tasks_nextstrain.wdl
+++ b/pipes/WDL/tasks/tasks_nextstrain.wdl
@@ -27,7 +27,7 @@ task nextclade_one_sample {
         # grab named nextclade dataset
         DATASET_ARG=""
         if [ -n "~{default='' dataset_name}" ]; then
-            nextclade dataset get --name="~{default='' dataset_name}" --output-all=.
+            nextclade dataset get --name="~{default='' dataset_name}" --output-dir=.
             DATASET_ARG="--input-dataset ."
         python3<<CODE1
         import json, os
@@ -110,7 +110,7 @@ task nextclade_many_samples {
         # grab named nextclade dataset
         DATASET_ARG=""
         if [ -n "~{default='' dataset_name}" ]; then
-            nextclade dataset get --name="~{default='' dataset_name}" --output-all=.
+            nextclade dataset get --name="~{default='' dataset_name}" --output-dir=.
             DATASET_ARG="--input-dataset ."
         python3<<CODE1
         import json, os

--- a/pipes/WDL/tasks/tasks_nextstrain.wdl
+++ b/pipes/WDL/tasks/tasks_nextstrain.wdl
@@ -27,7 +27,7 @@ task nextclade_one_sample {
         # grab named nextclade dataset
         DATASET_ARG=""
         if [ -n "~{default='' dataset_name}" ]; then
-            nextclade dataset get --name="~{default='' dataset_name}" --output-dir=.
+            nextclade dataset get --name="~{default='' dataset_name}" --output-all=.
             DATASET_ARG="--input-dataset ."
         python3<<CODE1
         import json, os
@@ -46,6 +46,7 @@ task nextclade_one_sample {
             ~{"--input-gene-map " + gene_annotations_json} \
             ~{"--input-pcr-primers " + pcr_primers_csv} \
             ~{"--input-virus-properties " + virus_properties}  \
+            --output-all=. \
             --output-basename "~{basename}" \
             --output-json "~{basename}".nextclade.json \
             --output-tsv  "~{basename}".nextclade.tsv \
@@ -109,7 +110,7 @@ task nextclade_many_samples {
         # grab named nextclade dataset
         DATASET_ARG=""
         if [ -n "~{default='' dataset_name}" ]; then
-            nextclade dataset get --name="~{default='' dataset_name}" --output-dir=.
+            nextclade dataset get --name="~{default='' dataset_name}" --output-all=.
             DATASET_ARG="--input-dataset ."
         python3<<CODE1
         import json, os
@@ -128,6 +129,7 @@ task nextclade_many_samples {
             ~{"--input-gene-map " + gene_annotations_json} \
             ~{"--input-pcr-primers " + pcr_primers_csv} \
             ~{"--input-virus-properties " + virus_properties}  \
+            --output-all=. \
             --output-basename "~{basename}" \
             --output-json "~{basename}".nextclade.json \
             --output-tsv  "~{basename}".nextclade.tsv \

--- a/pipes/WDL/tasks/tasks_nextstrain.wdl
+++ b/pipes/WDL/tasks/tasks_nextstrain.wdl
@@ -13,7 +13,7 @@ task nextclade_one_sample {
         File? pcr_primers_csv
         File? virus_properties
         String? dataset_name
-        String docker = "nextstrain/nextclade:1.11.0"
+        String docker = "nextstrain/nextclade:2.0.0"
     }
     String basename = basename(genome_fasta, ".fasta")
     command {
@@ -25,8 +25,10 @@ task nextclade_one_sample {
         echo $NEXTCLADE_VERSION > VERSION
 
         # grab named nextclade dataset
+        DATASET_ARG=""
         if [ -n "~{default='' dataset_name}" ]; then
             nextclade dataset get --name="~{default='' dataset_name}" --output-dir=.
+            DATASET_ARG="--input-dataset ."
         python3<<CODE1
         import json, os
         with open('tag.json', 'rt') as inf:
@@ -37,21 +39,22 @@ task nextclade_one_sample {
         fi
 
         nextclade run \
-            --input-fasta "~{genome_fasta}" \
-            --input-root-seq ~{default="reference.fasta" root_sequence} \
-            --input-tree ~{default="tree.json" auspice_reference_tree_json} \
-            --input-qc-config ~{default="qc.json" qc_config_json} \
-            --input-gene-map ~{default="genemap.gff" gene_annotations_json} \
-            --input-pcr-primers ~{default="primers.csv" pcr_primers_csv} \
-            --input-virus-properties ~{default="virus_properties.json" virus_properties}  \
+            $DATASET_ARG \
+            ~{"--input-root-seq " + root_sequence} \
+            ~{"--input-tree " + auspice_reference_tree_json} \
+            ~{"--input-qc-config " + qc_config_json} \
+            ~{"--input-gene-map " + gene_annotations_json} \
+            ~{"--input-pcr-primers " + pcr_primers_csv} \
+            ~{"--input-virus-properties " + virus_properties}  \
+            --output-basename "~{basename}" \
             --output-json "~{basename}".nextclade.json \
             --output-tsv  "~{basename}".nextclade.tsv \
-            --output-tree "~{basename}".nextclade.auspice.json
-        cp "~{basename}".nextclade.tsv input.tsv
+            --output-tree "~{basename}".nextclade.auspice.json \
+            "~{genome_fasta}"
         python3 <<CODE
         # transpose table
         import codecs
-        with codecs.open('input.tsv', 'r', encoding='utf-8') as inf:
+        with codecs.open('~{basename}.nextclade.tsv', 'r', encoding='utf-8') as inf:
             with codecs.open('transposed.tsv', 'w', encoding='utf-8') as outf:
                 for c in zip(*(l.rstrip().split('\t') for l in inf)):
                     outf.write('\t'.join(c)+'\n')
@@ -93,7 +96,7 @@ task nextclade_many_samples {
         File?        virus_properties
         String?      dataset_name
         String       basename
-        String       docker = "nextstrain/nextclade:1.11.0"
+        String       docker = "nextstrain/nextclade:2.0.0"
     }
     command <<<
         set -e
@@ -104,8 +107,10 @@ task nextclade_many_samples {
         echo $NEXTCLADE_VERSION > VERSION
 
         # grab named nextclade dataset
+        DATASET_ARG=""
         if [ -n "~{default='' dataset_name}" ]; then
             nextclade dataset get --name="~{default='' dataset_name}" --output-dir=.
+            DATASET_ARG="--input-dataset ."
         python3<<CODE1
         import json, os
         with open('tag.json', 'rt') as inf:
@@ -115,20 +120,20 @@ task nextclade_many_samples {
         CODE1
         fi
 
-        cat ~{sep=" " genome_fastas} > genomes.fasta
         nextclade run \
-            --input-fasta genomes.fasta \
-            --input-root-seq ~{default="reference.fasta" root_sequence} \
-            --input-tree ~{default="tree.json" auspice_reference_tree_json} \
-            --input-qc-config ~{default="qc.json" qc_config_json} \
-            --input-gene-map ~{default="genemap.gff" gene_annotations_json} \
-            --input-pcr-primers ~{default="primers.csv" pcr_primers_csv} \
-            --input-virus-properties ~{default="virus_properties.json" virus_properties}  \
+            $DATASET_ARG \
+            ~{"--input-root-seq " + root_sequence} \
+            ~{"--input-tree " + auspice_reference_tree_json} \
+            ~{"--input-qc-config " + qc_config_json} \
+            ~{"--input-gene-map " + gene_annotations_json} \
+            ~{"--input-pcr-primers " + pcr_primers_csv} \
+            ~{"--input-virus-properties " + virus_properties}  \
+            --output-basename "~{basename}" \
             --output-json "~{basename}".nextclade.json \
             --output-tsv  "~{basename}".nextclade.tsv \
-            --output-tree "~{basename}".nextclade.auspice.json
-
-        cp genomes.aligned.fasta "~{basename}".nextalign.msa.fasta
+            --output-tree "~{basename}".nextclade.auspice.json \
+            --output-fasta "~{basename}".nextalign.msa.fasta \
+            ~{sep=" " genome_fastas}
 
         python3 <<CODE
         # transpose table

--- a/requirements-modules.txt
+++ b/requirements-modules.txt
@@ -8,4 +8,4 @@ broadinstitute/ncbi-tools=2.10.7.10
 nextstrain/base=build-20211012T204409Z
 andersenlabapps/ivar=1.3.1
 quay.io/staphb/pangolin=4.0.6-pdata-1.9
-nextstrain/nextclade=1.11.0
+nextstrain/nextclade=2.0.0


### PR DESCRIPTION
Update nextclade docker from 1.11.0 to 2.0.0.

- The CLI arguments in v2 are slightly different. See [changelog](https://github.com/nextstrain/nextclade/blob/master/CHANGELOG.md#nextclade-200) and `nextclade --help`
- After v2 is released, Nextclade v1 will no longer be supported - there will be no software updates. Datasets for v1 will stay online, and they might receive occasional updates, but Nextclade will not be able to take advantage of improvements in v2. We recommend to upgrade soon.
- Nextstrain's [ncov-ingest](https://github.com/nextstrain/ncov-ingest) and [ncov](https://github.com/nextstrain/ncov) repositories will switch to nextclade/nextalign v2 during this period
- Nextstrain's [monkeypox](https://github.com/nextstrain/monkeypox) repo already uses v2 beta

Please adjust your scripts and workflows accordingly to avoid sudden breakage.

- :globe_with_meridians: [clades.nextstrain.org](http://clades.nextstrain.org/)
- :book: [Documentation](https://docs.nextstrain.org/projects/nextclade/en/stable/)
- :cat: [Downloads](https://github.com/nextstrain/nextclade/releases)
- :whale: [Docker images](https://hub.docker.com/r/nextstrain/nextclade)
- :interrobang: [Report issues](https://github.com/nextstrain/nextclade/issues)
- :speech_balloon: [Forum](https://discussion.nextstrain.org/)