### PR TITLE
move transposed parameter_meta block outside command block scope to where it belongs

### DIFF
--- a/pipes/WDL/tasks/tasks_demux.wdl
+++ b/pipes/WDL/tasks/tasks_demux.wdl
@@ -49,11 +49,6 @@ task samplesheet_rename_ids {
     String old_id_col = 'internal_id'
     String new_id_col = 'external_id'
   }
-  String new_base = basename(old_sheet, '.txt')
-  Int disk_size = 50
-  command <<<
-    python3 << CODE
-    import csv
   parameter_meta { 
     old_sheet: {
       description: "Illumina file with old sample names."
@@ -64,6 +59,11 @@ task samplesheet_rename_ids {
       category: "required"
     }
   }
+  String new_base = basename(old_sheet, '.txt')
+  Int disk_size = 50
+  command <<<
+    python3 << CODE
+    import csv
     # read in the rename_map file
     old_to_new = {}
     with open('~{default="/dev/null" rename_map}', 'rt') as inf:

--- a/pipes/WDL/tasks/tasks_demux.wdl
+++ b/pipes/WDL/tasks/tasks_demux.wdl
@@ -51,11 +51,11 @@ task samplesheet_rename_ids {
   }
   parameter_meta { 
     old_sheet: {
-      description: "Illumina file with old sample names."
+      description: "Illumina file with old sample names.",
       category: "required"
     }
     rename_map: {
-      description: "New sample name sheet."
+      description: "New sample name sheet.",
       category: "required"
     }
   }


### PR DESCRIPTION
A  `parameter_meta` block [was transposed](https://github.com/broadinstitute/viral-pipelines/pull/461/files#diff-acce979fc40f39acd2d7c54a32e1a221352dce59d6eb33a712814e0b955f63a3R57) in a recent PR. This moves it outside the command block scope, to where it belongs.
