### PR TITLE
task alignment_metrics: more resilient to large amplicon designs

### DIFF
--- a/pipes/WDL/tasks/tasks_reports.wdl
+++ b/pipes/WDL/tasks/tasks_reports.wdl
@@ -1,14 +1,18 @@
 version 1.0
 
 task alignment_metrics {
+  meta {
+      description: "Produce various standard metrics and coverage plots via Picard and Samtools for aligned BAM files."
+  }
+
   input {
     File   aligned_bam
     File   ref_fasta
     File?  primers_bed
     String? amplicon_set
     Int?   min_coverage
-    Int?   max_amp_len
-    Int?   max_amplicons
+    Int?   max_amp_len=5000
+    Int?   max_amplicons=500
 
     Int?   machine_mem_gb
     String docker = "quay.io/broadinstitute/viral-core:2.1.33"

--- a/pipes/WDL/tasks/tasks_reports.wdl
+++ b/pipes/WDL/tasks/tasks_reports.wdl
@@ -7,6 +7,8 @@ task alignment_metrics {
     File?  primers_bed
     String? amplicon_set
     Int?   min_coverage
+    Int?   max_amp_len
+    Int?   max_amplicons
 
     Int?   machine_mem_gb
     String docker = "quay.io/broadinstitute/viral-core:2.1.33"
@@ -62,6 +64,8 @@ task alignment_metrics {
       # samtools ampliconstats
       samtools ampliconstats -s -@ $(nproc) \
         ~{'-d ' + min_coverage} \
+        ~{'-l ' + max_amp_len} \
+        ~{'-a ' + max_amplicons} \
         -o "~{out_basename}".ampliconstats.txt "~{primers_bed}" "~{aligned_bam}"
 
       # parse into our own tsv to facilitate tsv joining later


### PR DESCRIPTION
Expose knobs for `samtools ampliconstats` `max_amp_len` and `max_amplicons`. Set our default values for those higher than samtools defaults (high enough to work for MPXV ARTIC designs). No apparent downside.