### PR TITLE
update pangolin docker to 4.1.1-pdata-1.11

### DIFF
--- a/pipes/WDL/tasks/tasks_sarscov2.wdl
+++ b/pipes/WDL/tasks/tasks_sarscov2.wdl
@@ -10,7 +10,7 @@ task pangolin_one_sample {
         Float?  max_ambig
         String? analysis_mode
         Boolean update_dbs_now=false
-        String  docker = "quay.io/staphb/pangolin:4.0.6-pdata-1.9"
+        String  docker = "quay.io/staphb/pangolin:4.1.1-pdata-1.11"
     }
     String basename = basename(genome_fasta, ".fasta")
     command <<<
@@ -91,7 +91,7 @@ task pangolin_many_samples {
         String?      analysis_mode
         Boolean      update_dbs_now=false
         String       basename
-        String       docker = "quay.io/staphb/pangolin:4.0.6-pdata-1.9"
+        String       docker = "quay.io/staphb/pangolin:4.1.1-pdata-1.11"
     }
     command <<<
         set -ex

--- a/pipes/WDL/workflows/sarscov2_batch_relineage.wdl
+++ b/pipes/WDL/workflows/sarscov2_batch_relineage.wdl
@@ -38,9 +38,10 @@ workflow sarscov2_batch_relineage {
 
     call nextstrain.nextclade_many_samples {
         input:
-            genome_fastas = [filter_sequences_by_length.filtered_fasta],
-            basename      = "nextclade-~{flowcell_id}",
-            dataset_name  = "sars-cov-2"
+            genome_fastas               = [filter_sequences_by_length.filtered_fasta],
+            genome_ids_setdefault_blank = fasta_to_ids.ids_txt,
+            basename                    = "nextclade-~{flowcell_id}",
+            dataset_name                = "sars-cov-2"
     }
 
     call sarscov2.pangolin_many_samples {

--- a/requirements-modules.txt
+++ b/requirements-modules.txt
@@ -7,5 +7,5 @@ broadinstitute/beast-beagle-cuda=1.10.5pre
 broadinstitute/ncbi-tools=2.10.7.10
 nextstrain/base=build-20211012T204409Z
 andersenlabapps/ivar=1.3.1
-quay.io/staphb/pangolin=4.0.6-pdata-1.9
+quay.io/staphb/pangolin=4.1.1-pdata-1.11
 nextstrain/nextclade=2.0.0


### PR DESCRIPTION
Update docker image for new release of pangolin v4.1.1 and new release of pangolin-data v1.11 -- `quay.io/staphb/pangolin:4.1.1-pdata-1.11`

What to expect:
- `--skip-scorpio` no longer necessary **with usher analysis-mode**. The option is on by default. Users should see significantly less sequences assigned as "Unassigned".
- In contrast, scorpio overrides will still occur when using pangolearn analysis mode. Use --skip-scorpio option if using pangolearn to prevent overrides.
- :rotating_light: pangolearn analysis-mode consumes more RAM than before, we have found that at least **21.5GB of RAM is required** to avoid out-of-memory errors :rotating_light:
- Adds many new sublineages of: AY.98, BA.1, BA.2, BA.4, BA.5
- Adds 10 new recombinant lineages. Full list included as a txt file in thread.
- To decode the [pango lineage aliases, see the key here](https://github.com/cov-lineages/pangolin-data/blob/main/pangolin_data/data/alias_key.json).

I recommend you check out the Pangolin documentation and release notes for more details:
- [Complete pangolin documentation](https://cov-lineages.org/resources/pangolin.html)
- [pangolin release notes](https://github.com/cov-lineages/pangolin/releases) (4.0.6 :arrow_right: 4.1.1)
- [pangolin-data release notes](https://github.com/cov-lineages/pangolin-data/releases) (1.9 :arrow_right: 1.11)
- [scorpio release notes](https://github.com/cov-lineages/scorpio/releases) (0.3.17, no change)
- [constellations release notes](https://github.com/cov-lineages/constellations/releases) (0.1.10, no change)
- [UShER release notes](https://github.com/yatisht/usher/releases) (0.5.4 :arrow_right: 0.5.6)