### PR TITLE
bump pangolin to 4.1.2-1.14 and nextclade to 2.5.0

### DIFF
--- a/pipes/WDL/tasks/tasks_nextstrain.wdl
+++ b/pipes/WDL/tasks/tasks_nextstrain.wdl
@@ -13,7 +13,7 @@ task nextclade_one_sample {
         File? pcr_primers_csv
         File? virus_properties
         String? dataset_name
-        String docker = "nextstrain/nextclade:2.3.0"
+        String docker = "nextstrain/nextclade:2.5.0"
     }
     String basename = basename(genome_fasta, ".fasta")
     command {
@@ -98,7 +98,7 @@ task nextclade_many_samples {
         String?      dataset_name
         String       basename
         File?        genome_ids_setdefault_blank
-        String       docker = "nextstrain/nextclade:2.3.0"
+        String       docker = "nextstrain/nextclade:2.5.0"
     }
     command <<<
         set -e

--- a/pipes/WDL/tasks/tasks_sarscov2.wdl
+++ b/pipes/WDL/tasks/tasks_sarscov2.wdl
@@ -10,7 +10,7 @@ task pangolin_one_sample {
         Float?  max_ambig
         String? analysis_mode
         Boolean update_dbs_now=false
-        String  docker = "quay.io/staphb/pangolin:4.1.1-pdata-1.11"
+        String  docker = "quay.io/staphb/pangolin:4.1.2-pdata-1.12"
     }
     String basename = basename(genome_fasta, ".fasta")
     command <<<
@@ -91,7 +91,7 @@ task pangolin_many_samples {
         String?      analysis_mode
         Boolean      update_dbs_now=false
         String       basename
-        String       docker = "quay.io/staphb/pangolin:4.1.1-pdata-1.11"
+        String       docker = "quay.io/staphb/pangolin:4.1.2-pdata-1.12"
     }
     command <<<
         set -ex

--- a/pipes/WDL/tasks/tasks_sarscov2.wdl
+++ b/pipes/WDL/tasks/tasks_sarscov2.wdl
@@ -10,7 +10,7 @@ task pangolin_one_sample {
         Float?  max_ambig
         String? analysis_mode
         Boolean update_dbs_now=false
-        String  docker = "quay.io/staphb/pangolin:4.1.2-pdata-1.12"
+        String  docker = "quay.io/staphb/pangolin:4.1.2-pdata-1.14"
     }
     String basename = basename(genome_fasta, ".fasta")
     command <<<
@@ -91,7 +91,7 @@ task pangolin_many_samples {
         String?      analysis_mode
         Boolean      update_dbs_now=false
         String       basename
-        String       docker = "quay.io/staphb/pangolin:4.1.2-pdata-1.12"
+        String       docker = "quay.io/staphb/pangolin:4.1.2-pdata-1.14"
     }
     command <<<
         set -ex

--- a/requirements-modules.txt
+++ b/requirements-modules.txt
@@ -7,5 +7,5 @@ broadinstitute/beast-beagle-cuda=1.10.5pre
 broadinstitute/ncbi-tools=2.10.7.10
 nextstrain/base=build-20211012T204409Z
 andersenlabapps/ivar=1.3.1
-quay.io/staphb/pangolin=4.1.1-pdata-1.11
+quay.io/staphb/pangolin=4.1.2-pdata-1.12
 nextstrain/nextclade=2.3.0

--- a/requirements-modules.txt
+++ b/requirements-modules.txt
@@ -7,5 +7,5 @@ broadinstitute/beast-beagle-cuda=1.10.5pre
 broadinstitute/ncbi-tools=2.10.7.10
 nextstrain/base=build-20211012T204409Z
 andersenlabapps/ivar=1.3.1
-quay.io/staphb/pangolin=4.1.2-pdata-1.12
-nextstrain/nextclade=2.3.0
+quay.io/staphb/pangolin=4.1.2-pdata-1.14
+nextstrain/nextclade=2.5.0


### PR DESCRIPTION
Docker image for new release of pangolin v4.1.2 and new release of pangolin-data v1.14. Available on [Quay](https://quay.io/repository/staphb/pangolin?tab=tags) `quay.io/staphb/pangolin:4.1.2-pdata-1.14`

What to expect:
- :rotating_light: pangolearn analysis-mode consumes more RAM than before, we have found that at least 25.0GB of RAM is required to avoid killed/out-of-memory errors :rotating_light:
- Adds many new Omicron/BA sublineages.
- Adds a 2 new recombinant lineages
- To decode the [pango lineage aliases, see the key here](https://github.com/cov-lineages/pangolin-data/blob/main/pangolin_data/data/alias_key.json).

I recommend you check out the Pangolin documentation and release notes for more details:
- [Complete pangolin documentation](https://cov-lineages.org/resources/pangolin.html)
- [pangolin release notes](https://github.com/cov-lineages/pangolin/releases) (4.1.1 :arrow_right: 4.1.2)
- [pangolin-data release notes](https://github.com/cov-lineages/pangolin-data/releases) (1.11 :arrow_right: 1.14)
- [scorpio release notes](https://github.com/cov-lineages/scorpio/releases) (0.3.17, no change)
- [constellations release notes](https://github.com/cov-lineages/constellations/releases) (0.1.10, no change)
- [UShER release notes](https://github.com/yatisht/usher/releases) (0.5.6, no change)