### PR TITLE
add check_terra_env task

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -144,6 +144,11 @@ workflows:
     primaryDescriptorPath: /pipes/WDL/workflows/downsample.wdl
     testParameterFiles:
       - empty.json
+  - name: dump_gcloud_env_info
+    subclass: WDL
+    primaryDescriptorPath: /pipes/WDL/workflows/dump_gcloud_env_info.wdl
+    testParameterFiles:
+      - empty.json
   - name: fastq_to_ubam
     subclass: WDL
     primaryDescriptorPath: /pipes/WDL/workflows/fastq_to_ubam.wdl

--- a/github_actions_ci/version-wdl-runtimes.sh
+++ b/github_actions_ci/version-wdl-runtimes.sh
@@ -5,7 +5,7 @@
 # skip this replacement for any version string line with the comment "#skip-global-version-pin"
 #
 # requires $MODULE_VERSIONS to be set to point to a text file with equal-sign-separated values
-# export MODULE_VERSIONS="./requirements-modules.txt" && ./github_actions_ci/check-wdl-runtimes.sh
+# export MODULE_VERSIONS="./requirements-modules.txt" && ./github_actions_ci/version-wdl-runtimes.sh
 
 printf "Updating docker image tags in WDL files with those in ${MODULE_VERSIONS}\n\n"
 

