### PR TITLE
omit --dirs from the MultiQC invocation to only show sample names in report

### DIFF
--- a/pipes/WDL/tasks/tasks_demux.wdl
+++ b/pipes/WDL/tasks/tasks_demux.wdl
@@ -152,7 +152,7 @@ task illumina_demux {
     Int?    maxRecordsInRam
 
     Int?    machine_mem_gb
-    Int?     disk_size = 2625
+    Int     disk_size = 2625
     String  docker = "quay.io/broadinstitute/viral-core:2.1.33"
   }
 

--- a/pipes/WDL/tasks/tasks_reports.wdl
+++ b/pipes/WDL/tasks/tasks_reports.wdl
@@ -464,7 +464,6 @@ task MultiQC {
     Array[String]? module_to_use
     Boolean        data_dir = false
     Boolean        no_data_dir = false
-    Boolean        show_sample_names_with_paths = false
     String?        output_data_format
     Boolean        zip_data_dir = false
     Boolean        export = false
@@ -509,7 +508,6 @@ task MultiQC {
       ${true="--exclude " false="" defined(exclude_modules)}${sep=' --exclude ' select_first([exclude_modules,[]])} \
       ${true="--module " false="" defined(module_to_use)}${sep=' --module ' select_first([module_to_use,[]])} \
       ${true="--data-dir" false="" data_dir} \
-      ${true="--dirs" false="" show_sample_names_with_paths} \
       ${true="--no-data-dir" false="" no_data_dir} \
       ${"--data-format " + output_data_format} \
       ${true="--zip-data-dir" false="" zip_data_dir} \

--- a/pipes/WDL/tasks/tasks_reports.wdl
+++ b/pipes/WDL/tasks/tasks_reports.wdl
@@ -447,7 +447,7 @@ task aggregate_metagenomics_reports {
 
 task MultiQC {
   input {
-    Array[File]    input_files = []
+    Array[File]    input_files
 
     Boolean        force = false
     Boolean        full_names = false
@@ -464,6 +464,7 @@ task MultiQC {
     Array[String]? module_to_use
     Boolean        data_dir = false
     Boolean        no_data_dir = false
+    Boolean        show_sample_names_with_paths = false
     String?        output_data_format
     Boolean        zip_data_dir = false
     Boolean        export = false
@@ -494,7 +495,6 @@ task MultiQC {
 
       multiqc \
       --file-list input-filenames.txt \
-      --dirs \
       --outdir "${out_dir}" \
       ${true="--force" false="" force} \
       ${true="--fullnames" false="" full_names} \
@@ -509,6 +509,7 @@ task MultiQC {
       ${true="--exclude " false="" defined(exclude_modules)}${sep=' --exclude ' select_first([exclude_modules,[]])} \
       ${true="--module " false="" defined(module_to_use)}${sep=' --module ' select_first([module_to_use,[]])} \
       ${true="--data-dir" false="" data_dir} \
+      ${true="--dirs" false="" show_sample_names_with_paths} \
       ${true="--no-data-dir" false="" no_data_dir} \
       ${"--data-format " + output_data_format} \
       ${true="--zip-data-dir" false="" zip_data_dir} \

--- a/pipes/WDL/workflows/bams_multiqc.wdl
+++ b/pipes/WDL/workflows/bams_multiqc.wdl
@@ -11,7 +11,6 @@ workflow bams_multiqc {
 
     input {
         Array[File]+ read_bams
-        Boolean      show_sample_names_with_paths = false
     }
 
     scatter(reads_bam in read_bams) {
@@ -23,8 +22,7 @@ workflow bams_multiqc {
 
     call reports.MultiQC {
         input:
-            input_files = fastqc.fastqc_zip,
-            show_sample_names_with_paths = show_sample_names_with_paths
+            input_files = fastqc.fastqc_zip
     }
 
     output {

--- a/pipes/WDL/workflows/bams_multiqc.wdl
+++ b/pipes/WDL/workflows/bams_multiqc.wdl
@@ -11,6 +11,7 @@ workflow bams_multiqc {
 
     input {
         Array[File]+ read_bams
+        Boolean      show_sample_names_with_paths = false
     }
 
     scatter(reads_bam in read_bams) {
@@ -22,7 +23,8 @@ workflow bams_multiqc {
 
     call reports.MultiQC {
         input:
-            input_files = fastqc.fastqc_zip
+            input_files = fastqc.fastqc_zip,
+            show_sample_names_with_paths = show_sample_names_with_paths
     }
 
     output {

--- a/pipes/WDL/workflows/multiqc_only.wdl
+++ b/pipes/WDL/workflows/multiqc_only.wdl
@@ -11,13 +11,11 @@ workflow multiqc_only {
     input {
         Array[File] input_files
         String      file_name = "multiqc-raw.html"
-        Boolean     show_sample_names_with_paths = false
     }
     call reports.MultiQC {
         input:
             input_files = input_files,
-            file_name = file_name,
-            show_sample_names_with_paths = show_sample_names_with_paths
+            file_name = file_name
     }
     output {
         File multiqc = MultiQC.multiqc_report

--- a/pipes/WDL/workflows/multiqc_only.wdl
+++ b/pipes/WDL/workflows/multiqc_only.wdl
@@ -8,7 +8,17 @@ workflow multiqc_only {
         author: "Broad Viral Genomics"
         email:  "viral-ngs@broadinstitute.org"
     }
-    call reports.MultiQC
+    input {
+        Array[File] input_files
+        String      file_name = "multiqc-raw.html"
+        Boolean     show_sample_names_with_paths = false
+    }
+    call reports.MultiQC {
+        input:
+            input_files = input_files,
+            file_name = file_name,
+            show_sample_names_with_paths = show_sample_names_with_paths
+    }
     output {
         File multiqc = MultiQC.multiqc_report
     }


### PR DESCRIPTION
omit `--dirs` from the MultiQC invocation to only show sample names in report; and provide a boolean to optionally enable display of full paths

Addresses #466 