### PR TITLE
tweaks to demux_only and demux_metag

### DIFF
--- a/pipes/WDL/workflows/demux_metag.wdl
+++ b/pipes/WDL/workflows/demux_metag.wdl
@@ -18,7 +18,7 @@ workflow demux_metag {
 
         File kraken2_db_tgz
         File krona_taxonomy_db_kraken2_tgz
-        File blast_db_tgz
+        #File blast_db_tgz
         File krona_taxonomy_db_blast_tgz
     }
 
@@ -53,12 +53,12 @@ workflow demux_metag {
                 kraken2_db_tgz        = kraken2_db_tgz,
                 krona_taxonomy_db_tgz = krona_taxonomy_db_kraken2_tgz
         }
-        call metagenomics.blastx as blastx {
-            input:
-                contigs_fasta         = spades.contigs_fasta,
-                blast_db_tgz          = blast_db_tgz,
-                krona_taxonomy_db_tgz = krona_taxonomy_db_blast_tgz
-        }
+        #call metagenomics.blastx as blastx {
+        #    input:
+        #        contigs_fasta         = spades.contigs_fasta,
+        #        blast_db_tgz          = blast_db_tgz,
+        #        krona_taxonomy_db_tgz = krona_taxonomy_db_blast_tgz
+        #}
     }
 
     call reports.MultiQC as multiqc_raw {
@@ -95,11 +95,11 @@ workflow demux_metag {
             out_basename  = "merged-kraken2.krona.html"
     }
 
-    call metagenomics.krona_merge as krona_merge_blastx {
-        input:
-            krona_reports = blastx.krona_report_html,
-            out_basename  = "merged-spades-blastx.krona.html"
-    }
+    #call metagenomics.krona_merge as krona_merge_blastx {
+    #    input:
+    #        krona_reports = blastx.krona_report_html,
+    #        out_basename  = "merged-spades-blastx.krona.html"
+    #}
 
     output {
         Array[File] raw_reads_unaligned_bams        = illumina_demux.raw_reads_unaligned_bams
@@ -124,12 +124,12 @@ workflow demux_metag {
         File        spikein_counts                  = spike_summary.count_summary
         File        kraken2_merged_krona            = krona_merge_kraken2.krona_report_html
         File        kraken2_summary                 = metag_summary_report.krakenuniq_aggregate_taxlevel_summary
-        File        blastx_merged_krona             = krona_merge_blastx.krona_report_html
+        #File        blastx_merged_krona             = krona_merge_blastx.krona_report_html
         
         Array[File] kraken2_summary_reports         = kraken2.kraken2_summary_report
         Array[File] kraken2_krona_by_sample         = kraken2.krona_report_html
-        Array[File] blastx_report_by_sample         = blastx.blast_report
-        Array[File] blastx_krona_by_sample          = blastx.krona_report_html
+        #Array[File] blastx_report_by_sample         = blastx.blast_report
+        #Array[File] blastx_krona_by_sample          = blastx.krona_report_html
         
         String      demux_viral_core_version        = illumina_demux.viralngs_version
         String      kraken2_viral_classify_version  = kraken2.viralngs_version[0]

--- a/pipes/WDL/workflows/demux_only.wdl
+++ b/pipes/WDL/workflows/demux_only.wdl
@@ -28,7 +28,19 @@ workflow demux_only {
         File        demux_commonBarcodes      = illumina_demux.commonBarcodes
         File        demux_outlierBarcodes     = illumina_demux.outlierBarcodes
         File        multiqc_report_raw        = MultiQC.multiqc_report
+
+        String             run_date           = illumina_demux.run_info['run_start_date']
+        Map[String,String] run_info           = illumina_demux.run_info
+        File               run_info_json      = illumina_demux.run_info_json
+        String             run_id             = illumina_demux.run_info['run_id']
+        String             run_lane_count     = illumina_demux.flowcell_lane_count
+
         String      instrument_model_inferred = select_first(flatten([[instrument_model_user_specified],[illumina_demux.run_info['sequencer_model']]]))
         String      demux_viral_core_version  = illumina_demux.viralngs_version
+
+        Map[String,Map[String,String]] meta_by_filename      = illumina_demux.meta_by_filename
+        Map[String,Map[String,String]] meta_by_sample        = illumina_demux.meta_by_sample
+        File                           meta_by_filename_json = illumina_demux.meta_by_filename_json
+        File                           meta_by_sample_json   = illumina_demux.meta_by_sample_json
     }
 }


### PR DESCRIPTION
Two tweaks to demux workflows to harmonize with others:
- `demux_metag` -- this WiP was mostly complete but for now this PR will comment out all the blastx components on contigs until we figure out how to do this more efficiently/deterministically/cost-effectively
- `demux_only` -- add workflow-level output variables copied from task outputs to mirror what `demux_deplete` has been emitting (in particular, run metadata extracted from the flowcell and sample/library metadata encoded in json structures)