### PR TITLE
update to pangolin 4.2 / pdata 1.18

### DIFF
--- a/pipes/WDL/tasks/tasks_sarscov2.wdl
+++ b/pipes/WDL/tasks/tasks_sarscov2.wdl
@@ -10,7 +10,7 @@ task pangolin_one_sample {
         Float?  max_ambig
         String? analysis_mode
         Boolean update_dbs_now=false
-        String  docker = "quay.io/staphb/pangolin:4.1.3-pdata-1.17"
+        String  docker = "quay.io/staphb/pangolin:4.2-pdata-1.18"
     }
     String basename = basename(genome_fasta, ".fasta")
     Int disk_size = 50
@@ -93,7 +93,7 @@ task pangolin_many_samples {
         String?      analysis_mode
         Boolean      update_dbs_now=false
         String       basename
-        String       docker = "quay.io/staphb/pangolin:4.1.3-pdata-1.17"
+        String       docker = "quay.io/staphb/pangolin:4.2-pdata-1.18"
     }
     Int disk_size = 100
     command <<<

--- a/requirements-modules.txt
+++ b/requirements-modules.txt
@@ -7,5 +7,5 @@ broadinstitute/beast-beagle-cuda=1.10.5pre
 broadinstitute/ncbi-tools=2.10.7.10
 nextstrain/base=build-20211012T204409Z
 andersenlabapps/ivar=1.3.1
-quay.io/staphb/pangolin=4.1.3-pdata-1.17
+quay.io/staphb/pangolin=4.2-pdata-1.18
 nextstrain/nextclade=2.9.1


### PR DESCRIPTION
Update pangolin docker image to `quay.io/staphb/pangolin:4.2-pdata-1.18`.

What to expect:
- pangolin runs much faster when running on a large number of input sequences, due to incorporation of new usher-sampled  TY 
- [@Angie Hinrichs (UCSC)](https://staph-b-dev.slack.com/team/U024QPL9YLA)
-  & UShER team!
- Adds many new Omicron/BA sublineages. Full list included as a TXT file in thread and [listed here](https://github.com/cov-lineages/pango-designation/releases).
- To decode the [pango lineage aliases, see the key here](https://github.com/cov-lineages/pangolin-data/blob/main/pangolin_data/data/alias_key.json).

I recommend you check out the Pangolin documentation and release notes for more details:
- [Complete pangolin documentation](https://cov-lineages.org/resources/pangolin.html)
- [pangolin release notes](https://github.com/cov-lineages/pangolin/releases) (4.1.3 :arrow_right:4.2)
- [pangolin-data release notes](https://github.com/cov-lineages/pangolin-data/releases) (1.17 :arrow_right: 1.18)
- [scorpio release notes](https://github.com/cov-lineages/scorpio/releases) (0.3.17, no change)
- [constellations release notes](https://github.com/cov-lineages/constellations/releases) (0.1.10, no change)
- [UShER release notes](https://github.com/yatisht/usher/releases) (0.6.1 :arrow_right: 0.6.2)