### PR TITLE
expose numberOfNegativeControls in illumina_demux

### DIFF
--- a/pipes/WDL/tasks/tasks_demux.wdl
+++ b/pipes/WDL/tasks/tasks_demux.wdl
@@ -159,6 +159,7 @@ task illumina_demux {
     Int?    threads
     String? runStartDate
     Int?    maxRecordsInRam
+    Int?    numberOfNegativeControls
 
     Int?    machine_mem_gb
     Int     disk_size = 2625
@@ -337,7 +338,7 @@ task illumina_demux {
       --out_runinfo runinfo.json \
       --loglevel=DEBUG
 
-    illumina.py guess_barcodes --expected_assigned_fraction=0 barcodes.txt metrics.txt barcodes_outliers.txt
+    illumina.py guess_barcodes ~{'--number_of_negative_controls ' + numberOfNegativeControls} --expected_assigned_fraction=0 barcodes.txt metrics.txt barcodes_outliers.txt
 
     illumina.py flowcell_metadata --inDir $FLOWCELL_DIR flowcellMetadataFile.tsv
 


### PR DESCRIPTION
In the event demux is run with a samplesheet containing only one sample row, find_uncertain_barcodes() will fail since it assumes at least one NTC is present in the samplesheet. The changes in this commit allow the user to set this param to zero, which should allow outlier detection to succeed.