### PR TITLE
more disk for nextstrain; dockstore API fix

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -278,89 +278,10 @@ workflows:
     subclass: WDL
     primaryDescriptorPath: /pipes/WDL/workflows/sarscov2_lineages.wdl
     testParameterFiles:
-  - name: kraken2_build
-    subclass: WDL
-    primaryDescriptorPath: /pipes/WDL/workflows/kraken2_build.wdl
-    testParameterFiles:
-      - empty.json
-  - name: mafft_and_snp
-    subclass: WDL
-    primaryDescriptorPath: /pipes/WDL/workflows/mafft_and_snp.wdl
-    testParameterFiles:
-      - empty.json
-  - name: mafft_and_snp_annotated
-    subclass: WDL
-    primaryDescriptorPath: /pipes/WDL/workflows/mafft_and_snp_annotated.wdl
-    testParameterFiles:
-      - empty.json
-  - name: mafft_and_trim
-    subclass: WDL
-    primaryDescriptorPath: /pipes/WDL/workflows/mafft_and_trim.wdl
-    testParameterFiles:
-      - empty.json
-  - name: mafft
-    subclass: WDL
-    primaryDescriptorPath: /pipes/WDL/workflows/mafft.wdl
-    testParameterFiles:
-      - empty.json
-  - name: merge_bams
-    subclass: WDL
-    primaryDescriptorPath: /pipes/WDL/workflows/merge_bams.wdl
-    testParameterFiles:
-      - empty.json
-  - name: merge_metagenomics
-    subclass: WDL
-    primaryDescriptorPath: /pipes/WDL/workflows/merge_metagenomics.wdl
-    testParameterFiles:
-      - empty.json
-  - name: merge_tar_chunks
-    subclass: WDL
-    primaryDescriptorPath: /pipes/WDL/workflows/merge_tar_chunks.wdl
-    testParameterFiles:
-      - empty.json
-  - name: merge_vcfs_and_annotate
-    subclass: WDL
-    primaryDescriptorPath: /pipes/WDL/workflows/merge_vcfs_and_annotate.wdl
-    testParameterFiles:
-      - empty.json
-  - name: merge_vcfs
-    subclass: WDL
-    primaryDescriptorPath: /pipes/WDL/workflows/merge_vcfs.wdl
-    testParameterFiles:
-      - empty.json
-  - name: multiqc_only
-    subclass: WDL
-    primaryDescriptorPath: /pipes/WDL/workflows/multiqc_only.wdl
-    testParameterFiles:
-      - empty.json
+    - /test/input/WDL/test_inputs-sarscov2_lineages-local.json
   - name: read_depths
     subclass: WDL
     primaryDescriptorPath: /pipes/WDL/workflows/read_depths.wdl
-    testParameterFiles:
-      - empty.json
-  - name: sarscov2_batch_relineage
-    subclass: WDL
-    primaryDescriptorPath: /pipes/WDL/workflows/sarscov2_batch_relineage.wdl
-    testParameterFiles:
-      - empty.json
-  - name: sarscov2_biosample_load
-    subclass: WDL
-    primaryDescriptorPath: /pipes/WDL/workflows/sarscov2_biosample_load.wdl
-    testParameterFiles:
-      - empty.json
-  - name: sarscov2_data_release
-    subclass: WDL
-    primaryDescriptorPath: /pipes/WDL/workflows/sarscov2_data_release.wdl
-    testParameterFiles:
-      - empty.json
-  - name: sarscov2_genbank
-    subclass: WDL
-    primaryDescriptorPath: /pipes/WDL/workflows/sarscov2_genbank.wdl
-    testParameterFiles:
-      - empty.json
-  - name: sarscov2_genbank_ingest
-    subclass: WDL
-    primaryDescriptorPath: /pipes/WDL/workflows/sarscov2_genbank_ingest.wdl
     testParameterFiles:
       - empty.json
   - name: sarscov2_gisaid_ingest
