### PR TITLE
denovo assembly SPAdes updates

### DIFF
--- a/pipes/WDL/tasks/tasks_assembly.wdl
+++ b/pipes/WDL/tasks/tasks_assembly.wdl
@@ -7,6 +7,7 @@ task assemble {
       
       Int      spades_n_reads = 10000000
       Int      spades_min_contig_len = 0
+      String?  spades_options
       
       String   assembler = "spades"
       Boolean  always_succeed = false
@@ -37,6 +38,7 @@ task assemble {
             ~{'--nReads=' + spades_n_reads} \
             ~{true="--alwaysSucceed" false="" always_succeed} \
             ~{'--minContigLen=' + spades_min_contig_len} \
+            ~{'--spadesOpts="' + spades_options + '"'} \
             --memLimitGb $mem_in_gb \
             --outReads=~{sample_name}.subsamp.bam \
             --loglevel=DEBUG

--- a/pipes/WDL/tasks/tasks_assembly.wdl
+++ b/pipes/WDL/tasks/tasks_assembly.wdl
@@ -16,7 +16,7 @@ task assemble {
       String   sample_name = basename(basename(reads_unmapped_bam, ".bam"), ".taxfilt")
       
       Int?     machine_mem_gb
-      String   docker = "quay.io/broadinstitute/viral-assemble:2.1.16.1"
+      String   docker = "quay.io/broadinstitute/viral-assemble:2.1.20.1"
     }
 
     Int disk_size = 375
@@ -86,7 +86,7 @@ task scaffold {
       Float?       scaffold_min_pct_contig_aligned
 
       Int?         machine_mem_gb
-      String       docker="quay.io/broadinstitute/viral-assemble:2.1.16.1"
+      String       docker="quay.io/broadinstitute/viral-assemble:2.1.20.1"
 
       # do this in multiple steps in case the input doesn't actually have "assembly1-x" in the name
       String       sample_name = basename(basename(contigs_fasta, ".fasta"), ".assembly1-spades")
@@ -428,7 +428,7 @@ task refine_assembly_with_aligned_reads {
       Int      min_coverage = 3
 
       Int?     machine_mem_gb
-      String   docker = "quay.io/broadinstitute/viral-assemble:2.1.16.1"
+      String   docker = "quay.io/broadinstitute/viral-assemble:2.1.20.1"
     }
 
     Int disk_size = 375
@@ -538,7 +538,7 @@ task refine_2x_and_plot {
       String? plot_coverage_novoalign_options = "-r Random -l 40 -g 40 -x 20 -t 100 -k"
 
       Int?    machine_mem_gb
-      String  docker = "quay.io/broadinstitute/viral-assemble:2.1.16.1"
+      String  docker = "quay.io/broadinstitute/viral-assemble:2.1.20.1"
 
       # do this in two steps in case the input doesn't actually have "cleaned" in the name
       String  sample_name = basename(basename(reads_unmapped_bam, ".bam"), ".cleaned")

--- a/pipes/WDL/tasks/tasks_assembly.wdl
+++ b/pipes/WDL/tasks/tasks_assembly.wdl
@@ -16,7 +16,7 @@ task assemble {
       String   sample_name = basename(basename(reads_unmapped_bam, ".bam"), ".taxfilt")
       
       Int?     machine_mem_gb
-      String   docker = "quay.io/broadinstitute/viral-assemble:2.1.20.1"
+      String   docker = "quay.io/broadinstitute/viral-assemble:2.1.20.2"
     }
 
     Int disk_size = 375
@@ -86,7 +86,7 @@ task scaffold {
       Float?       scaffold_min_pct_contig_aligned
 
       Int?         machine_mem_gb
-      String       docker="quay.io/broadinstitute/viral-assemble:2.1.20.1"
+      String       docker="quay.io/broadinstitute/viral-assemble:2.1.20.2"
 
       # do this in multiple steps in case the input doesn't actually have "assembly1-x" in the name
       String       sample_name = basename(basename(contigs_fasta, ".fasta"), ".assembly1-spades")
@@ -428,7 +428,7 @@ task refine_assembly_with_aligned_reads {
       Int      min_coverage = 3
 
       Int?     machine_mem_gb
-      String   docker = "quay.io/broadinstitute/viral-assemble:2.1.20.1"
+      String   docker = "quay.io/broadinstitute/viral-assemble:2.1.20.2"
     }
 
     Int disk_size = 375
@@ -538,7 +538,7 @@ task refine_2x_and_plot {
       String? plot_coverage_novoalign_options = "-r Random -l 40 -g 40 -x 20 -t 100 -k"
 
       Int?    machine_mem_gb
-      String  docker = "quay.io/broadinstitute/viral-assemble:2.1.20.1"
+      String  docker = "quay.io/broadinstitute/viral-assemble:2.1.20.2"
 
       # do this in two steps in case the input doesn't actually have "cleaned" in the name
       String  sample_name = basename(basename(reads_unmapped_bam, ".bam"), ".cleaned")

--- a/pipes/WDL/tasks/tasks_interhost.wdl
+++ b/pipes/WDL/tasks/tasks_interhost.wdl
@@ -9,7 +9,7 @@ task multi_align_mafft_ref {
     Float?       mafft_gapOpeningPenalty
 
     Int?         machine_mem_gb
-    String       docker = "quay.io/broadinstitute/viral-phylo:2.1.19.1"
+    String       docker = "quay.io/broadinstitute/viral-phylo:2.1.20.0"
   }
 
   String         fasta_basename = basename(reference_fasta, '.fasta')
@@ -56,7 +56,7 @@ task multi_align_mafft {
     Float?       mafft_gapOpeningPenalty
 
     Int?         machine_mem_gb
-    String       docker = "quay.io/broadinstitute/viral-phylo:2.1.19.1"
+    String       docker = "quay.io/broadinstitute/viral-phylo:2.1.20.0"
   }
 
   Int disk_size = 200
@@ -282,7 +282,7 @@ task merge_vcfs_gatk {
     File        ref_fasta
 
     Int?        machine_mem_gb
-    String      docker = "quay.io/broadinstitute/viral-phylo:2.1.19.1"
+    String      docker = "quay.io/broadinstitute/viral-phylo:2.1.20.0"
 
     String      output_prefix = "merged"
   }

--- a/pipes/WDL/tasks/tasks_intrahost.wdl
+++ b/pipes/WDL/tasks/tasks_intrahost.wdl
@@ -179,7 +179,7 @@ task isnvs_per_sample {
     Boolean removeDoublyMappedReads = true
 
     Int?    machine_mem_gb
-    String  docker = "quay.io/broadinstitute/viral-phylo:2.1.19.1"
+    String  docker = "quay.io/broadinstitute/viral-phylo:2.1.20.0"
 
     String  sample_name = basename(basename(basename(mapped_bam, ".bam"), ".all"), ".mapped")
   }
@@ -222,7 +222,7 @@ task isnvs_vcf {
     Boolean        naiveFilter = false
 
     Int?           machine_mem_gb
-    String         docker = "quay.io/broadinstitute/viral-phylo:2.1.19.1"
+    String         docker = "quay.io/broadinstitute/viral-phylo:2.1.20.0"
   }
 
   parameter_meta {
@@ -296,7 +296,7 @@ task annotate_vcf_snpeff {
     String?        emailAddress
 
     Int?           machine_mem_gb
-    String         docker = "quay.io/broadinstitute/viral-phylo:2.1.19.1"
+    String         docker = "quay.io/broadinstitute/viral-phylo:2.1.20.0"
 
     String         output_basename = basename(basename(in_vcf, ".gz"), ".vcf")
   }

--- a/pipes/WDL/tasks/tasks_metagenomics.wdl
+++ b/pipes/WDL/tasks/tasks_metagenomics.wdl
@@ -11,7 +11,7 @@ task krakenuniq {
     File        krona_taxonomy_db_tgz  # taxonomy.tab
 
     Int?        machine_mem_gb
-    String      docker = "quay.io/broadinstitute/viral-classify:2.1.16.0"
+    String      docker = "quay.io/broadinstitute/viral-classify:2.1.20.0"
   }
 
   Int disk_size = 750
@@ -140,7 +140,7 @@ task build_krakenuniq_db {
     Int?     zstd_compression_level
 
     Int?     machine_mem_gb
-    String   docker = "quay.io/broadinstitute/viral-classify:2.1.16.0"
+    String   docker = "quay.io/broadinstitute/viral-classify:2.1.20.0"
   }
 
   Int disk_size = 750
@@ -210,7 +210,7 @@ task kraken2 {
     Int?   min_base_qual
 
     Int?   machine_mem_gb
-    String docker = "quay.io/broadinstitute/viral-classify:2.1.16.0"
+    String docker = "quay.io/broadinstitute/viral-classify:2.1.20.0"
   }
 
   parameter_meta {
@@ -345,7 +345,7 @@ task build_kraken2_db {
     Int?          zstd_compression_level
 
     Int?          machine_mem_gb
-    String        docker = "quay.io/broadinstitute/viral-classify:2.1.16.0"
+    String        docker = "quay.io/broadinstitute/viral-classify:2.1.20.0"
   }
 
   Int disk_size = 750
@@ -487,7 +487,7 @@ task blastx {
     File   krona_taxonomy_db_tgz
 
     Int?   machine_mem_gb
-    String docker = "quay.io/broadinstitute/viral-classify:2.1.16.0"
+    String docker = "quay.io/broadinstitute/viral-classify:2.1.20.0"
   }
 
   parameter_meta {
@@ -577,7 +577,7 @@ task krona {
     Int?         magnitude_column
 
     Int?         machine_mem_gb
-    String       docker = "quay.io/broadinstitute/viral-classify:2.1.16.0"
+    String       docker = "quay.io/broadinstitute/viral-classify:2.1.20.0"
   }
 
   Int disk_size = 50
@@ -684,7 +684,7 @@ task filter_bam_to_taxa {
     String         out_filename_suffix = "filtered"
 
     Int?           machine_mem_gb
-    String         docker = "quay.io/broadinstitute/viral-classify:2.1.16.0"
+    String         docker = "quay.io/broadinstitute/viral-classify:2.1.20.0"
   }
 
   String out_basename = basename(classified_bam, ".bam") + "." + out_filename_suffix
@@ -771,7 +771,7 @@ task kaiju {
     File   krona_taxonomy_db_tgz  # taxonomy/taxonomy.tab
 
     Int?   machine_mem_gb
-    String docker = "quay.io/broadinstitute/viral-classify:2.1.16.0"
+    String docker = "quay.io/broadinstitute/viral-classify:2.1.20.0"
   }
 
   String   input_basename = basename(reads_unmapped_bam, ".bam")

--- a/pipes/WDL/tasks/tasks_ncbi.wdl
+++ b/pipes/WDL/tasks/tasks_ncbi.wdl
@@ -6,7 +6,7 @@ task download_fasta {
     Array[String]+ accessions
     String         emailAddress
 
-    String         docker = "quay.io/broadinstitute/viral-phylo:2.1.19.1"
+    String         docker = "quay.io/broadinstitute/viral-phylo:2.1.20.0"
   }
 
   command {
@@ -38,7 +38,7 @@ task download_annotations {
     String         emailAddress
     String         combined_out_prefix
 
-    String         docker = "quay.io/broadinstitute/viral-phylo:2.1.19.1"
+    String         docker = "quay.io/broadinstitute/viral-phylo:2.1.20.0"
   }
 
   command {
@@ -83,7 +83,7 @@ task annot_transfer {
     File         reference_fasta
     Array[File]+ reference_feature_table
 
-    String       docker = "quay.io/broadinstitute/viral-phylo:2.1.19.1"
+    String       docker = "quay.io/broadinstitute/viral-phylo:2.1.20.0"
   }
 
   parameter_meta {
@@ -137,7 +137,7 @@ task align_and_annot_transfer_single {
     Array[File]+ reference_fastas
     Array[File]+ reference_feature_tables
 
-    String       docker = "quay.io/broadinstitute/viral-phylo:2.1.19.1"
+    String       docker = "quay.io/broadinstitute/viral-phylo:2.1.20.0"
   }
 
   parameter_meta {
@@ -564,7 +564,7 @@ task biosample_to_genbank {
     File?   filter_to_ids
 
     Boolean s_dropout_note = true
-    String  docker = "quay.io/broadinstitute/viral-phylo:2.1.19.1"
+    String  docker = "quay.io/broadinstitute/viral-phylo:2.1.20.0"
   }
   String base = basename(biosample_attributes, ".txt")
   command {
@@ -730,7 +730,7 @@ task prepare_genbank {
     String?      assembly_method_version
 
     Int?         machine_mem_gb
-    String       docker = "quay.io/broadinstitute/viral-phylo:2.1.19.1"
+    String       docker = "quay.io/broadinstitute/viral-phylo:2.1.20.0"
   }
 
   parameter_meta {

--- a/pipes/WDL/tasks/tasks_nextstrain.wdl
+++ b/pipes/WDL/tasks/tasks_nextstrain.wdl
@@ -949,7 +949,7 @@ task mafft_one_chr {
         Boolean  large = false
         Boolean  memsavetree = false
 
-        String   docker = "quay.io/broadinstitute/viral-phylo:2.1.19.1"
+        String   docker = "quay.io/broadinstitute/viral-phylo:2.1.20.0"
         Int      mem_size = 500
         Int      cpus = 64
     }
@@ -1037,7 +1037,7 @@ task mafft_one_chr_chunked {
         Int      batch_chunk_size = 2000
         Int      threads_per_job = 2
 
-        String   docker = "quay.io/broadinstitute/viral-phylo:2.1.19.1"
+        String   docker = "quay.io/broadinstitute/viral-phylo:2.1.20.0"
         Int      mem_size = 32
         Int      cpus = 96
     }

--- a/pipes/WDL/tasks/tasks_reports.wdl
+++ b/pipes/WDL/tasks/tasks_reports.wdl
@@ -549,7 +549,7 @@ task compare_two_genomes {
     File   genome_two
     String out_basename
 
-    String docker = "quay.io/broadinstitute/viral-assemble:2.1.20.1"
+    String docker = "quay.io/broadinstitute/viral-assemble:2.1.20.2"
   }
 
   Int disk_size = 50

--- a/pipes/WDL/tasks/tasks_reports.wdl
+++ b/pipes/WDL/tasks/tasks_reports.wdl
@@ -401,7 +401,7 @@ task aggregate_metagenomics_reports {
     String       aggregate_taxlevel_focus                 = "species"
     Int          aggregate_top_N_hits                     = 5
 
-    String       docker = "quay.io/broadinstitute/viral-classify:2.1.16.0"
+    String       docker = "quay.io/broadinstitute/viral-classify:2.1.20.0"
   }
 
   parameter_meta {
@@ -549,7 +549,7 @@ task compare_two_genomes {
     File   genome_two
     String out_basename
 
-    String docker = "quay.io/broadinstitute/viral-assemble:2.1.16.1"
+    String docker = "quay.io/broadinstitute/viral-assemble:2.1.20.1"
   }
 
   Int disk_size = 50

--- a/pipes/WDL/tasks/tasks_taxon_filter.wdl
+++ b/pipes/WDL/tasks/tasks_taxon_filter.wdl
@@ -14,7 +14,7 @@ task deplete_taxa {
 
     Int?         cpu=8
     Int?         machine_mem_gb
-    String       docker = "quay.io/broadinstitute/viral-classify:2.1.16.0"
+    String       docker = "quay.io/broadinstitute/viral-classify:2.1.20.0"
   }
 
   parameter_meta {
@@ -113,7 +113,7 @@ task filter_to_taxon {
     String?  neg_control_prefixes_space_separated = "neg water NTC"
 
     Int?     machine_mem_gb
-    String   docker = "quay.io/broadinstitute/viral-classify:2.1.16.0"
+    String   docker = "quay.io/broadinstitute/viral-classify:2.1.20.0"
   }
 
   # do this in two steps in case the input doesn't actually have "cleaned" in the name
@@ -172,7 +172,7 @@ task build_lastal_db {
     File   sequences_fasta
 
     Int?   machine_mem_gb
-    String docker = "quay.io/broadinstitute/viral-classify:2.1.16.0"
+    String docker = "quay.io/broadinstitute/viral-classify:2.1.20.0"
   }
 
   String db_name = basename(sequences_fasta, ".fasta")

--- a/requirements-modules.txt
+++ b/requirements-modules.txt
@@ -1,5 +1,5 @@
 broadinstitute/viral-core=2.1.33
-broadinstitute/viral-assemble=2.1.20.1
+broadinstitute/viral-assemble=2.1.20.2
 broadinstitute/viral-classify=2.1.20.0
 broadinstitute/viral-phylo=2.1.20.0
 broadinstitute/py3-bio=0.1.2

--- a/requirements-modules.txt
+++ b/requirements-modules.txt
@@ -1,7 +1,7 @@
 broadinstitute/viral-core=2.1.33
-broadinstitute/viral-assemble=2.1.16.1
-broadinstitute/viral-classify=2.1.16.0
-broadinstitute/viral-phylo=2.1.19.1
+broadinstitute/viral-assemble=2.1.20.1
+broadinstitute/viral-classify=2.1.20.0
+broadinstitute/viral-phylo=2.1.20.0
 broadinstitute/py3-bio=0.1.2
 broadinstitute/beast-beagle-cuda=1.10.5pre
 broadinstitute/ncbi-tools=2.10.7.10

--- a/test/input/WDL/test_outputs-sarscov2_lineages-local.json
+++ b/test/input/WDL/test_outputs-sarscov2_lineages-local.json
@@ -1,5 +1,5 @@
 {
-  "sarscov2_lineages.nextclade_clade": "20A",
+  "sarscov2_lineages.nextclade_clade": "20C",
   "sarscov2_lineages.nextclade_aa_subs": "ORF1b:P314L,ORF3a:Q57H,S:D614G",
   "sarscov2_lineages.nextclade_aa_dels": "",
   "sarscov2_lineages.pango_lineage": "B.1"


### PR DESCRIPTION
Update SPAdes version. Change default to rnaviralspades (from rnaspades). Expose more optional parameters for SPAdes in assemble_denovo. Allow for override of default rnaviralspades to other modes (metaspades, metaviralspades).