### PR TITLE
parameterize more assembly knobs

### DIFF
--- a/pipes/WDL/workflows/assemble_refbased.wdl
+++ b/pipes/WDL/workflows/assemble_refbased.wdl
@@ -67,18 +67,18 @@ workflow assemble_refbased {
         Float        major_cutoff=0.75
         Boolean      skip_mark_dupes=false
         File?        trim_coords_bed
-    }
 
-    Map[String,String] align_to_ref_options = {
+        Map[String,String] align_to_ref_options = {
                             "novoalign": "-r Random -l 40 -g 40 -x 20 -t 501 -k",
                             "bwa": "-k 12 -B 1",
                             "minimap2": ""
                             }
-    Map[String,String] align_to_self_options = {
+        Map[String,String] align_to_self_options = {
                             "novoalign": "-r Random -l 40 -g 40 -x 20 -t 100",
                             "bwa": "",
                             "minimap2": ""
                             }
+    }
 
     scatter(reads_unmapped_bam in reads_unmapped_bams) {
         call assembly.align_reads as align_to_ref {

--- a/pipes/WDL/workflows/sarscov2_illumina_full.wdl
+++ b/pipes/WDL/workflows/sarscov2_illumina_full.wdl
@@ -126,7 +126,7 @@ workflow sarscov2_illumina_full {
                 skip_mark_dupes     = ampseq,
                 trim_coords_bed     = bed_rename.outfile,
                 major_cutoff        = 0.75,
-                min_coverage        = if defined(min_genome_coverage) then min_coverage else (if ampseq then 50 else 3)
+                min_coverage        = if defined(min_genome_coverage) then min_genome_coverage else (if ampseq then 50 else 3)
         }
 
         # log controls

--- a/pipes/WDL/workflows/sarscov2_illumina_full.wdl
+++ b/pipes/WDL/workflows/sarscov2_illumina_full.wdl
@@ -51,6 +51,7 @@ workflow sarscov2_illumina_full {
         Int           min_genome_bases = 24000
         Int           max_vadr_alerts = 0
         Int           ntc_max_unambig = 3000
+        Int?          min_genome_coverage
 
         File?         sample_rename_map
 
@@ -125,7 +126,7 @@ workflow sarscov2_illumina_full {
                 skip_mark_dupes     = ampseq,
                 trim_coords_bed     = bed_rename.outfile,
                 major_cutoff        = 0.75,
-                min_coverage        = if ampseq then 50 else 3
+                min_coverage        = if defined(min_genome_coverage) then min_coverage else (if ampseq then 50 else 3)
         }
 
         # log controls

--- a/pipes/WDL/workflows/sarscov2_illumina_full.wdl
+++ b/pipes/WDL/workflows/sarscov2_illumina_full.wdl
@@ -122,7 +122,6 @@ workflow sarscov2_illumina_full {
                 reads_unmapped_bams = name_reads.right,
                 reference_fasta     = reference_fasta,
                 sample_name         = name_reads.left,
-                aligner             = "minimap2",
                 skip_mark_dupes     = ampseq,
                 trim_coords_bed     = bed_rename.outfile,
                 major_cutoff        = 0.75,


### PR DESCRIPTION
In workflow `assemble_refbased`: allow user to override default aligner parameters

In workflow `sarscov2_illumina_full`: allow user to override `assemble_refbased` default aligner, aligner parameters, and minimum coverage cutoffs