@@ -368,16 +289,6 @@ workflows:
     primaryDescriptorPath: /pipes/WDL/workflows/sarscov2_gisaid_ingest.wdl
     testParameterFiles:
       - empty.json
-  - name: sarscov2_illumina_full
-    subclass: WDL
-    primaryDescriptorPath: /pipes/WDL/workflows/sarscov2_illumina_full.wdl
-    testParameterFiles:
-      - empty.json
-  - name: sarscov2_lineages
-    subclass: WDL
-    primaryDescriptorPath: /pipes/WDL/workflows/sarscov2_lineages.wdl
-    testParameterFiles:
-    - /test/input/WDL/test_inputs-sarscov2_lineages-local.json
   - name: sarscov2_nextclade_multi
     subclass: WDL
     primaryDescriptorPath: /pipes/WDL/workflows/sarscov2_nextclade_multi.wdl

--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -278,11 +278,6 @@ workflows:
     subclass: WDL
     primaryDescriptorPath: /pipes/WDL/workflows/sarscov2_lineages.wdl
     testParameterFiles:
-  - name: isnvs_merge_to_vcf
-    subclass: WDL
-    primaryDescriptorPath: /pipes/WDL/workflows/isnvs_merge_to_vcf.wdl
-    testParameterFiles:
-      - empty.json
   - name: isnvs_one_sample
     subclass: WDL
     primaryDescriptorPath: /pipes/WDL/workflows/isnvs_one_sample.wdl

--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -278,11 +278,6 @@ workflows:
     subclass: WDL
     primaryDescriptorPath: /pipes/WDL/workflows/sarscov2_lineages.wdl
     testParameterFiles:
-  - name: isnvs_one_sample
-    subclass: WDL
-    primaryDescriptorPath: /pipes/WDL/workflows/isnvs_one_sample.wdl
-    testParameterFiles:
-      - empty.json
   - name: kraken2_build
     subclass: WDL
     primaryDescriptorPath: /pipes/WDL/workflows/kraken2_build.wdl

--- a/pipes/WDL/tasks/tasks_nextstrain.wdl
+++ b/pipes/WDL/tasks/tasks_nextstrain.wdl
@@ -60,9 +60,9 @@ task nextclade_one_sample {
                 for c in zip(*(l.rstrip().split('\t') for l in inf)):
                     outf.write('\t'.join(c)+'\n')
         CODE
-        grep ^clade transposed.tsv | cut -f 2 | grep -v clade > NEXTCLADE_CLADE
-        grep ^aaSubstitutions transposed.tsv | cut -f 2 | grep -v aaSubstitutions > NEXTCLADE_AASUBS
-        grep ^aaDeletions transposed.tsv | cut -f 2 | grep -v aaDeletions > NEXTCLADE_AADELS
+        grep ^clade\\W transposed.tsv | cut -f 2 | grep -v clade > NEXTCLADE_CLADE
+        grep ^aaSubstitutions\\W transposed.tsv | cut -f 2 | grep -v aaSubstitutions > NEXTCLADE_AASUBS
+        grep ^aaDeletions\\W transposed.tsv | cut -f 2 | grep -v aaDeletions > NEXTCLADE_AADELS
     }
     runtime {
         docker: docker

--- a/pipes/WDL/tasks/tasks_utils.wdl
+++ b/pipes/WDL/tasks/tasks_utils.wdl
@@ -660,7 +660,7 @@ task filter_sequences_by_length {
         docker: docker
         memory: "1 GB"
         cpu :   1
-        disks:  "local-disk 300 HDD"
+        disks:  "local-disk 700 HDD"
         dx_instance_type: "mem1_ssd1_v2_x2"
         maxRetries: 2
     }


### PR DESCRIPTION
Several short but urgent fixes:
1. more disk space for filter sequences by length for nextstrain
2. dockstore API now breaks if our yml is malformed with duplicates. Not sure how we got all these dupes in our yml but this PR cleans them up so the API is no longer broken.
3. updates to nextclade output columns require some slight fixes to how we ingest in nextclade_one_sample