### PR TITLE
parameterize disk size for illumina_demux task

### DIFF
--- a/pipes/WDL/tasks/tasks_demux.wdl
+++ b/pipes/WDL/tasks/tasks_demux.wdl
@@ -152,9 +152,10 @@ task illumina_demux {
     Int?    maxRecordsInRam
 
     Int?    machine_mem_gb
+    Int?     disk_size = 2625
     String  docker = "quay.io/broadinstitute/viral-core:2.1.33"
   }
-  Int disk_size = 2625
+
   parameter_meta {
       flowcell_tgz: {
           description: "Illumina BCL directory compressed as tarball. Must contain RunInfo.xml (unless overridden by runinfo), SampleSheet.csv (unless overridden by samplesheet), RTAComplete.txt, and Data/Intensities/BaseCalls/*",

--- a/pipes/WDL/tasks/tasks_demux.wdl
+++ b/pipes/WDL/tasks/tasks_demux.wdl
@@ -155,7 +155,7 @@ task illumina_demux {
     Int?     disk_size = 2625
     String  docker = "quay.io/broadinstitute/viral-core:2.1.33"
   }
-
+  Int    disk_size = 8000
   parameter_meta {
       flowcell_tgz: {
           description: "Illumina BCL directory compressed as tarball. Must contain RunInfo.xml (unless overridden by runinfo), SampleSheet.csv (unless overridden by samplesheet), RTAComplete.txt, and Data/Intensities/BaseCalls/*",

--- a/pipes/WDL/tasks/tasks_demux.wdl
+++ b/pipes/WDL/tasks/tasks_demux.wdl
@@ -155,7 +155,7 @@ task illumina_demux {
     Int?     disk_size = 2625
     String  docker = "quay.io/broadinstitute/viral-core:2.1.33"
   }
-  Int    disk_size = 8000
+
   parameter_meta {
       flowcell_tgz: {
           description: "Illumina BCL directory compressed as tarball. Must contain RunInfo.xml (unless overridden by runinfo), SampleSheet.csv (unless overridden by samplesheet), RTAComplete.txt, and Data/Intensities/BaseCalls/*",


### PR DESCRIPTION
parameterize disk size for `illumina_demux` task, with same default as before (2625 GB)