### PR TITLE
samtools ampliconstats needs bed in certain order

### DIFF
--- a/pipes/WDL/tasks/tasks_reports.wdl
+++ b/pipes/WDL/tasks/tasks_reports.wdl
@@ -67,11 +67,12 @@ task alignment_metrics {
     echo -e "sample_sanitized\tbam\tamplicon_set\tamplicon_idx\tamplicon_left\tamplicon_right\tFREADS\tFDEPTH\tFPCOV\tFAMP" > "~{out_basename}.ampliconstats_parsed.txt"
     if [ -n "~{primers_bed}" ]; then
       # samtools ampliconstats
+      cat "~{primers_bed}" | sort -k 4 -t $'\t' > primers-sorted_for_samtools.bed
       samtools ampliconstats -s -@ $(nproc) \
         ~{'-d ' + min_coverage} \
         ~{'-l ' + max_amp_len} \
         ~{'-a ' + max_amplicons} \
-        -o "~{out_basename}".ampliconstats.txt "~{primers_bed}" "~{aligned_bam}"
+        -o "~{out_basename}".ampliconstats.txt primers-sorted_for_samtools.bed "~{aligned_bam}"
 
       # parse into our own tsv to facilitate tsv joining later
       if [ -n "~{default='' amplicon_set}" ]; then


### PR DESCRIPTION
As it turns out, `samtools ampliconstats` requires that the bed file describing the primers need to be sorted a certain way. This PR accomplishes that sorting. The reported primer and amplicon coordinates look good, as does `FAMP` and other metrics. `FPCOV` looks a bit non-sensible but the coordinates are good.