### PR TITLE
genbank prep and assemble_denovo updates

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -279,9 +279,9 @@ workflows:
     primaryDescriptorPath: /pipes/WDL/workflows/sarscov2_lineages.wdl
     testParameterFiles:
     - /test/input/WDL/test_inputs-sarscov2_lineages-local.json
-  - name: read_depths
+  - name: calc_bam_read_depths
     subclass: WDL
-    primaryDescriptorPath: /pipes/WDL/workflows/read_depths.wdl
+    primaryDescriptorPath: /pipes/WDL/workflows/calc_bam_read_depths.wdl
     testParameterFiles:
       - empty.json
   - name: sarscov2_gisaid_ingest

--- a/pipes/WDL/tasks/tasks_assembly.wdl
+++ b/pipes/WDL/tasks/tasks_assembly.wdl
@@ -6,7 +6,7 @@ task assemble {
       File     trim_clip_db
       
       Int      spades_n_reads = 10000000
-      Int      spades_min_contig_len = 0
+      Int?     spades_min_contig_len
       String?  spades_options
       
       Boolean  always_succeed = false
@@ -77,6 +77,7 @@ task scaffold {
       Int?         nucmer_max_gap
       Int?         nucmer_min_match
       Int?         nucmer_min_cluster
+      Int?         scaffold_min_contig_len
       Float?       scaffold_min_pct_contig_aligned
 
       Int?         machine_mem_gb
@@ -100,6 +101,7 @@ task scaffold {
           ~{contigs_fasta} \
           ~{sep=' ' reference_genome_fasta} \
           ~{sample_name}.intermediate_scaffold.fasta \
+          ~{'--min_contig_len=' + scaffold_min_contig_len} \
           ~{'--maxgap=' + nucmer_max_gap} \
           ~{'--minmatch=' + nucmer_min_match} \
           ~{'--mincluster=' + nucmer_min_cluster} \

--- a/pipes/WDL/tasks/tasks_assembly.wdl
+++ b/pipes/WDL/tasks/tasks_assembly.wdl
@@ -111,7 +111,7 @@ task scaffold {
           --outAlternateContigs ~{sample_name}.scaffolding_alt_contigs.fasta \
           --loglevel=DEBUG
 
-        grep '^>' ~{sample_name}.scaffolding_chosen_ref.fasta | cut -c 2- | tr '\n' '\t' > ~{sample_name}.scaffolding_chosen_ref.txt
+        grep '^>' ~{sample_name}.scaffolding_chosen_ref.fasta | cut -c 2- | cut -f 1 -d ' ' > ~{sample_name}.scaffolding_chosen_refs.txt
 
         assembly.py gapfill_gap2seq \
           ~{sample_name}.intermediate_scaffold.fasta \
@@ -142,7 +142,7 @@ task scaffold {
         File   intermediate_gapfill_fasta            = "~{sample_name}.intermediate_gapfill.fasta"
         Int    assembly_preimpute_length             = read_int("assembly_preimpute_length")
         Int    assembly_preimpute_length_unambiguous = read_int("assembly_preimpute_length_unambiguous")
-        String scaffolding_chosen_ref_name           = read_string("~{sample_name}.scaffolding_chosen_ref.txt")
+        Array[String] scaffolding_chosen_ref_names   = read_lines("~{sample_name}.scaffolding_chosen_refs.txt")
         File   scaffolding_chosen_ref                = "~{sample_name}.scaffolding_chosen_ref.fasta"
         File   scaffolding_stats                     = "~{sample_name}.scaffolding_stats.txt"
         File   scaffolding_alt_contigs               = "~{sample_name}.scaffolding_alt_contigs.fasta"

--- a/pipes/WDL/tasks/tasks_assembly.wdl
+++ b/pipes/WDL/tasks/tasks_assembly.wdl
@@ -9,7 +9,6 @@ task assemble {
       Int      spades_min_contig_len = 0
       String?  spades_options
       
-      String   assembler = "spades"
       Boolean  always_succeed = false
       
       # do this in two steps in case the input doesn't actually have "taxfilt" in the name
@@ -30,28 +29,23 @@ task assemble {
 
         assembly.py --version | tee VERSION
 
-        if [[ "~{assembler}" == "spades" ]]; then
-          assembly.py assemble_spades \
-            ~{reads_unmapped_bam} \
-            ~{trim_clip_db} \
-            ~{sample_name}.assembly1-~{assembler}.fasta \
-            ~{'--nReads=' + spades_n_reads} \
-            ~{true="--alwaysSucceed" false="" always_succeed} \
-            ~{'--minContigLen=' + spades_min_contig_len} \
-            ~{'--spadesOpts="' + spades_options + '"'} \
-            --memLimitGb $mem_in_gb \
-            --outReads=~{sample_name}.subsamp.bam \
-            --loglevel=DEBUG
-        else
-          echo "unrecognized assembler ~{assembler}" >&2
-          exit 1
-        fi
+        assembly.py assemble_spades \
+          ~{reads_unmapped_bam} \
+          ~{trim_clip_db} \
+          ~{sample_name}.assembly1-spades.fasta \
+          ~{'--nReads=' + spades_n_reads} \
+          ~{true="--alwaysSucceed" false="" always_succeed} \
+          ~{'--minContigLen=' + spades_min_contig_len} \
+          ~{'--spadesOpts="' + spades_options + '"'} \
+          --memLimitGb $mem_in_gb \
+          --outReads=~{sample_name}.subsamp.bam \
+          --loglevel=DEBUG
 
         samtools view -c ~{sample_name}.subsamp.bam | tee subsample_read_count >&2
     }
 
     output {
-        File   contigs_fasta        = "~{sample_name}.assembly1-~{assembler}.fasta"
+        File   contigs_fasta        = "~{sample_name}.assembly1-spades.fasta"
         File   subsampBam           = "~{sample_name}.subsamp.bam"
         Int    subsample_read_count = read_int("subsample_read_count")
         String viralngs_version     = read_string("VERSION")

--- a/pipes/WDL/tasks/tasks_assembly.wdl
+++ b/pipes/WDL/tasks/tasks_assembly.wdl
@@ -15,7 +15,7 @@ task assemble {
       String   sample_name = basename(basename(reads_unmapped_bam, ".bam"), ".taxfilt")
       
       Int?     machine_mem_gb
-      String   docker = "quay.io/broadinstitute/viral-assemble:2.1.20.2"
+      String   docker = "quay.io/broadinstitute/viral-assemble:2.1.33.0"
     }
 
     Int disk_size = 375
@@ -81,7 +81,7 @@ task scaffold {
       Float?       scaffold_min_pct_contig_aligned
 
       Int?         machine_mem_gb
-      String       docker="quay.io/broadinstitute/viral-assemble:2.1.20.2"
+      String       docker="quay.io/broadinstitute/viral-assemble:2.1.33.0"
 
       # do this in multiple steps in case the input doesn't actually have "assembly1-x" in the name
       String       sample_name = basename(basename(contigs_fasta, ".fasta"), ".assembly1-spades")
@@ -424,7 +424,7 @@ task refine_assembly_with_aligned_reads {
       Int      min_coverage = 3
 
       Int?     machine_mem_gb
-      String   docker = "quay.io/broadinstitute/viral-assemble:2.1.20.2"
+      String   docker = "quay.io/broadinstitute/viral-assemble:2.1.33.0"
     }
 
     Int disk_size = 375
@@ -534,7 +534,7 @@ task refine_2x_and_plot {
       String? plot_coverage_novoalign_options = "-r Random -l 40 -g 40 -x 20 -t 100 -k"
 
       Int?    machine_mem_gb
-      String  docker = "quay.io/broadinstitute/viral-assemble:2.1.20.2"
+      String  docker = "quay.io/broadinstitute/viral-assemble:2.1.33.0"
 
       # do this in two steps in case the input doesn't actually have "cleaned" in the name
       String  sample_name = basename(basename(reads_unmapped_bam, ".bam"), ".cleaned")

--- a/pipes/WDL/tasks/tasks_interhost.wdl
+++ b/pipes/WDL/tasks/tasks_interhost.wdl
@@ -9,7 +9,7 @@ task multi_align_mafft_ref {
     Float?       mafft_gapOpeningPenalty
 
     Int?         machine_mem_gb
-    String       docker = "quay.io/broadinstitute/viral-phylo:2.1.20.1"
+    String       docker = "quay.io/broadinstitute/viral-phylo:2.1.20.2"
   }
 
   String         fasta_basename = basename(reference_fasta, '.fasta')
@@ -56,7 +56,7 @@ task multi_align_mafft {
     Float?       mafft_gapOpeningPenalty
 
     Int?         machine_mem_gb
-    String       docker = "quay.io/broadinstitute/viral-phylo:2.1.20.1"
+    String       docker = "quay.io/broadinstitute/viral-phylo:2.1.20.2"
   }
 
   Int disk_size = 200
@@ -282,7 +282,7 @@ task merge_vcfs_gatk {
     File        ref_fasta
 
     Int?        machine_mem_gb
-    String      docker = "quay.io/broadinstitute/viral-phylo:2.1.20.1"
+    String      docker = "quay.io/broadinstitute/viral-phylo:2.1.20.2"
 
     String      output_prefix = "merged"
   }

--- a/pipes/WDL/tasks/tasks_interhost.wdl
+++ b/pipes/WDL/tasks/tasks_interhost.wdl
@@ -9,7 +9,7 @@ task multi_align_mafft_ref {
     Float?       mafft_gapOpeningPenalty
 
     Int?         machine_mem_gb
-    String       docker = "quay.io/broadinstitute/viral-phylo:2.1.20.0"
+    String       docker = "quay.io/broadinstitute/viral-phylo:2.1.20.1"
   }
 
   String         fasta_basename = basename(reference_fasta, '.fasta')
@@ -56,7 +56,7 @@ task multi_align_mafft {
     Float?       mafft_gapOpeningPenalty
 
     Int?         machine_mem_gb
-    String       docker = "quay.io/broadinstitute/viral-phylo:2.1.20.0"
+    String       docker = "quay.io/broadinstitute/viral-phylo:2.1.20.1"
   }
 
   Int disk_size = 200
@@ -282,7 +282,7 @@ task merge_vcfs_gatk {
     File        ref_fasta
 
     Int?        machine_mem_gb
-    String      docker = "quay.io/broadinstitute/viral-phylo:2.1.20.0"
+    String      docker = "quay.io/broadinstitute/viral-phylo:2.1.20.1"
 
     String      output_prefix = "merged"
   }

--- a/pipes/WDL/tasks/tasks_intrahost.wdl
+++ b/pipes/WDL/tasks/tasks_intrahost.wdl
@@ -179,7 +179,7 @@ task isnvs_per_sample {
     Boolean removeDoublyMappedReads = true
 
     Int?    machine_mem_gb
-    String  docker = "quay.io/broadinstitute/viral-phylo:2.1.20.0"
+    String  docker = "quay.io/broadinstitute/viral-phylo:2.1.20.1"
 
     String  sample_name = basename(basename(basename(mapped_bam, ".bam"), ".all"), ".mapped")
   }
@@ -222,7 +222,7 @@ task isnvs_vcf {
     Boolean        naiveFilter = false
 
     Int?           machine_mem_gb
-    String         docker = "quay.io/broadinstitute/viral-phylo:2.1.20.0"
+    String         docker = "quay.io/broadinstitute/viral-phylo:2.1.20.1"
   }
 
   parameter_meta {
@@ -296,7 +296,7 @@ task annotate_vcf_snpeff {
     String?        emailAddress
 
     Int?           machine_mem_gb
-    String         docker = "quay.io/broadinstitute/viral-phylo:2.1.20.0"
+    String         docker = "quay.io/broadinstitute/viral-phylo:2.1.20.1"
 
     String         output_basename = basename(basename(in_vcf, ".gz"), ".vcf")
   }

--- a/pipes/WDL/tasks/tasks_intrahost.wdl
+++ b/pipes/WDL/tasks/tasks_intrahost.wdl
@@ -179,7 +179,7 @@ task isnvs_per_sample {
     Boolean removeDoublyMappedReads = true
 
     Int?    machine_mem_gb
-    String  docker = "quay.io/broadinstitute/viral-phylo:2.1.20.1"
+    String  docker = "quay.io/broadinstitute/viral-phylo:2.1.20.2"
 
     String  sample_name = basename(basename(basename(mapped_bam, ".bam"), ".all"), ".mapped")
   }
@@ -222,7 +222,7 @@ task isnvs_vcf {
     Boolean        naiveFilter = false
 
     Int?           machine_mem_gb
-    String         docker = "quay.io/broadinstitute/viral-phylo:2.1.20.1"
+    String         docker = "quay.io/broadinstitute/viral-phylo:2.1.20.2"
   }
 
   parameter_meta {
@@ -296,7 +296,7 @@ task annotate_vcf_snpeff {
     String?        emailAddress
 
     Int?           machine_mem_gb
-    String         docker = "quay.io/broadinstitute/viral-phylo:2.1.20.1"
+    String         docker = "quay.io/broadinstitute/viral-phylo:2.1.20.2"
 
     String         output_basename = basename(basename(in_vcf, ".gz"), ".vcf")
   }

--- a/pipes/WDL/tasks/tasks_metagenomics.wdl
+++ b/pipes/WDL/tasks/tasks_metagenomics.wdl
@@ -11,7 +11,7 @@ task krakenuniq {
     File        krona_taxonomy_db_tgz  # taxonomy.tab
 
     Int?        machine_mem_gb
-    String      docker = "quay.io/broadinstitute/viral-classify:2.1.20.0"
+    String      docker = "quay.io/broadinstitute/viral-classify:2.1.33.0"
   }
 
   Int disk_size = 750
@@ -140,7 +140,7 @@ task build_krakenuniq_db {
     Int?     zstd_compression_level
 
     Int?     machine_mem_gb
-    String   docker = "quay.io/broadinstitute/viral-classify:2.1.20.0"
+    String   docker = "quay.io/broadinstitute/viral-classify:2.1.33.0"
   }
 
   Int disk_size = 750
@@ -210,7 +210,7 @@ task kraken2 {
     Int?   min_base_qual
 
     Int?   machine_mem_gb
-    String docker = "quay.io/broadinstitute/viral-classify:2.1.20.0"
+    String docker = "quay.io/broadinstitute/viral-classify:2.1.33.0"
   }
 
   parameter_meta {
@@ -345,7 +345,7 @@ task build_kraken2_db {
     Int?          zstd_compression_level
 
     Int?          machine_mem_gb
-    String        docker = "quay.io/broadinstitute/viral-classify:2.1.20.0"
+    String        docker = "quay.io/broadinstitute/viral-classify:2.1.33.0"
   }
 
   Int disk_size = 750
@@ -487,7 +487,7 @@ task blastx {
     File   krona_taxonomy_db_tgz
 
     Int?   machine_mem_gb
-    String docker = "quay.io/broadinstitute/viral-classify:2.1.20.0"
+    String docker = "quay.io/broadinstitute/viral-classify:2.1.33.0"
   }
 
   parameter_meta {
@@ -577,7 +577,7 @@ task krona {
     Int?         magnitude_column
 
     Int?         machine_mem_gb
-    String       docker = "quay.io/broadinstitute/viral-classify:2.1.20.0"
+    String       docker = "quay.io/broadinstitute/viral-classify:2.1.33.0"
   }
 
   Int disk_size = 50
@@ -684,7 +684,7 @@ task filter_bam_to_taxa {
     String         out_filename_suffix = "filtered"
 
     Int?           machine_mem_gb
-    String         docker = "quay.io/broadinstitute/viral-classify:2.1.20.0"
+    String         docker = "quay.io/broadinstitute/viral-classify:2.1.33.0"
   }
 
   String out_basename = basename(classified_bam, ".bam") + "." + out_filename_suffix
@@ -771,7 +771,7 @@ task kaiju {
     File   krona_taxonomy_db_tgz  # taxonomy/taxonomy.tab
 
     Int?   machine_mem_gb
-    String docker = "quay.io/broadinstitute/viral-classify:2.1.20.0"
+    String docker = "quay.io/broadinstitute/viral-classify:2.1.33.0"
   }
 
   String   input_basename = basename(reads_unmapped_bam, ".bam")

--- a/pipes/WDL/tasks/tasks_ncbi.wdl
+++ b/pipes/WDL/tasks/tasks_ncbi.wdl
@@ -54,6 +54,7 @@ task download_annotations {
         ./ \
         ${sep=' ' accessions} \
         --combinedFilePrefix "${combined_out_prefix}" \
+        --forceOverwrite \
         --loglevel DEBUG
   }
 

--- a/pipes/WDL/tasks/tasks_ncbi.wdl
+++ b/pipes/WDL/tasks/tasks_ncbi.wdl
@@ -6,7 +6,7 @@ task download_fasta {
     Array[String]+ accessions
     String         emailAddress
 
-    String         docker = "quay.io/broadinstitute/viral-phylo:2.1.20.1"
+    String         docker = "quay.io/broadinstitute/viral-phylo:2.1.20.2"
   }
 
   command {
@@ -38,7 +38,7 @@ task download_annotations {
     String         emailAddress
     String         combined_out_prefix
 
-    String         docker = "quay.io/broadinstitute/viral-phylo:2.1.20.1"
+    String         docker = "quay.io/broadinstitute/viral-phylo:2.1.20.2"
   }
 
   command <<<
@@ -85,7 +85,7 @@ task annot_transfer {
     File         reference_fasta
     Array[File]+ reference_feature_table
 
-    String       docker = "quay.io/broadinstitute/viral-phylo:2.1.20.1"
+    String       docker = "quay.io/broadinstitute/viral-phylo:2.1.20.2"
   }
 
   parameter_meta {
@@ -139,7 +139,7 @@ task align_and_annot_transfer_single {
     Array[File]+ reference_fastas
     Array[File]+ reference_feature_tables
 
-    String       docker = "quay.io/broadinstitute/viral-phylo:2.1.20.1"
+    String       docker = "quay.io/broadinstitute/viral-phylo:2.1.20.2"
   }
 
   parameter_meta {
@@ -566,7 +566,7 @@ task biosample_to_genbank {
     File?   filter_to_ids
 
     Boolean s_dropout_note = true
-    String  docker = "quay.io/broadinstitute/viral-phylo:2.1.20.1"
+    String  docker = "quay.io/broadinstitute/viral-phylo:2.1.20.2"
   }
   String base = basename(biosample_attributes, ".txt")
   command {
@@ -732,7 +732,7 @@ task prepare_genbank {
     String?      assembly_method_version
 
     Int?         machine_mem_gb
-    String       docker = "quay.io/broadinstitute/viral-phylo:2.1.20.1"
+    String       docker = "quay.io/broadinstitute/viral-phylo:2.1.20.2"
   }
 
   parameter_meta {

--- a/pipes/WDL/tasks/tasks_ncbi.wdl
+++ b/pipes/WDL/tasks/tasks_ncbi.wdl
@@ -41,25 +41,26 @@ task download_annotations {
     String         docker = "quay.io/broadinstitute/viral-phylo:2.1.20.0"
   }
 
-  command {
+  command <<<
     set -ex -o pipefail
     ncbi.py --version | tee VERSION
     ncbi.py fetch_feature_tables \
-        ${emailAddress} \
+        ~{emailAddress} \
         ./ \
-        ${sep=' ' accessions} \
+        ~{sep=' ' accessions} \
         --loglevel DEBUG
+    mkdir -p combined
     ncbi.py fetch_fastas \
-        ${emailAddress} \
+        ~{emailAddress} \
         ./ \
-        ${sep=' ' accessions} \
-        --combinedFilePrefix "${combined_out_prefix}" \
+        ~{sep=' ' accessions} \
+        --combinedFilePrefix "combined/~{combined_out_prefix}" \
         --forceOverwrite \
         --loglevel DEBUG
-  }
+  >>>
 
   output {
-    File        combined_fasta   = "${combined_out_prefix}.fasta"
+    File        combined_fasta   = "~{combined_out_prefix}.fasta"
     Array[File] genomes_fasta    = glob("*.fasta")
     Array[File] features_tbl     = glob("*.tbl")
     String      viralngs_version = read_string("VERSION")

--- a/pipes/WDL/tasks/tasks_ncbi.wdl
+++ b/pipes/WDL/tasks/tasks_ncbi.wdl
@@ -6,7 +6,7 @@ task download_fasta {
     Array[String]+ accessions
     String         emailAddress
 
-    String         docker = "quay.io/broadinstitute/viral-phylo:2.1.20.0"
+    String         docker = "quay.io/broadinstitute/viral-phylo:2.1.20.1"
   }
 
   command {
@@ -38,7 +38,7 @@ task download_annotations {
     String         emailAddress
     String         combined_out_prefix
 
-    String         docker = "quay.io/broadinstitute/viral-phylo:2.1.20.0"
+    String         docker = "quay.io/broadinstitute/viral-phylo:2.1.20.1"
   }
 
   command <<<
@@ -85,7 +85,7 @@ task annot_transfer {
     File         reference_fasta
     Array[File]+ reference_feature_table
 
-    String       docker = "quay.io/broadinstitute/viral-phylo:2.1.20.0"
+    String       docker = "quay.io/broadinstitute/viral-phylo:2.1.20.1"
   }
 
   parameter_meta {
@@ -139,7 +139,7 @@ task align_and_annot_transfer_single {
     Array[File]+ reference_fastas
     Array[File]+ reference_feature_tables
 
-    String       docker = "quay.io/broadinstitute/viral-phylo:2.1.20.0"
+    String       docker = "quay.io/broadinstitute/viral-phylo:2.1.20.1"
   }
 
   parameter_meta {
@@ -566,7 +566,7 @@ task biosample_to_genbank {
     File?   filter_to_ids
 
     Boolean s_dropout_note = true
-    String  docker = "quay.io/broadinstitute/viral-phylo:2.1.20.0"
+    String  docker = "quay.io/broadinstitute/viral-phylo:2.1.20.1"
   }
   String base = basename(biosample_attributes, ".txt")
   command {
@@ -732,7 +732,7 @@ task prepare_genbank {
     String?      assembly_method_version
 
     Int?         machine_mem_gb
-    String       docker = "quay.io/broadinstitute/viral-phylo:2.1.20.0"
+    String       docker = "quay.io/broadinstitute/viral-phylo:2.1.20.1"
   }
 
   parameter_meta {

--- a/pipes/WDL/tasks/tasks_ncbi_tools.wdl
+++ b/pipes/WDL/tasks/tasks_ncbi_tools.wdl
@@ -154,12 +154,12 @@ task fetch_genbank_metadata {
     command <<<
         set -e
         esearch -db nuccore -q "~{genbank_accession}" | efetch -db nuccore -format gb -mode xml -json  > gb.json
-        jq -r '[.GBSet.GBSeq."GBSeq_feature-table".GBFeature[0].GBFeature_quals.GBQualifier|.[]| {(.GBQualifier_name): .GBQualifier_value}]|add ' gb.json > metadata.json
-        jq -r '.db_xref' meta.json | grep ^taxon: | cut -f 2 -d : > taxid.txt
-        jq -r '.organism' meta.json > organism.txt
+        jq -r '[.GBSet.GBSeq."GBSeq_feature-table".GBFeature[0].GBFeature_quals.GBQualifier|.[]|{(.GBQualifier_name): .GBQualifier_value}]|add ' gb.json > "~{genbank_accession}".metadata.json
+        jq -r '.db_xref' "~{genbank_accession}".metadata.json | grep ^taxon: | cut -f 2 -d : > taxid.txt
+        jq -r '.organism' "~{genbank_accession}".metadata.json > organism.txt
     >>>
     output {
-        Map[String,String] metadata = read_json("metadata.json")
+        Map[String,String] metadata = read_json("~{genbank_accession}.metadata.json")
         String taxid = read_string("taxid.txt")
         String organism = read_string("organism.txt")
     }

--- a/pipes/WDL/tasks/tasks_ncbi_tools.wdl
+++ b/pipes/WDL/tasks/tasks_ncbi_tools.wdl
@@ -153,7 +153,7 @@ task fetch_genbank_metadata {
     Int disk_size = 50
     command <<<
         set -e
-        activate $CONDA_DEFAULT_ENV # for miniwdl / non-login docker runners
+        source /opt/miniconda/bin/activate $CONDA_DEFAULT_ENV # for miniwdl / non-login docker runners
         esearch -db nuccore -q "~{genbank_accession}" | efetch -db nuccore -format gb -mode xml -json  > gb.json
         jq -r '[.GBSet.GBSeq."GBSeq_feature-table".GBFeature[0].GBFeature_quals.GBQualifier|.[]|{(.GBQualifier_name): .GBQualifier_value}]|add ' gb.json > "~{genbank_accession}".metadata.json
         jq -r '.db_xref' "~{genbank_accession}".metadata.json | grep ^taxon: | cut -f 2 -d : > taxid.txt

--- a/pipes/WDL/tasks/tasks_ncbi_tools.wdl
+++ b/pipes/WDL/tasks/tasks_ncbi_tools.wdl
@@ -153,6 +153,7 @@ task fetch_genbank_metadata {
     Int disk_size = 50
     command <<<
         set -e
+        source activate $CONDA_DEFAULT_ENV # for miniwdl / non-login docker runners
         esearch -db nuccore -q "~{genbank_accession}" | efetch -db nuccore -format gb -mode xml -json  > gb.json
         jq -r '[.GBSet.GBSeq."GBSeq_feature-table".GBFeature[0].GBFeature_quals.GBQualifier|.[]|{(.GBQualifier_name): .GBQualifier_value}]|add ' gb.json > "~{genbank_accession}".metadata.json
         jq -r '.db_xref' "~{genbank_accession}".metadata.json | grep ^taxon: | cut -f 2 -d : > taxid.txt

--- a/pipes/WDL/tasks/tasks_ncbi_tools.wdl
+++ b/pipes/WDL/tasks/tasks_ncbi_tools.wdl
@@ -153,7 +153,7 @@ task fetch_genbank_metadata {
     Int disk_size = 50
     command <<<
         set -e
-        source activate $CONDA_DEFAULT_ENV # for miniwdl / non-login docker runners
+        activate $CONDA_DEFAULT_ENV # for miniwdl / non-login docker runners
         esearch -db nuccore -q "~{genbank_accession}" | efetch -db nuccore -format gb -mode xml -json  > gb.json
         jq -r '[.GBSet.GBSeq."GBSeq_feature-table".GBFeature[0].GBFeature_quals.GBQualifier|.[]|{(.GBQualifier_name): .GBQualifier_value}]|add ' gb.json > "~{genbank_accession}".metadata.json
         jq -r '.db_xref' "~{genbank_accession}".metadata.json | grep ^taxon: | cut -f 2 -d : > taxid.txt

--- a/pipes/WDL/tasks/tasks_nextstrain.wdl
+++ b/pipes/WDL/tasks/tasks_nextstrain.wdl
@@ -13,7 +13,7 @@ task nextclade_one_sample {
         File? pcr_primers_csv
         File? virus_properties
         String? dataset_name
-        String docker = "nextstrain/nextclade:2.5.0"
+        String docker = "nextstrain/nextclade:2.9.1"
     }
     String basename = basename(genome_fasta, ".fasta")
     Int disk_size = 50
@@ -100,7 +100,7 @@ task nextclade_many_samples {
         String?      dataset_name
         String       basename
         File?        genome_ids_setdefault_blank
-        String       docker = "nextstrain/nextclade:2.5.0"
+        String       docker = "nextstrain/nextclade:2.9.1"
     }
     Int disk_size = 100
     command <<<

--- a/pipes/WDL/tasks/tasks_nextstrain.wdl
+++ b/pipes/WDL/tasks/tasks_nextstrain.wdl
@@ -949,7 +949,7 @@ task mafft_one_chr {
         Boolean  large = false
         Boolean  memsavetree = false
 
-        String   docker = "quay.io/broadinstitute/viral-phylo:2.1.20.1"
+        String   docker = "quay.io/broadinstitute/viral-phylo:2.1.20.2"
         Int      mem_size = 500
         Int      cpus = 64
     }
@@ -1037,7 +1037,7 @@ task mafft_one_chr_chunked {
         Int      batch_chunk_size = 2000
         Int      threads_per_job = 2
 
-        String   docker = "quay.io/broadinstitute/viral-phylo:2.1.20.1"
+        String   docker = "quay.io/broadinstitute/viral-phylo:2.1.20.2"
         Int      mem_size = 32
         Int      cpus = 96
     }

--- a/pipes/WDL/tasks/tasks_nextstrain.wdl
+++ b/pipes/WDL/tasks/tasks_nextstrain.wdl
@@ -949,7 +949,7 @@ task mafft_one_chr {
         Boolean  large = false
         Boolean  memsavetree = false
 
-        String   docker = "quay.io/broadinstitute/viral-phylo:2.1.20.0"
+        String   docker = "quay.io/broadinstitute/viral-phylo:2.1.20.1"
         Int      mem_size = 500
         Int      cpus = 64
     }
@@ -1037,7 +1037,7 @@ task mafft_one_chr_chunked {
         Int      batch_chunk_size = 2000
         Int      threads_per_job = 2
 
-        String   docker = "quay.io/broadinstitute/viral-phylo:2.1.20.0"
+        String   docker = "quay.io/broadinstitute/viral-phylo:2.1.20.1"
         Int      mem_size = 32
         Int      cpus = 96
     }

--- a/pipes/WDL/tasks/tasks_reports.wdl
+++ b/pipes/WDL/tasks/tasks_reports.wdl
@@ -401,7 +401,7 @@ task aggregate_metagenomics_reports {
     String       aggregate_taxlevel_focus                 = "species"
     Int          aggregate_top_N_hits                     = 5
 
-    String       docker = "quay.io/broadinstitute/viral-classify:2.1.20.0"
+    String       docker = "quay.io/broadinstitute/viral-classify:2.1.33.0"
   }
 
   parameter_meta {
@@ -549,7 +549,7 @@ task compare_two_genomes {
     File   genome_two
     String out_basename
 
-    String docker = "quay.io/broadinstitute/viral-assemble:2.1.20.2"
+    String docker = "quay.io/broadinstitute/viral-assemble:2.1.33.0"
   }
 
   Int disk_size = 50

--- a/pipes/WDL/tasks/tasks_taxon_filter.wdl
+++ b/pipes/WDL/tasks/tasks_taxon_filter.wdl
@@ -14,7 +14,7 @@ task deplete_taxa {
 
     Int?         cpu=8
     Int?         machine_mem_gb
-    String       docker = "quay.io/broadinstitute/viral-classify:2.1.20.0"
+    String       docker = "quay.io/broadinstitute/viral-classify:2.1.33.0"
   }
 
   parameter_meta {
@@ -113,7 +113,7 @@ task filter_to_taxon {
     String?  neg_control_prefixes_space_separated = "neg water NTC"
 
     Int?     machine_mem_gb
-    String   docker = "quay.io/broadinstitute/viral-classify:2.1.20.0"
+    String   docker = "quay.io/broadinstitute/viral-classify:2.1.33.0"
   }
 
   # do this in two steps in case the input doesn't actually have "cleaned" in the name
@@ -172,7 +172,7 @@ task build_lastal_db {
     File   sequences_fasta
 
     Int?   machine_mem_gb
-    String docker = "quay.io/broadinstitute/viral-classify:2.1.20.0"
+    String docker = "quay.io/broadinstitute/viral-classify:2.1.33.0"
   }
 
   String db_name = basename(sequences_fasta, ".fasta")

--- a/pipes/WDL/tasks/tasks_utils.wdl
+++ b/pipes/WDL/tasks/tasks_utils.wdl
@@ -586,6 +586,26 @@ task rename_file {
   }
 }
 
+task raise {
+  input {
+    String message = "error!"
+  }
+  command {
+    set -e
+    echo "$message"
+    exit 1
+  }
+  runtime {
+    memory: "1 GB"
+    cpu: 1
+    docker: "ubuntu"
+    disks:  "local-disk 30 HDD"
+    disk: "30 GB" # TES
+    dx_instance_type: "mem1_ssd1_v2_x2"
+    maxRetries: 2
+  }
+}
+
 task unique_strings {
   input {
     Array[String]  strings

--- a/pipes/WDL/tasks/tasks_utils.wdl
+++ b/pipes/WDL/tasks/tasks_utils.wdl
@@ -586,6 +586,50 @@ task rename_file {
   }
 }
 
+task unique_strings {
+  input {
+    Array[String]  strings
+  }
+  Int disk_size = 50
+  command {
+    cat ~{write_lines(strings)} | sort | uniq > UNIQUE_OUT
+  }
+  output {
+    Array[String]  sorted_unique = read_lines("UNIQUE_OUT")
+  }
+  runtime {
+    memory: "1 GB"
+    cpu: 1
+    docker: "ubuntu"
+    disks:  "local-disk " + disk_size + " HDD"
+    disk: disk_size + " GB" # TES
+    dx_instance_type: "mem1_ssd1_v2_x2"
+    maxRetries: 2
+  }
+}
+
+task unique_arrays {
+  input {
+    Array[Array[String]]  string_arrays
+  }
+  Int disk_size = 50
+  command {
+    cat ~{write_tsv(string_arrays)} | sort | uniq > UNIQUE_OUT
+  }
+  output {
+    Array[Array[String]]  sorted_unique = read_tsv("UNIQUE_OUT")
+  }
+  runtime {
+    memory: "1 GB"
+    cpu: 1
+    docker: "ubuntu"
+    disks:  "local-disk " + disk_size + " HDD"
+    disk: disk_size + " GB" # TES
+    dx_instance_type: "mem1_ssd1_v2_x2"
+    maxRetries: 2
+  }
+}
+
 task today {
   input {
     String? timezone

--- a/pipes/WDL/workflows/assemble_denovo.wdl
+++ b/pipes/WDL/workflows/assemble_denovo.wdl
@@ -157,6 +157,7 @@ workflow assemble_denovo {
     Int     read_pairs_aligned                    = refine.align_to_self_merged_read_pairs_aligned
     Float   bases_aligned                         = refine.align_to_self_merged_bases_aligned
     
+    String  assembly_method = "viral-ngs/assemble_denovo"
     String? deplete_viral_classify_version        = deplete_taxa.viralngs_version
     String? taxfilt_viral_classify_version        = filter_to_taxon.viralngs_version
     String  assemble_viral_assemble_version       = assemble.viralngs_version

--- a/pipes/WDL/workflows/assemble_denovo.wdl
+++ b/pipes/WDL/workflows/assemble_denovo.wdl
@@ -129,7 +129,7 @@ workflow assemble_denovo {
     File    intermediate_gapfill_fasta            = scaffold.intermediate_gapfill_fasta
     Int     assembly_preimpute_length             = scaffold.assembly_preimpute_length
     Int     assembly_preimpute_length_unambiguous = scaffold.assembly_preimpute_length_unambiguous
-    String  scaffolding_chosen_ref_name           = scaffold.scaffolding_chosen_ref_name
+    Array[String]  scaffolding_chosen_ref_names   = scaffold.scaffolding_chosen_ref_names
     File    scaffolding_stats                     = scaffold.scaffolding_stats
     File    scaffolding_alt_contigs               = scaffold.scaffolding_alt_contigs
 

--- a/pipes/WDL/workflows/assemble_denovo.wdl
+++ b/pipes/WDL/workflows/assemble_denovo.wdl
@@ -27,7 +27,7 @@ workflow assemble_denovo {
     File?        filter_to_taxon_db
     File         trim_clip_db
 
-    String       sample_name = basename(basename(reads_unmapped_bams[0], ".bam"), ".cleaned")
+    String       out_basename = basename(basename(reads_unmapped_bams[0], ".bam"), ".cleaned")
     String?      sample_original_name
   }
 
@@ -53,61 +53,91 @@ workflow assemble_denovo {
       description: "After denovo assembly, large contigs are scaffolded against a reference genome to determine orientation and to join contigs together, before further polishing by reads. You must supply at least one reference genome (all segments/chromomes in a single fasta file). If more than one reference is provided, contigs will be scaffolded against all of them and the one with the most complete assembly will be chosen for downstream polishing.",
       patterns: ["*.fasta"]
     }
+    out_basename: { description: "a filename-friendly basename for output files" }
+    sample_original_name: { description: "a (possibly filename-unfriendly) sample name for fasta and bam headers" }
   }
 
-  if(length(reads_unmapped_bams)>1 || defined(sample_original_name)) {
-      call read_utils.merge_and_reheader_bams as merge_reads {
+  # parallelize across provided input read files
+  scatter(reads_unmapped_bam in reads_unmapped_bams) {
+
+    # rename SM value in bam header if requested
+    if(defined(sample_original_name)) {
+      call read_utils.merge_and_reheader_bams as renamed_reads {
           input:
-              in_bams      = reads_unmapped_bams,
+              in_bams      = [reads_unmapped_bam],
               sample_name  = sample_original_name,
-              out_basename = sample_name
+              out_basename = out_basename
       }
-  }
-  File reads_unmapped_bam = select_first([merge_reads.out_bam, reads_unmapped_bams[0]])
+    }
+    File reads_unmapped_renamed_bams = select_first([renamed_reads.out_bam, reads_unmapped_bam])
 
-  if(length(deplete_bmtaggerDbs) + length(deplete_blastDbs) + length(deplete_bwaDbs) > 0) {
-    call taxon_filter.deplete_taxa {
+    # deplete host if requested
+    if(length(deplete_bmtaggerDbs) + length(deplete_blastDbs) + length(deplete_bwaDbs) > 0) {
+      call taxon_filter.deplete_taxa {
+        input:
+          raw_reads_unmapped_bam = reads_unmapped_renamed_bams,
+          bmtaggerDbs            = deplete_bmtaggerDbs,
+          blastDbs               = deplete_blastDbs,
+          bwaDbs                 = deplete_bwaDbs
+      }
+    }
+    File reads_depleted_bams = select_first([deplete_taxa.cleaned_bam, reads_unmapped_bam])
+
+    # select reads if requested
+    if(defined(filter_to_taxon_db)) {
+      call taxon_filter.filter_to_taxon {
+        input:
+          reads_unmapped_bam = reads_depleted_bams,
+          lastal_db_fasta    = select_first([filter_to_taxon_db])
+      }
+    }
+    File reads_taxfilt_bams = select_first([filter_to_taxon.taxfilt_bam, reads_depleted_bams])
+
+    # alignment-free PCR duplicate removal
+    call read_utils.rmdup_ubam {
       input:
-        raw_reads_unmapped_bam = reads_unmapped_bam,
-        bmtaggerDbs            = deplete_bmtaggerDbs,
-        blastDbs               = deplete_blastDbs,
-        bwaDbs                 = deplete_bwaDbs
+        reads_unmapped_bam = reads_taxfilt_bams
     }
   }
 
-  if(defined(filter_to_taxon_db)) {
-    call taxon_filter.filter_to_taxon {
+  # merge all reads into single file
+  call read_utils.merge_and_reheader_bams as merge_dedup_reads {
       input:
-        reads_unmapped_bam = select_first([deplete_taxa.cleaned_bam, reads_unmapped_bam]),
-        lastal_db_fasta    = select_first([filter_to_taxon_db])
-    }
+          in_bams      = rmdup_ubam.dedup_bam,
+          out_basename = out_basename
+  }
+  call read_utils.merge_and_reheader_bams as merge_cleaned_reads {
+      input:
+          in_bams      = reads_depleted_bams,
+          out_basename = out_basename
+  }
+  call read_utils.merge_and_reheader_bams as merge_taxfilt_reads {
+      input:
+          in_bams      = reads_taxfilt_bams,
+          out_basename = out_basename
   }
 
-  call read_utils.rmdup_ubam {
-    input:
-      reads_unmapped_bam = select_first([filter_to_taxon.taxfilt_bam, deplete_taxa.cleaned_bam, reads_unmapped_bam])
-  }
-
+  # denovo assembly pipeline below
   call assembly.assemble {
     input:
-      reads_unmapped_bam = rmdup_ubam.dedup_bam,
+      reads_unmapped_bam = merge_dedup_reads.out_bam,
       trim_clip_db       = trim_clip_db,
       always_succeed     = true,
-      sample_name        = sample_name
+      sample_name        = out_basename
   }
 
   call assembly.scaffold {
     input:
       contigs_fasta           = assemble.contigs_fasta,
-      reads_bam               = select_first([filter_to_taxon.taxfilt_bam, deplete_taxa.cleaned_bam, reads_unmapped_bam]),
+      reads_bam               = merge_dedup_reads.out_bam,
       reference_genome_fasta  = reference_genome_fasta
   }
 
   call assemble_refbased.assemble_refbased as refine {
       input:
-          reads_unmapped_bams = [rmdup_ubam.dedup_bam],
+          reads_unmapped_bams = reads_depleted_bams, # assemble_refbased will scatter on individual bams
           reference_fasta     = scaffold.scaffold_fasta,
-          sample_name         = sample_name
+          sample_name         = out_basename
   }
 
   if (defined(sample_original_name)) {
@@ -127,18 +157,17 @@ workflow assemble_denovo {
     Int     reads_aligned                         = refine.align_to_self_merged_reads_aligned
     Float   mean_coverage                         = refine.align_to_self_merged_mean_coverage
     
-    File    cleaned_bam                           = select_first([deplete_taxa.cleaned_bam, reads_unmapped_bam])
-    File?   cleaned_fastqc                        = deplete_taxa.cleaned_fastqc
-    Int?    depletion_read_count_pre              = deplete_taxa.depletion_read_count_pre
-    Int?    depletion_read_count_post             = deplete_taxa.depletion_read_count_post
+    File    cleaned_bam                           = merge_cleaned_reads.out_bam
+    File    cleaned_fastqc                        = merge_cleaned_reads.fastqc
+    Int     depletion_read_count_post             = merge_cleaned_reads.read_count
     
-    File?   taxfilt_bam                           = filter_to_taxon.taxfilt_bam
-    File?   taxfilt_fastqc                        = filter_to_taxon.taxfilt_fastqc
-    Int?    filter_read_count_post                = filter_to_taxon.filter_read_count_post
+    File    taxfilt_bam                           = merge_taxfilt_reads.out_bam
+    File    taxfilt_fastqc                        = merge_taxfilt_reads.fastqc
+    Int     filter_read_count_post                = merge_taxfilt_reads.read_count
     
-    File    dedup_bam                             = rmdup_ubam.dedup_bam
-    File    dedup_fastqc                          = rmdup_ubam.dedup_fastqc
-    Int     dedup_read_count_post                 = rmdup_ubam.dedup_read_count_post
+    File    dedup_bam                             = merge_dedup_reads.out_bam
+    File    dedup_fastqc                          = merge_dedup_reads.fastqc
+    Int     dedup_read_count_post                 = merge_dedup_reads.read_count
     
     File    contigs_fasta                         = assemble.contigs_fasta
     File    subsampBam                            = assemble.subsampBam
@@ -162,15 +191,13 @@ workflow assemble_denovo {
 
     File    isnvs_vcf                             = refine.align_to_self_isnvs_vcf
     
-    File    aligned_bam                           = refine.align_to_self_merged_aligned_and_unaligned_bam[0]
-    File    aligned_only_reads_fastqc             = refine.align_to_ref_per_input_fastqc[0]
+    File    aligned_bam                           = refine.align_to_self_merged_aligned_only_bam
+    File    aligned_only_reads_fastqc             = refine.align_to_ref_fastqc
     File    coverage_tsv                          = refine.align_to_self_merged_coverage_tsv
     Int     read_pairs_aligned                    = refine.align_to_self_merged_read_pairs_aligned
     Float   bases_aligned                         = refine.align_to_self_merged_bases_aligned
     
     String  assembly_method = "viral-ngs/assemble_denovo"
-    String? deplete_viral_classify_version        = deplete_taxa.viralngs_version
-    String? taxfilt_viral_classify_version        = filter_to_taxon.viralngs_version
     String  assemble_viral_assemble_version       = assemble.viralngs_version
     String  scaffold_viral_assemble_version       = scaffold.viralngs_version
   }

--- a/pipes/WDL/workflows/assemble_refbased.wdl
+++ b/pipes/WDL/workflows/assemble_refbased.wdl
@@ -237,6 +237,7 @@ workflow assemble_refbased {
         Float       align_to_self_merged_mean_coverage           = plot_self_coverage.mean_coverage
         File        align_to_self_isnvs_vcf                      = isnvs_self.report_vcf
         
+        String      assembly_method = "viral-ngs/assemble_refbased"
         String      align_to_ref_viral_core_version              = align_to_ref.viralngs_version[0]
         String      ivar_version                                 = ivar_trim.ivar_version[0]
         String      viral_assemble_version                       = call_consensus.viralngs_version

--- a/pipes/WDL/workflows/assemble_refbased.wdl
+++ b/pipes/WDL/workflows/assemble_refbased.wdl
@@ -210,9 +210,9 @@ workflow assemble_refbased {
         Array[File] align_to_ref_per_input_aligned_flagstat      = align_to_ref.aligned_bam_flagstat
         Array[Int]  align_to_ref_per_input_reads_provided        = align_to_ref.reads_provided
         Array[Int]  align_to_ref_per_input_reads_aligned         = align_to_ref.reads_aligned
-        Array[File] align_to_ref_per_input_fastqc                = align_to_ref.aligned_only_reads_fastqc
-        
+
         File        align_to_ref_merged_aligned_trimmed_only_bam = aligned_trimmed_bam
+        File        align_to_ref_fastqc                          = select_first([merge_align_to_ref.fastqc, align_to_ref.aligned_only_reads_fastqc[0]])
         File        align_to_ref_merged_coverage_plot            = plot_ref_coverage.coverage_plot
         File        align_to_ref_merged_coverage_tsv             = plot_ref_coverage.coverage_tsv
         Int         align_to_ref_merged_reads_aligned            = plot_ref_coverage.reads_aligned

--- a/pipes/WDL/workflows/calc_bam_read_depths.wdl
+++ b/pipes/WDL/workflows/calc_bam_read_depths.wdl
@@ -2,7 +2,7 @@ version 1.0
 
 import "../tasks/tasks_read_utils.wdl" as read_utils
 
-workflow read_depths {
+workflow calc_bam_read_depths {
     meta {
         description: "Generates read depth tables."
         author: "Broad Viral Genomics"

--- a/pipes/WDL/workflows/classify_multi.wdl
+++ b/pipes/WDL/workflows/classify_multi.wdl
@@ -101,7 +101,6 @@ workflow classify_multi {
         }
         call assembly.assemble as spades {
             input:
-                assembler          = "spades",
                 reads_unmapped_bam = rmdup_ubam.dedup_bam,
                 trim_clip_db       = trim_clip_db,
                 always_succeed     = true

--- a/pipes/WDL/workflows/classify_single.wdl
+++ b/pipes/WDL/workflows/classify_single.wdl
@@ -93,7 +93,6 @@ workflow classify_single {
     }
     call assembly.assemble as spades {
         input:
-            assembler          = "spades",
             reads_unmapped_bam = rmdup_ubam.dedup_bam,
             trim_clip_db       = trim_clip_db,
             always_succeed     = true

--- a/pipes/WDL/workflows/contigs.wdl
+++ b/pipes/WDL/workflows/contigs.wdl
@@ -31,7 +31,6 @@ workflow contigs {
 
     call assembly.assemble as spades {
         input:
-            assembler          = "spades",
             reads_unmapped_bam = rmdup_ubam.dedup_bam
     }
 

--- a/pipes/WDL/workflows/demux_metag.wdl
+++ b/pipes/WDL/workflows/demux_metag.wdl
@@ -43,7 +43,6 @@ workflow demux_metag {
         }
         call assembly.assemble as spades {
             input:
-                assembler          = "spades",
                 reads_unmapped_bam = rmdup_ubam.dedup_bam,
                 trim_clip_db       = trim_clip_db,
                 always_succeed     = true

--- a/pipes/WDL/workflows/demux_plus.wdl
+++ b/pipes/WDL/workflows/demux_plus.wdl
@@ -41,7 +41,6 @@ workflow demux_plus {
         }
         call assembly.assemble as spades {
             input:
-                assembler          = "spades",
                 reads_unmapped_bam = deplete.cleaned_bam,
                 trim_clip_db       = trim_clip_db,
                 always_succeed     = true

--- a/pipes/WDL/workflows/genbank.wdl
+++ b/pipes/WDL/workflows/genbank.wdl
@@ -73,6 +73,7 @@ workflow genbank {
     }
 
     scatter(segment_acc in reference_accessions) {
+      # scatter these calls in order to preserve original order
       call ncbi_tools.fetch_genbank_metadata {
         input:
           genbank_accession = segment_acc
@@ -105,7 +106,7 @@ workflow genbank {
         call ncbi.align_and_annot_transfer_single as annot {
             input:
                 genome_fasta             = assembly,
-                reference_fastas         = download_annotations.combined_fasta,
+                reference_fastas         = flatten(download_annotations.genomes_fasta),
                 reference_feature_tables = flatten(download_annotations.features_tbl)
         }
     }

--- a/pipes/WDL/workflows/genbank.wdl
+++ b/pipes/WDL/workflows/genbank.wdl
@@ -105,7 +105,7 @@ workflow genbank {
         call ncbi.align_and_annot_transfer_single as annot {
             input:
                 genome_fasta             = assembly,
-                reference_fastas         = flatten(download_annotations.genomes_fasta),
+                reference_fastas         = download_annotations.combined_fasta,
                 reference_feature_tables = flatten(download_annotations.features_tbl)
         }
     }

--- a/pipes/WDL/workflows/genbank.wdl
+++ b/pipes/WDL/workflows/genbank.wdl
@@ -3,6 +3,7 @@ version 1.0
 import "../tasks/tasks_ncbi.wdl" as ncbi
 import "../tasks/tasks_ncbi_tools.wdl" as ncbi_tools
 import "../tasks/tasks_reports.wdl" as reports
+import "../tasks/tasks_utils.wdl" as utils
 
 workflow genbank {
 
@@ -14,8 +15,8 @@ workflow genbank {
     }
 
     input {
-        Array[File]+   assemblies_fasta
-        Array[String]+ reference_accessions
+        Array[File]+          assemblies_fasta
+        Array[Array[String]]+ reference_accessions_list
 
         Array[File]   alignments_bams
         File?         coverage_table
@@ -35,8 +36,8 @@ workflow genbank {
           description: "Genomes to prepare for Genbank submission. One file per genome: all segments/chromosomes included in one file. All fasta files must contain exactly the same number of sequences as reference_fasta (which must equal the number of files in reference_annot_tbl).",
           patterns: ["*.fasta"]
         }
-        reference_accessions: {
-          description: "Reference genome Genbank accessions, each segment/chromosome in the exact same count and order as the segments/chromosomes described in genome_fasta.",
+        reference_accessions_list: {
+          description: "Reference genome Genbank accessions, each segment/chromosome in the exact same count and order as the segments/chromosomes described in assemblies_fasta. This is allowed to be an Array of such accession lists, but if so, all Array[String]s must be identical to each other or an error will be raised.",
           patterns: ["*.fasta"]
         }
         author_list: {
@@ -72,6 +73,20 @@ workflow genbank {
 
     }
 
+    # take a array-array-string of scaffolding_chosen_refs output -> uniqified list of reference_accessions -- fail if not exactly one unique array-string across all array-array-strings
+    call utils.unique_arrays as unique_references {
+      input:
+        string_arrays = reference_accessions_list
+    }
+    if((length(unique_references.sorted_unique) != 1)
+      || length(unique_references.sorted_unique[0]) < 1) {
+      call utils.raise {
+        input:
+          message = "all Array[String] reference accession lists in reference_accessions_list must be identical!"
+      }
+    }
+    Array[String] reference_accessions = unique_references.sorted_unique[0]
+
     scatter(segment_acc in reference_accessions) {
       # scatter these calls in order to preserve original order
       call ncbi_tools.fetch_genbank_metadata {
@@ -94,6 +109,7 @@ workflow genbank {
       }
     }
 
+    # TO DO dpark: if ! defined biosample_attributes, call ncbi_tools.fetch_biosamples on external ids (where do we get external ids?)
     call ncbi.biosample_to_genbank {
         input:
             biosample_attributes = biosample_attributes,

--- a/pipes/WDL/workflows/genbank.wdl
+++ b/pipes/WDL/workflows/genbank.wdl
@@ -3,7 +3,7 @@ version 1.0
 import "../tasks/tasks_ncbi.wdl" as ncbi
 import "../tasks/tasks_ncbi_tools.wdl" as ncbi_tools
 import "../tasks/tasks_reports.wdl" as reports
-#import "../tasks/tasks_utils.wdl" as utils
+import "../tasks/tasks_utils.wdl" as utils
 
 workflow genbank {
 
@@ -93,6 +93,11 @@ workflow genbank {
           mapped_bams = alignments_bams,
           mapped_bam_idx = []
       }
+      call utils.tsv_drop_cols as coverage_two_col {
+        input:
+          in_tsv = coverage_report.coverage_report,
+          drop_cols = ["aln2self_cov_median", "aln2self_cov_mean_non0", "aln2self_cov_1X", "aln2self_cov_5X", "aln2self_cov_20X", "aln2self_cov_100X"]
+      }
     }
 
     # TO DO dpark: if ! defined biosample_attributes, call ncbi_tools.fetch_biosamples on external ids (where do we get external ids?)
@@ -127,7 +132,7 @@ workflow genbank {
             authors_sbt        = generate_author_sbt.sbt_file,
             biosampleMap       = biosample_to_genbank.biosample_map,
             genbankSourceTable = biosample_to_genbank.genbank_source_modifier_table,
-            coverage_table     = select_first([coverage_report.coverage_report, coverage_table]),
+            coverage_table     = select_first([coverage_two_col.out_tsv, coverage_table]),
             sequencingTech     = sequencingTech,
             comment            = comment,
             organism           = fetch_genbank_metadata.organism[0],

--- a/pipes/WDL/workflows/metagenomic_denovo.wdl
+++ b/pipes/WDL/workflows/metagenomic_denovo.wdl
@@ -248,8 +248,8 @@ workflow metagenomic_denovo {
 
     File    isnvs_vcf                             = refine.align_to_self_isnvs_vcf
     
-    File    aligned_bam                           = refine.align_to_self_merged_aligned_and_unaligned_bam[0]
-    File    aligned_only_reads_fastqc             = refine.align_to_ref_per_input_fastqc[0]
+    File    aligned_bam                           = refine.align_to_self_merged_aligned_only_bam
+    File    aligned_only_reads_fastqc             = refine.align_to_ref_fastqc
     File    coverage_tsv                          = refine.align_to_self_merged_coverage_tsv
     Int     read_pairs_aligned                    = refine.align_to_self_merged_read_pairs_aligned
     Float   bases_aligned                         = refine.align_to_self_merged_bases_aligned

--- a/pipes/WDL/workflows/metagenomic_denovo.wdl
+++ b/pipes/WDL/workflows/metagenomic_denovo.wdl
@@ -235,7 +235,7 @@ workflow metagenomic_denovo {
     File    intermediate_gapfill_fasta            = scaffold.intermediate_gapfill_fasta
     Int     assembly_preimpute_length             = scaffold.assembly_preimpute_length
     Int     assembly_preimpute_length_unambiguous = scaffold.assembly_preimpute_length_unambiguous
-    String  scaffolding_chosen_ref_name           = scaffold.scaffolding_chosen_ref_name
+    Array[String]  scaffolding_chosen_ref_names   = scaffold.scaffolding_chosen_ref_names
     File    scaffolding_stats                     = scaffold.scaffolding_stats
     File    scaffolding_alt_contigs               = scaffold.scaffolding_alt_contigs
 

--- a/pipes/WDL/workflows/scaffold_and_refine.wdl
+++ b/pipes/WDL/workflows/scaffold_and_refine.wdl
@@ -40,7 +40,7 @@ workflow scaffold_and_refine {
     File   intermediate_gapfill_fasta            = scaffold.intermediate_gapfill_fasta
     Int    assembly_preimpute_length             = scaffold.assembly_preimpute_length
     Int    assembly_preimpute_length_unambiguous = scaffold.assembly_preimpute_length_unambiguous
-    String scaffolding_chosen_ref_name           = scaffold.scaffolding_chosen_ref_name
+    Array[String]  scaffolding_chosen_ref_names  = scaffold.scaffolding_chosen_ref_names
     File   scaffolding_stats                     = scaffold.scaffolding_stats
     File   scaffolding_alt_contigs               = scaffold.scaffolding_alt_contigs
 

--- a/pipes/WDL/workflows/scaffold_and_refine.wdl
+++ b/pipes/WDL/workflows/scaffold_and_refine.wdl
@@ -53,8 +53,8 @@ workflow scaffold_and_refine {
 
     File   isnvsFile                             = refine.align_to_self_isnvs_vcf
     
-    File   aligned_bam                           = refine.align_to_self_merged_aligned_and_unaligned_bam[0]
-    File   aligned_only_reads_fastqc             = refine.align_to_ref_per_input_fastqc[0]
+    File   aligned_bam                           = refine.align_to_self_merged_aligned_only_bam
+    File   aligned_only_reads_fastqc             = refine.align_to_ref_fastqc
     File   coverage_tsv                          = refine.align_to_self_merged_coverage_tsv
     Int    read_pairs_aligned                    = refine.align_to_self_merged_read_pairs_aligned
     Float  bases_aligned                         = refine.align_to_self_merged_bases_aligned

--- a/requirements-modules.txt
+++ b/requirements-modules.txt
@@ -8,4 +8,4 @@ broadinstitute/ncbi-tools=2.10.7.10
 nextstrain/base=build-20211012T204409Z
 andersenlabapps/ivar=1.3.1
 quay.io/staphb/pangolin=4.1.2-pdata-1.14
-nextstrain/nextclade=2.5.0
+nextstrain/nextclade=2.9.1

--- a/requirements-modules.txt
+++ b/requirements-modules.txt
@@ -1,7 +1,7 @@
 broadinstitute/viral-core=2.1.33
 broadinstitute/viral-assemble=2.1.33.0
 broadinstitute/viral-classify=2.1.33.0
-broadinstitute/viral-phylo=2.1.20.1
+broadinstitute/viral-phylo=2.1.20.2
 broadinstitute/py3-bio=0.1.2
 broadinstitute/beast-beagle-cuda=1.10.5pre
 broadinstitute/ncbi-tools=2.10.7.10

--- a/requirements-modules.txt
+++ b/requirements-modules.txt
@@ -1,6 +1,6 @@
 broadinstitute/viral-core=2.1.33
-broadinstitute/viral-assemble=2.1.20.2
-broadinstitute/viral-classify=2.1.20.0
+broadinstitute/viral-assemble=2.1.33.0
+broadinstitute/viral-classify=2.1.33.0
 broadinstitute/viral-phylo=2.1.20.0
 broadinstitute/py3-bio=0.1.2
 broadinstitute/beast-beagle-cuda=1.10.5pre

--- a/requirements-modules.txt
+++ b/requirements-modules.txt
@@ -1,7 +1,7 @@
 broadinstitute/viral-core=2.1.33
 broadinstitute/viral-assemble=2.1.33.0
 broadinstitute/viral-classify=2.1.33.0
-broadinstitute/viral-phylo=2.1.20.0
+broadinstitute/viral-phylo=2.1.20.1
 broadinstitute/py3-bio=0.1.2
 broadinstitute/beast-beagle-cuda=1.10.5pre
 broadinstitute/ncbi-tools=2.10.7.10

--- a/test/input/WDL/cromwell-local/test_inputs-genbank-local.json
+++ b/test/input/WDL/cromwell-local/test_inputs-genbank-local.json
@@ -1,6 +1,7 @@
 {
   "genbank.molType": "cRNA",
   "genbank.coverage_table": "test/input/genbank/coverage-ma_mgh.txt",
+  "genbank.alignments_bams": [],
   "genbank.reference_accessions": ["MN908947.3"],
   "genbank.sequencingTech": "Illumina NovaSeq",
   "genbank.biosample_attributes": "test/input/genbank/sars-cov-2_attributes_updated.txt",

--- a/test/input/WDL/cromwell-local/test_inputs-genbank-local.json
+++ b/test/input/WDL/cromwell-local/test_inputs-genbank-local.json
@@ -2,7 +2,7 @@
   "genbank.molType": "cRNA",
   "genbank.coverage_table": "test/input/genbank/coverage-ma_mgh.txt",
   "genbank.alignments_bams": [],
-  "genbank.reference_accessions": ["MN908947.3"],
+  "genbank.reference_accessions_list": [["MN908947.3"],["MN908947.3"],["MN908947.3"]],
   "genbank.sequencingTech": "Illumina NovaSeq",
   "genbank.biosample_attributes": "test/input/genbank/sars-cov-2_attributes_updated.txt",
   "genbank.prep_genbank.assembly_method": "placeholder assembly software",

--- a/test/input/WDL/cromwell-local/test_inputs-genbank-local.json
+++ b/test/input/WDL/cromwell-local/test_inputs-genbank-local.json
@@ -2,7 +2,7 @@
   "genbank.molType": "cRNA",
   "genbank.coverage_table": "test/input/genbank/coverage-ma_mgh.txt",
   "genbank.alignments_bams": [],
-  "genbank.reference_accessions_list": [["MN908947.3"],["MN908947.3"],["MN908947.3"]],
+  "genbank.reference_accessions": ["MN908947.3"],
   "genbank.sequencingTech": "Illumina NovaSeq",
   "genbank.biosample_attributes": "test/input/genbank/sars-cov-2_attributes_updated.txt",
   "genbank.prep_genbank.assembly_method": "placeholder assembly software",

--- a/test/input/WDL/cromwell-local/test_inputs-genbank-local.json
+++ b/test/input/WDL/cromwell-local/test_inputs-genbank-local.json
@@ -1,12 +1,8 @@
 {
   "genbank.molType": "cRNA",
   "genbank.coverage_table": "test/input/genbank/coverage-ma_mgh.txt",
-  "genbank.reference_feature_tables": [
-    "test/input/genbank/MN908947.3.tbl"
-  ],
-  "genbank.organism": "Severe acute respiratory syndrome coronavirus 2",
+  "genbank.reference_accessions": ["MN908947.3"],
   "genbank.sequencingTech": "Illumina NovaSeq",
-  "genbank.taxid": 2697049,
   "genbank.biosample_attributes": "test/input/genbank/sars-cov-2_attributes_updated.txt",
   "genbank.prep_genbank.assembly_method": "placeholder assembly software",
   "genbank.prep_genbank.assembly_method_version": "5.4.3.2.1",
@@ -19,8 +15,6 @@
     "test/input/MA_MGH_00004.fasta",
     "test/input/MA_MGH_00005.fasta"
   ],
-  "genbank.reference_fastas": [
-    "test/input/genbank/MN908947.3.fasta"
-  ]
+  "genbank.email_address": "viral-ngs@broadinstitute.org"
 }
 

--- a/test/input/WDL/miniwdl-local/test_inputs-genbank-local.json
+++ b/test/input/WDL/miniwdl-local/test_inputs-genbank-local.json
@@ -1,6 +1,6 @@
 {
   "genbank.molType": "cRNA",
-  "genbank.reference_accessions_list": [["KM821997.1", "KM821998.1"]],
+  "genbank.reference_accessions": ["KM821997.1", "KM821998.1"],
   "genbank.coverage_table": "test/input/genbank/coverage_report-RUN1-workflow.txt",
   "genbank.alignments_bams": [],
   "genbank.sequencingTech": "Illumina MiSeq",

--- a/test/input/WDL/miniwdl-local/test_inputs-genbank-local.json
+++ b/test/input/WDL/miniwdl-local/test_inputs-genbank-local.json
@@ -2,6 +2,7 @@
   "genbank.molType": "cRNA",
   "genbank.reference_accessions": ["KM821997.1", "KM821998.1"],
   "genbank.coverage_table": "test/input/genbank/coverage_report-RUN1-workflow.txt",
+  "genbank.alignments_bams": [],
   "genbank.sequencingTech": "Illumina MiSeq",
   "genbank.biosample_attributes": "test/input/genbank/biosample-attributes-lasv.txt",
   "genbank.prep_genbank.assembly_method": "placeholder assembly software",

--- a/test/input/WDL/miniwdl-local/test_inputs-genbank-local.json
+++ b/test/input/WDL/miniwdl-local/test_inputs-genbank-local.json
@@ -1,13 +1,8 @@
 {
   "genbank.molType": "cRNA",
+  "genbank.reference_accessions": ["KM821997.1", "KM821998.1"],
   "genbank.coverage_table": "test/input/genbank/coverage_report-RUN1-workflow.txt",
-  "genbank.reference_feature_tables": [
-    "test/input/genbank/KM821997.1.tbl",
-    "test/input/genbank/KM821998.1.tbl"
-  ],
-  "genbank.organism": "Lassa mammarenavirus",
   "genbank.sequencingTech": "Illumina MiSeq",
-  "genbank.taxid": 11620,
   "genbank.biosample_attributes": "test/input/genbank/biosample-attributes-lasv.txt",
   "genbank.prep_genbank.assembly_method": "placeholder assembly software",
   "genbank.prep_genbank.assembly_method_version": "5.4.3.2.1",
@@ -20,9 +15,6 @@
     "test/input/LASV_NGA_2018_0097.fasta",
     "test/input/LASV_NGA_2018_0541.fasta"
   ],
-  "genbank.reference_fastas": [
-    "test/input/genbank/KM821997.1.fasta",
-    "test/input/genbank/KM821998.1.fasta"
-  ]
+  "genbank.email_address": "viral-ngs@broadinstitute.org"
 }
 

--- a/test/input/WDL/miniwdl-local/test_inputs-genbank-local.json
+++ b/test/input/WDL/miniwdl-local/test_inputs-genbank-local.json
@@ -1,6 +1,6 @@
 {
   "genbank.molType": "cRNA",
-  "genbank.reference_accessions": ["KM821997.1", "KM821998.1"],
+  "genbank.reference_accessions_list": [["KM821997.1", "KM821998.1"]],
   "genbank.coverage_table": "test/input/genbank/coverage_report-RUN1-workflow.txt",
   "genbank.alignments_bams": [],
   "genbank.sequencingTech": "Illumina MiSeq",

--- a/test/input/WDL/test_inputs-assemble_denovo-dnanexus.dx.json
+++ b/test/input/WDL/test_inputs-assemble_denovo-dnanexus.dx.json
@@ -1,5 +1,5 @@
 {
-	"stage-common.reads_unmapped_bam": { "$dnanexus_link": { "project": "project-F8PQ6380xf5bK0Qk0YPjB17P", "id": "file-F8F2kVQ09y3Q9Qj14fF806q2" } },
+	"stage-common.reads_unmapped_bams": [ { "$dnanexus_link": { "project": "project-F8PQ6380xf5bK0Qk0YPjB17P", "id": "file-F8F2kVQ09y3Q9Qj14fF806q2" } } ],
 
 	"stage-common.deplete_bmtaggerDbs": [
 		{ "$dnanexus_link": { "project": "project-F8PQ6380xf5bK0Qk0YPjB17P", "id": "file-BYF6g8Q0zjF77x79bGYgJ1Zb" } }

--- a/test/input/WDL/test_inputs-assemble_denovo-local.json
+++ b/test/input/WDL/test_inputs-assemble_denovo-local.json
@@ -1,5 +1,5 @@
 {
-  "assemble_denovo.reads_unmapped_bam": "test/input/G5012.3.testreads.bam",
+  "assemble_denovo.reads_unmapped_bams": ["test/input/G5012.3.testreads.bam"],
   "assemble_denovo.deplete_blastDbs": [
     "test/input/5kb_human_from_chr6.fasta"
   ],

--- a/test/input/WDL/test_inputs-assemble_denovo-local.json
+++ b/test/input/WDL/test_inputs-assemble_denovo-local.json
@@ -5,5 +5,6 @@
   ],
   "assemble_denovo.filter_to_taxon_db": "test/input/ebov-makona.fasta",
   "assemble_denovo.trim_clip_db": "test/input/clipDb.fasta",
-  "assemble_denovo.reference_genome_fasta": ["test/input/ebov-makona.fasta"]
+  "assemble_denovo.reference_genome_fasta": ["test/input/ebov-makona.fasta"],
+  "assemble_denovo.sample_original_name": "USA/ this ? is an un-friendly sample_name! / 1999"
 }

--- a/test/input/WDL/test_inputs-genbank-local.json
+++ b/test/input/WDL/test_inputs-genbank-local.json
@@ -1,6 +1,6 @@
 {
   "genbank.molType": "cRNA",
-  "genbank.reference_accessions_list": [["KM821997.1", "KM821998.1"]],
+  "genbank.reference_accessions": ["KM821997.1", "KM821998.1"],
   "genbank.coverage_table": "test/input/genbank/coverage_report-RUN1-workflow.txt",
   "genbank.alignments_bams": [],
   "genbank.sequencingTech": "Illumina MiSeq",

--- a/test/input/WDL/test_inputs-genbank-local.json
+++ b/test/input/WDL/test_inputs-genbank-local.json
@@ -2,6 +2,7 @@
   "genbank.molType": "cRNA",
   "genbank.reference_accessions": ["KM821997.1", "KM821998.1"],
   "genbank.coverage_table": "test/input/genbank/coverage_report-RUN1-workflow.txt",
+  "genbank.alignments_bams": [],
   "genbank.sequencingTech": "Illumina MiSeq",
   "genbank.biosample_attributes": "test/input/genbank/biosample-attributes-lasv.txt",
   "genbank.prep_genbank.assembly_method": "placeholder assembly software",

--- a/test/input/WDL/test_inputs-genbank-local.json
+++ b/test/input/WDL/test_inputs-genbank-local.json
@@ -1,13 +1,8 @@
 {
   "genbank.molType": "cRNA",
+  "genbank.reference_accessions": ["KM821997.1", "KM821998.1"],
   "genbank.coverage_table": "test/input/genbank/coverage_report-RUN1-workflow.txt",
-  "genbank.reference_feature_tables": [
-    "test/input/genbank/KM821997.1.tbl",
-    "test/input/genbank/KM821998.1.tbl"
-  ],
-  "genbank.organism": "Lassa mammarenavirus",
   "genbank.sequencingTech": "Illumina MiSeq",
-  "genbank.taxid": 11620,
   "genbank.biosample_attributes": "test/input/genbank/biosample-attributes-lasv.txt",
   "genbank.prep_genbank.assembly_method": "placeholder assembly software",
   "genbank.prep_genbank.assembly_method_version": "5.4.3.2.1",
@@ -20,9 +15,6 @@
     "test/input/LASV_NGA_2018_0097.fasta",
     "test/input/LASV_NGA_2018_0541.fasta"
   ],
-  "genbank.reference_fastas": [
-    "test/input/genbank/KM821997.1.fasta",
-    "test/input/genbank/KM821998.1.fasta"
-  ]
+  "genbank.email_address": "viral-ngs@broadinstitute.org"
 }
 

--- a/test/input/WDL/test_inputs-genbank-local.json
+++ b/test/input/WDL/test_inputs-genbank-local.json
@@ -1,6 +1,6 @@
 {
   "genbank.molType": "cRNA",
-  "genbank.reference_accessions": ["KM821997.1", "KM821998.1"],
+  "genbank.reference_accessions_list": [["KM821997.1", "KM821998.1"]],
   "genbank.coverage_table": "test/input/genbank/coverage_report-RUN1-workflow.txt",
   "genbank.alignments_bams": [],
   "genbank.sequencingTech": "Illumina MiSeq",

--- a/test/input/WDL/test_outputs-assemble_denovo-local.json
+++ b/test/input/WDL/test_outputs-assemble_denovo-local.json
@@ -8,6 +8,5 @@
     "assemble_denovo.assembly_length_unambiguous": 18843,
     "assemble_denovo.assembly_length": 18843,
     "assemble_denovo.filter_read_count_post": 18710,
-    "assemble_denovo.depletion_read_count_post": 18710,
-    "assemble_denovo.depletion_read_count_pre": 18710
+    "assemble_denovo.depletion_read_count_post": 18710
 }


### PR DESCRIPTION
- `genbank`: dust off genbank prep workflow, update it to make it more smooth to run after a series of assemble_denovo or assemble_refbased runs in Terra, have it figure out more things by itself, add hard assumption that annotations will be transferred from a genbank genome. Fix annotation transfer for sequences with filename-unfriendly names.
- `assemble_denovo`: slight tweaks to denovo assembly workflow inputs/outputs/cleanups, allow it to parallelize across and merge results from multiple input bams, emit assembly_method by default
- build: fix dxwdl build errors
- docker: bump viral-phylo, viral-assemble, viral-classify, and nextclade docker images