--- a/pipes/WDL/tasks/tasks_terra.wdl
+++ b/pipes/WDL/tasks/tasks_terra.wdl
@@ -107,9 +107,9 @@ task get_gcloud_env_info {
     Array[String] env_info_files            = glob("./*_info.log")
     File          additional_command_stdout = "additional_command_stdout.log"
     
-    String workspace_name      = read_string("workspace_name.txt")
-    String workspace_namespace = read_string("workspace_namespace.txt")
-    String google_project_id   = read_string("google_project_id.txt")
+    String workspace_name_out      = read_string("workspace_name.txt")
+    String workspace_namespace_out = read_string("workspace_namespace.txt")
+    String google_project_id_out   = read_string("google_project_id.txt")
   }
   runtime {
     docker: "quay.io/broadinstitute/viral-baseimage:0.1.20"

--- a/pipes/WDL/tasks/tasks_terra.wdl
+++ b/pipes/WDL/tasks/tasks_terra.wdl
@@ -45,9 +45,6 @@ task get_gcloud_env_info {
   command <<<
     set -ex
 
-    echo "~{WORKSPACE_NAMESPACE}"
-    echo "~{WORKSPACE_NAME}"
-
     gcloud auth print-access-token
 
     touch additional_command_stdout.log

--- a/pipes/WDL/tasks/tasks_terra.wdl
+++ b/pipes/WDL/tasks/tasks_terra.wdl
@@ -129,9 +129,11 @@ task check_terra_env {
       -H 'accept: application/json' \
       -H "Authorization: Bearer $(gcloud auth print-access-token)" > submission_metadata.json
 
-      INPUT_TABLE_NAME="$(jq -cr '.submissionEntity.entityType | select (.!=null)' submission_metadata.json)"
+      #INPUT_TABLE_NAME="$(jq -cr '.submissionEntity.entityType | select (.!=null)' submission_metadata.json)"
+      INPUT_TABLE_NAME="$(jq -cr 'if .submissionEntity == null then "" elif (.workflows | length)==1 then .submissionEntity.entityType else [.workflows[].workflowEntity.entityType] | join(",") end' submission_metadata.json)"
       echo "$INPUT_TABLE_NAME" | tee input_table_name.txt
-      INPUT_ROW_ID="$(jq -cr '.submissionEntity.entityName | select (.!=null)' submission_metadata.json)"
+      #INPUT_ROW_ID="$(jq -cr '.submissionEntity.entityName | select (.!=null)' submission_metadata.json)"
+      INPUT_ROW_ID="$(jq -cr 'if .submissionEntity == null then "" elif (.workflows | length)==1 then .submissionEntity.entityName else [.workflows[].workflowEntity.entityName] | join(",") end' submission_metadata.json)"
       echo "$INPUT_ROW_ID" | tee input_row_id.txt
     else 
       echo "Not running on Terra+GCP"

--- a/pipes/WDL/tasks/tasks_terra.wdl
+++ b/pipes/WDL/tasks/tasks_terra.wdl
@@ -35,16 +35,9 @@ task get_gcloud_env_info {
     String? workspace_name
     String? workspace_namespace
     String? workspace_googleProject
-
-    String? additional_command_to_run
   }
   meta {
     description: "task for inspection of backend env, and optionally running a command"
-  }
-  parameter_meta {
-    additional_command_to_run: {
-      description: "Command that can optionally be included and executed as part of this task"
-    }
   }
   command <<<
     set -ex
@@ -92,11 +85,11 @@ task get_gcloud_env_info {
 
     # ======================================================================================
 
-    touch additional_command_stdout.log
+    #touch additional_command_stdout.log
 
-    if [ -n "~{default='' additional_command_to_run}" ]; then
-      ~{default='echo ""' additional_command_to_run} | tee -a additional_command_stdout.log
-    fi
+    #if [ -n "~{default='' additional_command_to_run}" ]; then
+    #  ~{default='echo ""' additional_command_to_run} | tee -a additional_command_stdout.log
+    #fi
 
     env | tee -a env_info.log
     
@@ -107,7 +100,7 @@ task get_gcloud_env_info {
   >>>
   output {
     Array[String] env_info_files            = glob("./*_info.log")
-    File          additional_command_stdout = "additional_command_stdout.log"
+    #File          additional_command_stdout = "additional_command_stdout.log"
     
     String workspace_name_out      = read_string("workspace_name.txt")
     String workspace_namespace_out = read_string("workspace_namespace.txt")

--- a/pipes/WDL/tasks/tasks_terra.wdl
+++ b/pipes/WDL/tasks/tasks_terra.wdl
@@ -65,6 +65,8 @@ task get_gcloud_env_info {
 
     # ========== method 2: matching a project returned by the API based on the google project ID
 
+    GOOGLE_PROJECT_ID="$(gcloud config list --format='value(core.project)')"
+
     # get list of workspaces, limiting the output to only the fields we need
     curl -X 'GET' \
     'https://api.firecloud.org/api/workspaces?fields=workspace.name%2Cworkspace.namespace%2Cworkspace.googleProject' \
@@ -72,11 +74,11 @@ task get_gcloud_env_info {
     -H "Authorization: Bearer $(gcloud auth print-access-token)" > workspace_list.json
 
     # extract workspace name
-    WORKSPACE_NAME=$(jq -cr '.[] | select( .workspace.googleProject == "terra-bf70b335" ).workspace | .name' workspace_list.json)
+    WORKSPACE_NAME=$(jq -cr '.[] | select( .workspace.googleProject == "'${GOOGLE_PROJECT_ID}'" ).workspace | .name' workspace_list.json)
     echo "$WORKSPACE_NAME" > workspace_name.txt
     
     # extract workspace namespace
-    WORKSPACE_NAMESPACE=$(jq -cr '.[] | select( .workspace.googleProject == "terra-bf70b335" ).workspace | .namespace' workspace_list.json)
+    WORKSPACE_NAMESPACE=$(jq -cr '.[] | select( .workspace.googleProject == "'${GOOGLE_PROJECT_ID}'" ).workspace | .namespace' workspace_list.json)
     echo "$WORKSPACE_NAMESPACE" > workspace_namespace.txt
 
     # ========== method 3: resolved by Terra as inputs

--- a/pipes/WDL/tasks/tasks_terra.wdl
+++ b/pipes/WDL/tasks/tasks_terra.wdl
@@ -47,6 +47,8 @@ task get_gcloud_env_info {
 
     gcloud auth print-access-token
 
+    gcloud config list --format='text(core.project)'
+
     touch additional_command_stdout.log
 
     if [ -n "~{default='' additional_command_to_run}" ]; then

--- a/pipes/WDL/tasks/tasks_terra.wdl
+++ b/pipes/WDL/tasks/tasks_terra.wdl
@@ -57,6 +57,11 @@ task get_gcloud_env_info {
     echo "WORKSPACE_NAMESPACE: ${WORKSPACE_NAMESPACE}"
     echo "WORKSPACE_NAME:      ${WORKSPACE_NAME}"
 
+    curl -X 'GET' \
+    "https://leonardo.dsde-dev.broadinstitute.org/api/google/v1/apps/${GOOGLE_PROJECT_ID}" \
+    -H 'accept: text/plain' \
+    -H "Authorization: Bearer $(gcloud auth print-access-token)"
+
     touch additional_command_stdout.log
 
     if [ -n "~{default='' additional_command_to_run}" ]; then

--- a/pipes/WDL/tasks/tasks_terra.wdl
+++ b/pipes/WDL/tasks/tasks_terra.wdl
@@ -100,7 +100,7 @@ task get_gcloud_env_info {
     String google_project_id_out   = read_string("google_project_id.txt")
   }
   runtime {
-    docker: "quay.io/broadinstitute/viral-baseimage:0.1.20"
+    docker: "quay.io/broadinstitute/ncbi-tools:2.10.7.10"
     memory: "1 GB"
     cpu: 1
     maxRetries: 1

--- a/pipes/WDL/tasks/tasks_terra.wdl
+++ b/pipes/WDL/tasks/tasks_terra.wdl
@@ -51,6 +51,9 @@ task check_terra_env {
     # write system environment variables to output file
     env | tee -a env_info.log
 
+    GOOGLE_PROJECT_ID="$(gcloud config list --format='value(core.project)')"
+    echo "$GOOGLE_PROJECT_ID" > google_project_id.txt
+
     # check whether gcloud project has a "terra-" prefix
     # to determine if running on Terra
     if case ${GOOGLE_PROJECT_ID} in terra-*) ;; *) false;; esac; then
@@ -78,9 +81,6 @@ task check_terra_env {
       echo "Running on Terra+GCP"
 
       # === Determine Terra workspace name and namespace for the workspace responsible for this job
-
-      GOOGLE_PROJECT_ID="$(gcloud config list --format='value(core.project)')"
-      echo "$GOOGLE_PROJECT_ID" > google_project_id.txt
 
       # get list of workspaces, limiting the output to only the fields we need
       curl -s -X 'GET' \

--- a/pipes/WDL/tasks/tasks_terra.wdl
+++ b/pipes/WDL/tasks/tasks_terra.wdl
@@ -32,9 +32,9 @@ task gcs_copy {
 
 task get_gcloud_env_info {
   input {
-    String workspace_name
-    String workspace_namespace
-    String workspace_googleProject
+    String? workspace_name
+    String? workspace_namespace
+    String? workspace_googleProject
 
     String? additional_command_to_run
   }

--- a/pipes/WDL/tasks/tasks_terra.wdl
+++ b/pipes/WDL/tasks/tasks_terra.wdl
@@ -47,6 +47,7 @@ task check_terra_env {
     # create Terra-related output files
     touch workspace_name.txt
     touch workspace_namespace.txt
+    touch workspace_bucket_path.txt
 
     # write system environment variables to output file
     env | tee -a env_info.log
@@ -84,7 +85,7 @@ task check_terra_env {
 
       # get list of workspaces, limiting the output to only the fields we need
       curl -s -X 'GET' \
-      'https://api.firecloud.org/api/workspaces?fields=workspace.name%2Cworkspace.namespace%2Cworkspace.googleProject' \
+      'https://api.firecloud.org/api/workspaces?fields=workspace.name%2Cworkspace.namespace%2Cworkspace.bucketName%2Cworkspace.googleProject' \
       -H 'accept: application/json' \
       -H "Authorization: Bearer $(gcloud auth print-access-token)" > workspace_list.json
 
@@ -95,21 +96,26 @@ task check_terra_env {
       # extract workspace namespace
       WORKSPACE_NAMESPACE=$(jq -cr '.[] | select( .workspace.googleProject == "'${GOOGLE_PROJECT_ID}'" ).workspace | .namespace' workspace_list.json)
       echo "$WORKSPACE_NAMESPACE" | tee workspace_namespace.txt
+
+      # extract workspace bucket
+      WORKSPACE_BUCKET=$(jq -cr '.[] | select( .workspace.googleProject == "'${GOOGLE_PROJECT_ID}'" ).workspace | .bucketName' workspace_list.json)
+      echo "gs://${WORKSPACE_BUCKET}" | tee workspace_bucket_path.txt
     else 
       echo "Not running on Terra+GCP"
     fi
 
   >>>
   output {
-    Boolean is_running_on_terra = read_boolean("RUNNING_ON_TERRA")
-    Boolean is_backed_by_gcp    = read_boolean("RUNNING_ON_GCP")
+    Boolean is_running_on_terra  = read_boolean("RUNNING_ON_TERRA")
+    Boolean is_backed_by_gcp     = read_boolean("RUNNING_ON_GCP")
 
-    String workspace_name       = read_string("workspace_name.txt")
-    String workspace_namespace  = read_string("workspace_namespace.txt")
-    String google_project_id    = read_string("google_project_id.txt")
+    String workspace_name        = read_string("workspace_name.txt")
+    String workspace_namespace   = read_string("workspace_namespace.txt")
+    String workspace_bucket_path = read_string("workspace_bucket_path.txt")
+    String google_project_id     = read_string("google_project_id.txt")
 
-    File env_info               = "env_info.log"
-    File gcloud_config_info     = "gcloud_config_info.log"
+    File env_info                = "env_info.log"
+    File gcloud_config_info      = "gcloud_config_info.log"
   }
   runtime {
     docker: docker
@@ -249,3 +255,4 @@ task download_entities_tsv {
     File tsv_file = '~{outname}'
   }
 }
+

--- a/pipes/WDL/tasks/tasks_terra.wdl
+++ b/pipes/WDL/tasks/tasks_terra.wdl
@@ -87,16 +87,20 @@ task check_terra_env {
 
       # Scrape out various workflow / workspace info from the localization and delocalization scripts.
       #   from: https://github.com/broadinstitute/gatk/blob/ah_var_store/scripts/variantstore/wdl/GvsUtils.wdl#L35-L40
-      sed -n -E 's!.*gs://fc-(secure-)?([^\/]+).*!\2!p' /cromwell_root/gcs_delocalization.sh | sort -u 
-      sed -n -E 's!.*(gs://(fc-(secure-)?[^\/]+)).*!\1!p' /cromwell_root/gcs_delocalization.sh | sort -u 
+      WORKSPACE_ID="$(sed -n -E 's!.*gs://fc-(secure-)?([^\/]+).*!\2!p' /cromwell_root/gcs_delocalization.sh | sort -u | tee workspace_id.txt)"
+      echo "WORKSPACE_ID: ${WORKSPACE_ID}"
+
+      # bucket path prefix
+      #BUCKET_PREFIX="$(sed -n -E 's!.*(gs://(fc-(secure-)?[^\/]+)).*!\1!p' /cromwell_root/gcs_delocalization.sh | sort -u | tee bucket_prefix.txt)"
+      #echo "BUCKET_PREFIX: ${BUCKET_PREFIX}"
 
       # top-level submission ID
-      TOP_LEVEL_SUBMISSION_ID="$(sed -n -E 's!.*gs://fc-(secure-)?([^\/]+)/submissions/([^\/]+).*!\3!p' /cromwell_root/gcs_delocalization.sh | sort -u)"
+      TOP_LEVEL_SUBMISSION_ID="$(sed -n -E 's!.*gs://fc-(secure-)?([^\/]+)/submissions/([^\/]+).*!\3!p' /cromwell_root/gcs_delocalization.sh | sort -u | tee top_level_submission_id.txt)"
       echo "TOP_LEVEL_SUBMISSION_ID: ${TOP_LEVEL_SUBMISSION_ID}"
+
       # workflow job ID within submission
       sed -n -E 's!.*gs://fc-(secure-)?([^\/]+)/submissions/([^\/]+)/([^\/]+)/([^\/]+).*!\5!p' /cromwell_root/gcs_delocalization.sh | sort -u 
-
-      sed -n -E 's!.*(terra-[0-9a-f]+).*# project to use if requester pays$!\1!p' /cromwell_root/gcs_localization.sh | sort -u 
+      #sed -n -E 's!.*(terra-[0-9a-f]+).*# project to use if requester pays$!\1!p' /cromwell_root/gcs_localization.sh | sort -u 
 
       # MORE DIRECT IF BUCKET PATH IS KNOWN:
       #curl -X 'GET' \
@@ -141,18 +145,23 @@ task check_terra_env {
 
   >>>
   output {
-    Boolean is_running_on_terra  = read_boolean("RUNNING_ON_TERRA")
-    Boolean is_backed_by_gcp     = read_boolean("RUNNING_ON_GCP")
+    Boolean is_running_on_terra    = read_boolean("RUNNING_ON_TERRA")
+    Boolean is_backed_by_gcp       = read_boolean("RUNNING_ON_GCP")
 
-    String workspace_name        = read_string("workspace_name.txt")
-    String workspace_namespace   = read_string("workspace_namespace.txt")
-    String workspace_bucket_path = read_string("workspace_bucket_path.txt")
-    String google_project_id     = read_string("google_project_id.txt")
-    String input_table_name      = read_string("input_table_name.txt")
-    String input_row_id          = read_string("input_row_id.txt")
+    String google_project_id       = read_string("google_project_id.txt")
 
-    File env_info                = "env_info.log"
-    File gcloud_config_info      = "gcloud_config_info.log"
+    String workspace_id            = read_string("workspace_id.txt")
+    String workspace_name          = read_string("workspace_name.txt")
+    String workspace_namespace     = read_string("workspace_namespace.txt")
+    String workspace_bucket_path   = read_string("workspace_bucket_path.txt")    
+
+    String input_table_name        = read_string("input_table_name.txt")
+    String input_row_id            = read_string("input_row_id.txt")
+
+    String top_level_submission_id = read_string("top_level_submission_id.txt")
+
+    File env_info                  = "env_info.log"
+    File gcloud_config_info        = "gcloud_config_info.log"
   }
   runtime {
     docker: docker

--- a/pipes/WDL/tasks/tasks_terra.wdl
+++ b/pipes/WDL/tasks/tasks_terra.wdl
@@ -45,9 +45,11 @@ task get_gcloud_env_info {
   command <<<
     set -ex
 
+    # ========== method 1: from google project IAM label metadata
     gcloud auth print-access-token
 
     GOOGLE_PROJECT_ID="$(gcloud config list --format='value(core.project)')"
+    echo "$GOOGLE_PROJECT_ID" > google_project_id.txt
 
     #get project namespace:
     WORKSPACE_NAMESPACE="$(gcloud projects describe $GOOGLE_PROJECT_ID --format='value(labels.workspacenamespace)')"
@@ -57,12 +59,23 @@ task get_gcloud_env_info {
     echo "WORKSPACE_NAMESPACE: ${WORKSPACE_NAMESPACE}"
     echo "WORKSPACE_NAME:      ${WORKSPACE_NAME}"
 
-    ls -lah /cromwell_root
+    # ========== method 2: matching a project returned by the API based on the google project ID
 
+    # get list of workspaces, limiting the output to only the fields we need
     curl -X 'GET' \
-    "https://leonardo.dsde-dev.broadinstitute.org/api/google/v1/apps/${GOOGLE_PROJECT_ID}" \
-    -H 'accept: text/plain' \
-    -H "Authorization: Bearer $(gcloud auth print-access-token)"
+    'https://api.firecloud.org/api/workspaces?fields=workspace.name%2Cworkspace.namespace%2Cworkspace.googleProject' \
+    -H 'accept: application/json' \
+    -H "Authorization: Bearer $(gcloud auth print-access-token)" > workspace_list.json
+
+    # extract workspace name
+    WORKSPACE_NAME=$(jq -cr '.[] | select( .workspace.googleProject == "terra-bf70b335" ).workspace | .name' workspace_list.json)
+    echo "$WORKSPACE_NAME" > workspace_name.txt
+    
+    # extract workspace namespace
+    WORKSPACE_NAMESPACE=$(jq -cr '.[] | select( .workspace.googleProject == "terra-bf70b335" ).workspace | .namespace' workspace_list.json)
+    echo "$WORKSPACE_NAMESPACE" > workspace_namespace.txt
+
+    # ======================================================================================
 
     touch additional_command_stdout.log
 
@@ -80,6 +93,10 @@ task get_gcloud_env_info {
   output {
     Array[String] env_info_files            = glob("./*_info.log")
     File          additional_command_stdout = "additional_command_stdout.log"
+    
+    String workspace_name      = read_string("workspace_name.txt")
+    String workspace_namespace = read_string("workspace_namespace.txt")
+    String google_project_id   = read_string("google_project_id.txt")
   }
   runtime {
     docker: "quay.io/broadinstitute/viral-baseimage:0.1.20"

--- a/pipes/WDL/tasks/tasks_terra.wdl
+++ b/pipes/WDL/tasks/tasks_terra.wdl
@@ -45,7 +45,11 @@ task get_gcloud_env_info {
   command {
     set -ex
 
-    ~{additional_command_to_run} ~{if additional_command_to_run then "| tee -a additional_command_stdout.log" else ""}
+    touch additional_command_stdout.log
+
+    if [ -n "~{default='' additional_command_to_run}" ]; then
+      ~{default='echo ""' additional_command_to_run} | tee -a additional_command_stdout.log
+    fi
 
     env | tee -a env_info.log
     

--- a/pipes/WDL/tasks/tasks_terra.wdl
+++ b/pipes/WDL/tasks/tasks_terra.wdl
@@ -48,6 +48,8 @@ task get_gcloud_env_info {
     echo "~{WORKSPACE_NAMESPACE}"
     echo "~{WORKSPACE_NAME}"
 
+    gcloud auth print-access-token
+
     touch additional_command_stdout.log
 
     if [ -n "~{default='' additional_command_to_run}" ]; then

--- a/pipes/WDL/tasks/tasks_terra.wdl
+++ b/pipes/WDL/tasks/tasks_terra.wdl
@@ -32,6 +32,10 @@ task gcs_copy {
 
 task get_gcloud_env_info {
   input {
+    String workspace_name
+    String workspace_namespace
+    String workspace_googleProject
+
     String? additional_command_to_run
   }
   meta {
@@ -74,6 +78,15 @@ task get_gcloud_env_info {
     # extract workspace namespace
     WORKSPACE_NAMESPACE=$(jq -cr '.[] | select( .workspace.googleProject == "terra-bf70b335" ).workspace | .namespace' workspace_list.json)
     echo "$WORKSPACE_NAMESPACE" > workspace_namespace.txt
+
+    # ========== method 3: resolved by Terra as inputs
+
+    echo ""
+    echo "Strings passed in to workflow:"
+    echo "workspace.name: ~{workspace_name}"
+    echo "workspace.namespace: ~{workspace_namespace}"
+    echo "workspace.googleProject: ~{workspace_googleProject}"
+    echo ""
 
     # ======================================================================================
 

--- a/pipes/WDL/tasks/tasks_terra.wdl
+++ b/pipes/WDL/tasks/tasks_terra.wdl
@@ -45,7 +45,7 @@ task get_gcloud_env_info {
   command {
     set -ex
 
-    ~{additional_command_to_run} | tee -a additional_command_stdout.log
+    ~{additional_command_to_run} ~{if additional_command_to_run then "| tee -a additional_command_stdout.log" else ""}
 
     env | tee -a env_info.log
     

--- a/pipes/WDL/tasks/tasks_terra.wdl
+++ b/pipes/WDL/tasks/tasks_terra.wdl
@@ -47,7 +47,15 @@ task get_gcloud_env_info {
 
     gcloud auth print-access-token
 
-    gcloud config list --format='text(core.project)'
+    GOOGLE_PROJECT_ID="$(gcloud config list --format='value(core.project)')"
+
+    #get project namespace:
+    WORKSPACE_NAMESPACE="$(gcloud projects describe $GOOGLE_PROJECT_ID --format='value(labels.workspacenamespace)')"
+    WORKSPACE_NAME="$(gcloud projects describe $GOOGLE_PROJECT_ID --format='value(labels.workspacename)')"
+
+    echo "GOOGLE_PROJECT_ID:   ${GOOGLE_PROJECT_ID}"
+    echo "WORKSPACE_NAMESPACE: ${WORKSPACE_NAMESPACE}"
+    echo "WORKSPACE_NAME:      ${WORKSPACE_NAME}"
 
     touch additional_command_stdout.log
 

--- a/pipes/WDL/tasks/tasks_terra.wdl
+++ b/pipes/WDL/tasks/tasks_terra.wdl
@@ -42,6 +42,7 @@ task check_terra_env {
 
     # create gcloud-related output file
     touch gcloud_config_info.log
+    touch google_project_id.txt
 
     # create Terra-related output files
     touch workspace_name.txt
@@ -79,6 +80,7 @@ task check_terra_env {
       # === Determine Terra workspace name and namespace for the workspace responsible for this job
 
       GOOGLE_PROJECT_ID="$(gcloud config list --format='value(core.project)')"
+      echo "$GOOGLE_PROJECT_ID" > google_project_id.txt
 
       # get list of workspaces, limiting the output to only the fields we need
       curl -s -X 'GET' \

--- a/pipes/WDL/tasks/tasks_terra.wdl
+++ b/pipes/WDL/tasks/tasks_terra.wdl
@@ -91,7 +91,8 @@ task check_terra_env {
       sed -n -E 's!.*(gs://(fc-(secure-)?[^\/]+)).*!\1!p' /cromwell_root/gcs_delocalization.sh | sort -u 
 
       # top-level submission ID
-      sed -n -E 's!.*gs://fc-(secure-)?([^\/]+)/submissions/([^\/]+).*!\3!p' /cromwell_root/gcs_delocalization.sh | sort -u 
+      TOP_LEVEL_SUBMISSION_ID="$(sed -n -E 's!.*gs://fc-(secure-)?([^\/]+)/submissions/([^\/]+).*!\3!p' /cromwell_root/gcs_delocalization.sh | sort -u)"
+      echo "TOP_LEVEL_SUBMISSION_ID: ${TOP_LEVEL_SUBMISSION_ID}"
       # workflow job ID within submission
       sed -n -E 's!.*gs://fc-(secure-)?([^\/]+)/submissions/([^\/]+)/([^\/]+)/([^\/]+).*!\5!p' /cromwell_root/gcs_delocalization.sh | sort -u 
 
@@ -124,7 +125,7 @@ task check_terra_env {
 
       touch submission_metadata.json
       curl -s -X 'GET' \
-      "https://api.firecloud.org/api/workspaces/${WORKSPACE_NAMESPACE}/${WORKSPACE_NAME_URL_ENCODED}/submissions/d4b0ecfd-a630-431f-ad82-d95eefa7ed2f" \
+      "https://api.firecloud.org/api/workspaces/${WORKSPACE_NAMESPACE}/${WORKSPACE_NAME_URL_ENCODED}/submissions/${TOP_LEVEL_SUBMISSION_ID}" \
       -H 'accept: application/json' \
       -H "Authorization: Bearer $(gcloud auth print-access-token)" > submission_metadata.json
 

--- a/pipes/WDL/tasks/tasks_terra.wdl
+++ b/pipes/WDL/tasks/tasks_terra.wdl
@@ -85,12 +85,6 @@ task get_gcloud_env_info {
 
     # ======================================================================================
 
-    #touch additional_command_stdout.log
-
-    #if [ -n "~{default='' additional_command_to_run}" ]; then
-    #  ~{default='echo ""' additional_command_to_run} | tee -a additional_command_stdout.log
-    #fi
-
     env | tee -a env_info.log
     
     gcloud config list | tee -a gcloud_config_info.log
@@ -99,8 +93,7 @@ task get_gcloud_env_info {
 
   >>>
   output {
-    Array[String] env_info_files            = glob("./*_info.log")
-    #File          additional_command_stdout = "additional_command_stdout.log"
+    Array[String] env_info_files   = glob("./*_info.log")
     
     String workspace_name_out      = read_string("workspace_name.txt")
     String workspace_namespace_out = read_string("workspace_namespace.txt")

--- a/pipes/WDL/tasks/tasks_terra.wdl
+++ b/pipes/WDL/tasks/tasks_terra.wdl
@@ -30,6 +30,42 @@ task gcs_copy {
   }
 }
 
+task get_gcloud_env_info {
+  input {
+    String? additional_command_to_run
+  }
+  meta {
+    description: "task for inspection of backend env, and optionally running a command"
+  }
+  parameter_meta {
+    additional_command_to_run: {
+      description: "Command that can optionally be included and executed as part of this task"
+    }
+  }
+  command {
+    set -ex
+
+    ~{additional_command_to_run} | tee -a additional_command_stdout.log
+
+    env | tee -a env_info.log
+    
+    gcloud config list | tee -a gcloud_config_info.log
+    
+    gcloud info | tee -a gcloud_env_info.log
+
+  }
+  output {
+    Array[String] env_info_files            = glob("./*_info.log")
+    File          additional_command_stdout = "additional_command_stdout.log"
+  }
+  runtime {
+    docker: "quay.io/broadinstitute/viral-baseimage:0.1.20"
+    memory: "1 GB"
+    cpu: 1
+    maxRetries: 1
+  }
+}
+
 task upload_reads_assemblies_entities_tsv {
   input {
     String        workspace_name

--- a/pipes/WDL/tasks/tasks_terra.wdl
+++ b/pipes/WDL/tasks/tasks_terra.wdl
@@ -57,6 +57,8 @@ task get_gcloud_env_info {
     echo "WORKSPACE_NAMESPACE: ${WORKSPACE_NAMESPACE}"
     echo "WORKSPACE_NAME:      ${WORKSPACE_NAME}"
 
+    ls -lah /cromwell_root
+
     curl -X 'GET' \
     "https://leonardo.dsde-dev.broadinstitute.org/api/google/v1/apps/${GOOGLE_PROJECT_ID}" \
     -H 'accept: text/plain' \

--- a/pipes/WDL/tasks/tasks_terra.wdl
+++ b/pipes/WDL/tasks/tasks_terra.wdl
@@ -100,7 +100,7 @@ task get_gcloud_env_info {
     String google_project_id_out   = read_string("google_project_id.txt")
   }
   runtime {
-    docker: "quay.io/broadinstitute/ncbi-tools:2.10.7.10"
+    docker: "quay.io/broadinstitute/viral-core:2.2.2"
     memory: "1 GB"
     cpu: 1
     maxRetries: 1

--- a/pipes/WDL/tasks/tasks_terra.wdl
+++ b/pipes/WDL/tasks/tasks_terra.wdl
@@ -42,8 +42,11 @@ task get_gcloud_env_info {
       description: "Command that can optionally be included and executed as part of this task"
     }
   }
-  command {
+  command <<<
     set -ex
+
+    echo "~{WORKSPACE_NAMESPACE}"
+    echo "~{WORKSPACE_NAME}"
 
     touch additional_command_stdout.log
 
@@ -57,7 +60,7 @@ task get_gcloud_env_info {
     
     gcloud info | tee -a gcloud_env_info.log
 
-  }
+  >>>
   output {
     Array[String] env_info_files            = glob("./*_info.log")
     File          additional_command_stdout = "additional_command_stdout.log"

--- a/pipes/WDL/tasks/tasks_terra.wdl
+++ b/pipes/WDL/tasks/tasks_terra.wdl
@@ -68,7 +68,7 @@ task get_gcloud_env_info {
     GOOGLE_PROJECT_ID="$(gcloud config list --format='value(core.project)')"
 
     # get list of workspaces, limiting the output to only the fields we need
-    curl -X 'GET' \
+    curl -s -X 'GET' \
     'https://api.firecloud.org/api/workspaces?fields=workspace.name%2Cworkspace.namespace%2Cworkspace.googleProject' \
     -H 'accept: application/json' \
     -H "Authorization: Bearer $(gcloud auth print-access-token)" > workspace_list.json

--- a/pipes/WDL/tasks/tasks_terra.wdl
+++ b/pipes/WDL/tasks/tasks_terra.wdl
@@ -83,6 +83,21 @@ task check_terra_env {
 
       # === Determine Terra workspace name and namespace for the workspace responsible for this job
 
+      # Scrape out various workflow / workspace info from the localization and delocalization scripts.
+      #   from: https://github.com/broadinstitute/gatk/blob/ah_var_store/scripts/variantstore/wdl/GvsUtils.wdl#L35-L40
+      sed -n -E 's!.*gs://fc-(secure-)?([^\/]+).*!\2!p' /cromwell_root/gcs_delocalization.sh | sort -u 
+      sed -n -E 's!.*(gs://(fc-(secure-)?[^\/]+)).*!\1!p' /cromwell_root/gcs_delocalization.sh | sort -u 
+      sed -n -E 's!.*gs://fc-(secure-)?([^\/]+)/submissions/([^\/]+).*!\3!p' /cromwell_root/gcs_delocalization.sh | sort -u 
+      sed -n -E 's!.*gs://fc-(secure-)?([^\/]+)/submissions/([^\/]+)/([^\/]+)/([^\/]+).*!\5!p' /cromwell_root/gcs_delocalization.sh | sort -u 
+      sed -n -E 's!.*(terra-[0-9a-f]+).*# project to use if requester pays$!\1!p' /cromwell_root/gcs_localization.sh | sort -u 
+
+      # MORE DIRECT IF BUCKET PATH IS KNOWN:
+      #curl -X 'GET' \
+      #  'https://rawls.dsde-prod.broadinstitute.org/api/workspaces/id/8819db8a-7afb-4a27-97e2-6c314968b421?fields=workspace.name%2Cworkspace.namespace' \
+      #  -H 'accept: application/json' \
+      #  -H 'Authorization: Bearer ya29.a0AfB_byDnTCv4_f-qON3w2_z-zFv8Px1_sA1xy8n2Q4MD4suiWyi6YGCYNTs-QXI8VN50COKFT5FtrN05FpWtgPfGv8EZcAxBGNw3TRkYSIbDfbOgRzRVmHe2fmcompALhnHXbVC837qHqUeit1cD22rhwxZQX3EpP2APaCgYKAS0SARMSFQGOcNnCnzFNqCJPvZrC7iHFMed00w0171'
+
+
       # get list of workspaces, limiting the output to only the fields we need
       curl -s -X 'GET' \
       'https://api.firecloud.org/api/workspaces?fields=workspace.name%2Cworkspace.namespace%2Cworkspace.bucketName%2Cworkspace.googleProject' \
@@ -256,3 +271,39 @@ task download_entities_tsv {
   }
 }
 
+task create_or_update_sample_tables {
+  input {
+    String flowcell_run_id
+
+    String workspace_namespace
+    String workspace_name
+    String workspace_bucket
+
+    String  docker = "quay.io/broadinstitute/viral-core:2.2.2" #skip-global-version-pin
+  }
+
+  meta {
+    volatile: true
+  }
+
+  command <<<
+    python3<<CODE
+
+    workspace_project = '~{workspace_namespace}'
+    workspace_name    = '~{workspace_name}'
+    workspace_bucket  = '~{workspace_bucket}'
+    table_name        = ''
+
+    CODE
+  >>>
+  runtime {
+    docker: docker
+    memory: "2 GB"
+    cpu: 1
+    maxRetries: 2
+  }
+  output {
+    File stdout_log = stdout()
+    File stderr_log = stderr()
+  }
+}

--- a/pipes/WDL/workflows/dump_gcloud_env_info.wdl
+++ b/pipes/WDL/workflows/dump_gcloud_env_info.wdl
@@ -14,19 +14,22 @@ workflow dump_gcloud_env_info {
     call terra.check_terra_env
 
     output {
-        Boolean is_running_on_terra   = check_terra_env.is_running_on_terra
-        Boolean is_backed_by_gcp      = check_terra_env.is_backed_by_gcp
+        Boolean is_running_on_terra     = check_terra_env.is_running_on_terra
+        Boolean is_backed_by_gcp        = check_terra_env.is_backed_by_gcp
 
-        String  workspace_name        = check_terra_env.workspace_name
-        String  workspace_namespace   = check_terra_env.workspace_namespace
-        String  workspace_bucket_path = check_terra_env.workspace_bucket_path
+        String  google_project_id       = check_terra_env.google_project_id
+
+        String  workspace_id            = check_terra_env.workspace_id
+        String  workspace_name          = check_terra_env.workspace_name
+        String  workspace_namespace     = check_terra_env.workspace_namespace
+        String  workspace_bucket_path   = check_terra_env.workspace_bucket_path
         
-        String  input_table_name      = check_terra_env.input_table_name
-        String  input_row_id          = check_terra_env.input_row_id
+        String  input_table_name        = check_terra_env.input_table_name
+        String  input_row_id            = check_terra_env.input_row_id
 
-        String  google_project_id     = check_terra_env.google_project_id
+        String  top_level_submission_id = check_terra_env.top_level_submission_id
 
-        File    env_info              = check_terra_env.env_info
-        File    gcloud_config_info    = check_terra_env.gcloud_config_info
+        File    env_info                = check_terra_env.env_info
+        File    gcloud_config_info      = check_terra_env.gcloud_config_info
     }
 }

--- a/pipes/WDL/workflows/dump_gcloud_env_info.wdl
+++ b/pipes/WDL/workflows/dump_gcloud_env_info.wdl
@@ -20,6 +20,9 @@ workflow dump_gcloud_env_info {
         String  workspace_name        = check_terra_env.workspace_name
         String  workspace_namespace   = check_terra_env.workspace_namespace
         String  workspace_bucket_path = check_terra_env.workspace_bucket_path
+        
+        String  input_table_name      = check_terra_env.input_table_name
+        String  input_row_id          = check_terra_env.input_row_id
 
         String  google_project_id     = check_terra_env.google_project_id
 

--- a/pipes/WDL/workflows/dump_gcloud_env_info.wdl
+++ b/pipes/WDL/workflows/dump_gcloud_env_info.wdl
@@ -17,8 +17,8 @@ workflow dump_gcloud_env_info {
         Array[String] gcloud_env_info_files     = get_gcloud_env_info.env_info_files
         File          additional_command_stdout = get_gcloud_env_info.additional_command_stdout
         
-        String workspace_name_out      = get_gcloud_env_info.workspace_name
-        String workspace_namespace_out = get_gcloud_env_info.workspace_namespace
-        String google_project_id_out   = get_gcloud_env_info.google_project_id
+        String workspace_name_out      = get_gcloud_env_info.workspace_name_out
+        String workspace_namespace_out = get_gcloud_env_info.workspace_namespace_out
+        String google_project_id_out   = get_gcloud_env_info.google_project_id_out
     }
 }

--- a/pipes/WDL/workflows/dump_gcloud_env_info.wdl
+++ b/pipes/WDL/workflows/dump_gcloud_env_info.wdl
@@ -1,0 +1,20 @@
+version 1.0
+
+#DX_SKIP_WORKFLOW
+
+import "../tasks/tasks_terra.wdl" as terra
+
+workflow dump_gcloud_env_info {
+    meta {
+        description: "Write system and gcloud environment info to output files."
+        author: "Broad Viral Genomics"
+        email:  "viral-ngs@broadinstitute.org"
+    }
+
+    call terra.get_gcloud_env_info
+
+    output {
+        Array[String] gcloud_env_info_files     = get_gcloud_env_info.env_info_files
+        File          additional_command_stdout = get_gcloud_env_info.additional_command_stdout
+    }
+}

--- a/pipes/WDL/workflows/dump_gcloud_env_info.wdl
+++ b/pipes/WDL/workflows/dump_gcloud_env_info.wdl
@@ -16,5 +16,9 @@ workflow dump_gcloud_env_info {
     output {
         Array[String] gcloud_env_info_files     = get_gcloud_env_info.env_info_files
         File          additional_command_stdout = get_gcloud_env_info.additional_command_stdout
+        
+        String workspace_name      = get_gcloud_env_info.workspace_name
+        String workspace_namespace = get_gcloud_env_info.workspace_namespace
+        String google_project_id   = get_gcloud_env_info.google_project_id
     }
 }

--- a/pipes/WDL/workflows/dump_gcloud_env_info.wdl
+++ b/pipes/WDL/workflows/dump_gcloud_env_info.wdl
@@ -14,15 +14,16 @@ workflow dump_gcloud_env_info {
     call terra.check_terra_env
 
     output {
-        Boolean is_running_on_terra = check_terra_env.is_running_on_terra
-        Boolean is_backed_by_gcp    = check_terra_env.is_backed_by_gcp
+        Boolean is_running_on_terra   = check_terra_env.is_running_on_terra
+        Boolean is_backed_by_gcp      = check_terra_env.is_backed_by_gcp
 
-        String  workspace_name      = check_terra_env.workspace_name
-        String  workspace_namespace = check_terra_env.workspace_namespace
+        String  workspace_name        = check_terra_env.workspace_name
+        String  workspace_namespace   = check_terra_env.workspace_namespace
+        String  workspace_bucket_path = check_terra_env.workspace_bucket_path
 
-        String  google_project_id   = check_terra_env.google_project_id
+        String  google_project_id     = check_terra_env.google_project_id
 
-        File    env_info            = check_terra_env.env_info
-        File    gcloud_config_info  = check_terra_env.gcloud_config_info
+        File    env_info              = check_terra_env.env_info
+        File    gcloud_config_info    = check_terra_env.gcloud_config_info
     }
 }

--- a/pipes/WDL/workflows/dump_gcloud_env_info.wdl
+++ b/pipes/WDL/workflows/dump_gcloud_env_info.wdl
@@ -14,8 +14,7 @@ workflow dump_gcloud_env_info {
     call terra.get_gcloud_env_info
 
     output {
-        Array[String] gcloud_env_info_files     = get_gcloud_env_info.env_info_files
-        File          additional_command_stdout = get_gcloud_env_info.additional_command_stdout
+        Array[String] gcloud_env_info_files = get_gcloud_env_info.env_info_files
         
         String workspace_name_out      = get_gcloud_env_info.workspace_name_out
         String workspace_namespace_out = get_gcloud_env_info.workspace_namespace_out

--- a/pipes/WDL/workflows/dump_gcloud_env_info.wdl
+++ b/pipes/WDL/workflows/dump_gcloud_env_info.wdl
@@ -17,8 +17,8 @@ workflow dump_gcloud_env_info {
         Array[String] gcloud_env_info_files     = get_gcloud_env_info.env_info_files
         File          additional_command_stdout = get_gcloud_env_info.additional_command_stdout
         
-        String workspace_name      = get_gcloud_env_info.workspace_name
-        String workspace_namespace = get_gcloud_env_info.workspace_namespace
-        String google_project_id   = get_gcloud_env_info.google_project_id
+        String workspace_name_out      = get_gcloud_env_info.workspace_name
+        String workspace_namespace_out = get_gcloud_env_info.workspace_namespace
+        String google_project_id_out   = get_gcloud_env_info.google_project_id
     }
 }

--- a/pipes/WDL/workflows/dump_gcloud_env_info.wdl
+++ b/pipes/WDL/workflows/dump_gcloud_env_info.wdl
@@ -11,13 +11,18 @@ workflow dump_gcloud_env_info {
         email:  "viral-ngs@broadinstitute.org"
     }
 
-    call terra.get_gcloud_env_info
+    call terra.check_terra_env
 
     output {
-        Array[String] gcloud_env_info_files = get_gcloud_env_info.env_info_files
-        
-        String workspace_name_out      = get_gcloud_env_info.workspace_name_out
-        String workspace_namespace_out = get_gcloud_env_info.workspace_namespace_out
-        String google_project_id_out   = get_gcloud_env_info.google_project_id_out
+        Boolean is_running_on_terra = check_terra_env.is_running_on_terra
+        Boolean is_backed_by_gcp    = check_terra_env.is_backed_by_gcp
+
+        String  workspace_name      = check_terra_env.workspace_name
+        String  workspace_namespace = check_terra_env.workspace_namespace
+
+        String  google_project_id   = check_terra_env.google_project_id
+
+        File    env_info            = check_terra_env.env_info
+        File    gcloud_config_info  = check_terra_env.gcloud_config_info
     }
 }


### PR DESCRIPTION
This adds a new task, `check_terra_env`, which returns a number of fields related to the execution environment for a submitted job, including the following:

```WDL
    Boolean is_running_on_terra
    Boolean is_backed_by_gcp

    String google_project_id

    String workspace_id
    String workspace_name
    String workspace_namespace
    String workspace_bucket_path

    String input_table_name
    String input_row_id

    String top_level_submission_id

    File env_info # output of running 'env'
    File gcloud_config_info # output of 'gcloud info'
```
These fields can be used downstream for programmatic interaction with (Terra) backend systems.

A workflow is included to run the task in isolation, called `dump_gcloud_env_info`.
