### PR TITLE
pangolin 4.1.3 / pdata 1.17

### DIFF
--- a/pipes/WDL/tasks/tasks_sarscov2.wdl
+++ b/pipes/WDL/tasks/tasks_sarscov2.wdl
@@ -10,7 +10,7 @@ task pangolin_one_sample {
         Float?  max_ambig
         String? analysis_mode
         Boolean update_dbs_now=false
-        String  docker = "quay.io/staphb/pangolin:4.1.2-pdata-1.14"
+        String  docker = "quay.io/staphb/pangolin:4.1.3-pdata-1.17"
     }
     String basename = basename(genome_fasta, ".fasta")
     Int disk_size = 50
@@ -93,7 +93,7 @@ task pangolin_many_samples {
         String?      analysis_mode
         Boolean      update_dbs_now=false
         String       basename
-        String       docker = "quay.io/staphb/pangolin:4.1.2-pdata-1.14"
+        String       docker = "quay.io/staphb/pangolin:4.1.3-pdata-1.17"
     }
     Int disk_size = 100
     command <<<

--- a/requirements-modules.txt
+++ b/requirements-modules.txt
@@ -7,5 +7,5 @@ broadinstitute/beast-beagle-cuda=1.10.5pre
 broadinstitute/ncbi-tools=2.10.7.10
 nextstrain/base=build-20211012T204409Z
 andersenlabapps/ivar=1.3.1
-quay.io/staphb/pangolin=4.1.2-pdata-1.14
+quay.io/staphb/pangolin=4.1.3-pdata-1.17
 nextstrain/nextclade=2.9.1

--- a/test/input/WDL/test_outputs-sarscov2_lineages-local.json
+++ b/test/input/WDL/test_outputs-sarscov2_lineages-local.json
@@ -1,5 +1,5 @@
 {
-  "sarscov2_lineages.nextclade_clade": "20C",
+  "sarscov2_lineages.nextclade_clade": "20A",
   "sarscov2_lineages.nextclade_aa_subs": "ORF1b:P314L,ORF3a:Q57H,S:D614G",
   "sarscov2_lineages.nextclade_aa_dels": "",
   "sarscov2_lineages.pango_lineage": "B.1"


### PR DESCRIPTION
Update docker image for pangolin v4.1.3 and new release of pangolin-data v1.17 (`quay.io/staphb/pangolin:4.1.3-pdata-1.17`)

What to expect:
- [Complete pangolin documentation](https://cov-lineages.org/resources/pangolin.html)
- [pangolin release notes](https://github.com/cov-lineages/pangolin/releases) (4.1.3, no change)
- [pangolin-data release notes](https://github.com/cov-lineages/pangolin-data/releases) (1.16 :arrow_right: 1.17)
- [scorpio release notes](https://github.com/cov-lineages/scorpio/releases) (0.3.17, no change)
- [constellations release notes](https://github.com/cov-lineages/constellations/releases) (0.1.10, no change)
- [UShER release notes](https://github.com/yatisht/usher/releases) (0.6.0 :arrow_right: 0.6.1)
