### PR TITLE
allow docker image pinning to be skipped with #skip-global-version-pin annotation

### DIFF
--- a/github_actions_ci/check-wdl-runtimes.sh
+++ b/github_actions_ci/check-wdl-runtimes.sh
@@ -12,7 +12,7 @@ for task_file in $(ls -1 pipes/WDL/tasks/*.wdl); do
     	OLD_TAG=$module
     	NEW_TAG="$module:$version"
         
-        offending_lines="$(grep -nE "^[^#]*$OLD_TAG" "${task_file}" | grep -v $NEW_TAG)"
+        offending_lines="$(grep -nE "^[^#]*$OLD_TAG" "${task_file}" | grep -v '#skip-global-version-pin' | grep -v $NEW_TAG)"
 
         # if the expected tag is not seen, let us know the file and exit
         if [ $? -eq 0 ]; then

--- a/github_actions_ci/version-wdl-runtimes.sh
+++ b/github_actions_ci/version-wdl-runtimes.sh
@@ -1,13 +1,21 @@
 #!/bin/bash
 
 # use sed to replace version strings of docker images based on versions defined in txt file
-
+#
+# skip this replacement for any version string line with the comment "#skip-global-version-pin"
+#
 # requires $MODULE_VERSIONS to be set to point to a text file with equal-sign-separated values
 # export MODULE_VERSIONS="./requirements-modules.txt" && ./github_actions_ci/check-wdl-runtimes.sh
+
+printf "Updating docker image tags in WDL files with those in ${MODULE_VERSIONS}\n\n"
 
 while IFS='=' read module version; do
   OLD_TAG=$module
   NEW_TAG="$module:$version"
-  echo Replacing $OLD_TAG with $NEW_TAG in all task WDL files
-  sed -i '' "s|$OLD_TAG[^\"\']*|$NEW_TAG|g" pipes/WDL/tasks/*.wdl
+  NEW_TAG_BOLD="$module:$(tput bold)$version$(tput sgr0)"
+  printf "Replacing: %-14s \n with tag: %-14s \n\n" "$OLD_TAG" "$NEW_TAG_BOLD"
+
+  sed -i '' "/^\(.*\)[[:space:]]*#skip-global-version-pin[[:space:]]*$/!s|$OLD_TAG[^\"\']*|$NEW_TAG|g" pipes/WDL/tasks/*.wdl
 done < $MODULE_VERSIONS
+
+printf "Replacements skipped for lines marked with '#skip-global-version-pin' \n\n"

--- a/pipes/WDL/tasks/tasks_metagenomics.wdl
+++ b/pipes/WDL/tasks/tasks_metagenomics.wdl
@@ -11,7 +11,7 @@ task krakenuniq {
     File        krona_taxonomy_db_tgz  # taxonomy.tab
 
     Int?        machine_mem_gb
-    String      docker = "quay.io/broadinstitute/viral-classify:2.1.33.0"
+    String      docker = "quay.io/broadinstitute/viral-classify:2.1.33.0" #skip-global-version-pin
   }
 
   Int disk_size = 750
@@ -143,7 +143,7 @@ task build_krakenuniq_db {
     Int?     zstd_compression_level
 
     Int?     machine_mem_gb
-    String   docker = "quay.io/broadinstitute/viral-classify:2.1.33.0"
+    String   docker = "quay.io/broadinstitute/viral-classify:2.1.33.0" #skip-global-version-pin
   }
 
   Int disk_size = 750

--- a/pipes/WDL/tasks/tasks_nextstrain.wdl
+++ b/pipes/WDL/tasks/tasks_nextstrain.wdl
@@ -847,7 +847,8 @@ task filter_sequences_to_list {
         Array[File]? keep_list
 
         String       out_fname = sub(sub(basename(sequences, ".zst"), ".vcf", ".filtered.vcf"), ".fasta$", ".filtered.fasta")
-        String       docker = "quay.io/broadinstitute/viral-core:2.1.33" # "nextstrain/base:build-20211012T204409Z"
+        # Prior docker image: "nextstrain/base:build-20211012T204409Z"
+        String       docker = "quay.io/broadinstitute/viral-core:2.1.33"
         Int          disk_size = 750
     }
     parameter_meta {


### PR DESCRIPTION
The script `github_actions_ci/version-wdl-runtimes.sh` is used to replace docker image tags in WDL task files with the tags listed in the `requirements-modules.txt` file. These replacements were previously applied globally. With this commit, image references on lines ending with the comment `#skip-global-version-pin` are exempt from these replacements. This allows tasks to have image versions held back; this is useful in the event that a task has commands that are incompatible with newer image versions.

The script `github_actions_ci/check-wdl-runtimes.sh` also honors these annotations. 

The `#skip-global-version-pin` is also applied to two tasks using krakenuniq, as newer versions of the viral-classify image will not provide krakenuniq until an updated conda rebuild exists for the fork https://github.com/yesimon/krakenuniq and its associated dependencies.