### PR TITLE
update classify_single to accept multiple bams

### DIFF
--- a/pipes/WDL/tasks/tasks_read_utils.wdl
+++ b/pipes/WDL/tasks/tasks_read_utils.wdl
@@ -144,7 +144,7 @@ task merge_and_reheader_bams {
       Array[File]+ in_bams
       String?      sample_name
       File?        reheader_table
-      String       out_basename
+      String       out_basename = basename(in_bams[0], ".bam")
 
       String       docker = "quay.io/broadinstitute/viral-core:2.1.33"
     }


### PR DESCRIPTION
Slight update to allow `classify_single` to merge multiple input bams (replicate sequencing, not multiple samples).

Also promote some orphaned task level output files to workflow level output files.