### PR TITLE
Update pangolin, nextclade, and vadr docker images

### DIFF
--- a/pipes/WDL/tasks/tasks_ncbi.wdl
+++ b/pipes/WDL/tasks/tasks_ncbi.wdl
@@ -928,9 +928,11 @@ task vadr {
     File   genome_fasta
     String vadr_opts = "--glsearch -s -r --nomisc --mkey sarscov2 --lowsim5seq 6 --lowsim3seq 6 --alt_fail lowscore,insertnn,deletinn"
 
-    String docker = "quay.io/staphb/vadr:1.4.2"
+    String docker = "quay.io/staphb/vadr:1.5.1"
     Int    minlen = 50
     Int    maxlen = 30000
+    Int    mem_size = 4
+    Int    cpus = 2
   }
   String out_base = basename(genome_fasta, '.fasta')
   command <<<
@@ -969,8 +971,8 @@ task vadr {
   }
   runtime {
     docker: docker
-    memory: "2 GB"
-    cpu: 1
+    memory: mem_size + " GB"
+    cpu: cpus
     dx_instance_type: "mem1_ssd1_v2_x2"
     maxRetries: 2
   }

--- a/pipes/WDL/tasks/tasks_nextstrain.wdl
+++ b/pipes/WDL/tasks/tasks_nextstrain.wdl
@@ -13,7 +13,7 @@ task nextclade_one_sample {
         File? pcr_primers_csv
         File? virus_properties
         String? dataset_name
-        String docker = "nextstrain/nextclade:2.9.1"
+        String docker = "nextstrain/nextclade:2.12.0"
     }
     String basename = basename(genome_fasta, ".fasta")
     Int disk_size = 50
@@ -100,7 +100,7 @@ task nextclade_many_samples {
         String?      dataset_name
         String       basename
         File?        genome_ids_setdefault_blank
-        String       docker = "nextstrain/nextclade:2.9.1"
+        String       docker = "nextstrain/nextclade:2.12.0"
     }
     Int disk_size = 100
     command <<<

--- a/pipes/WDL/tasks/tasks_sarscov2.wdl
+++ b/pipes/WDL/tasks/tasks_sarscov2.wdl
@@ -10,7 +10,7 @@ task pangolin_one_sample {
         Float?  max_ambig
         String? analysis_mode
         Boolean update_dbs_now=false
-        String  docker = "quay.io/staphb/pangolin:4.2-pdata-1.18"
+        String  docker = "quay.io/staphb/pangolin:4.2-pdata-1.18.1.1"
     }
     String basename = basename(genome_fasta, ".fasta")
     Int disk_size = 50
@@ -93,7 +93,7 @@ task pangolin_many_samples {
         String?      analysis_mode
         Boolean      update_dbs_now=false
         String       basename
-        String       docker = "quay.io/staphb/pangolin:4.2-pdata-1.18"
+        String       docker = "quay.io/staphb/pangolin:4.2-pdata-1.18.1.1"
     }
     Int disk_size = 100
     command <<<

--- a/requirements-modules.txt
+++ b/requirements-modules.txt
@@ -7,5 +7,5 @@ broadinstitute/beast-beagle-cuda=1.10.5pre
 broadinstitute/ncbi-tools=2.10.7.10
 nextstrain/base=build-20211012T204409Z
 andersenlabapps/ivar=1.3.1
-quay.io/staphb/pangolin=4.2-pdata-1.18
-nextstrain/nextclade=2.9.1
+quay.io/staphb/pangolin=4.2-pdata-1.18.1.1
+nextstrain/nextclade=2.12.0


### PR DESCRIPTION
# Updates for pangolin
New release of pangolin-data v1.18.1.1 and corresponding docker image `quay.io/staphb/pangolin:4.2-pdata-1.18.1.1`
What to expect:
- :rotating_light: pangolearn model has not been updated since pangolin-data v1.18 (due to server issues), lineage calls for newly-designated lineages may be discrepant from calls generated by UShER/accurate mode
- :rotating_light: pangolearn analysis-mode consumes more RAM than before, we have found that at least 38 GB of RAM is required to avoid killed/out-of-memory errors
- Adds many new Omicron/BA sublineages. Full list included as a TXT file in thread and [listed here](https://github.com/cov-lineages/pango-designation/releases).
- To decode the [pango lineage aliases, see the key here](https://github.com/cov-lineages/pangolin-data/blob/main/pangolin_data/data/alias_key.json).

I recommend you check out the Pangolin documentation and release notes for more details:
- [Complete pangolin documentation](https://cov-lineages.org/resources/pangolin.html)
- [pangolin release notes](https://github.com/cov-lineages/pangolin/releases) (4.2, no change)
- [pangolin-data release notes](https://github.com/cov-lineages/pangolin-data/releases) (1.18 :arrow_right: 1.18.1.1)
- [scorpio release notes](https://github.com/cov-lineages/scorpio/releases) (0.3.17, no change)
- [constellations release notes](https://github.com/cov-lineages/constellations/releases) (0.1.10, no change)
- [UShER release notes](https://github.com/yatisht/usher/releases) (0.6.2, no change)

# Updates for nextclade
Further info in [release notes](https://github.com/nextstrain/nextclade/releases/tag/2.12.0).

# Updates for VADR
There is a new VADR docker image for v1.5.1 (`quay.io/staphb/vadr:1.5.1`) that includes the new RSV model files (as well as SARS-CoV-2, Mpox, Dengue virus and other flaviviridae, Norovirus and other caliciviridae). Short [README & Dockerfile on the docker image here](https://github.com/StaPH-B/docker-builds/tree/master/vadr/1.5.1).

Also parameterize VADR task VM shape, as different species have different memory requirements.