### PR TITLE
enable merge_group builds in github actions CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,7 @@ name: "viral-pipelines CI"
 
 on:
   push:
+  merge_group:
   pull_request:
     branches:
       - master


### PR DESCRIPTION
Adding this build hook to the default branch is a pre-requisite for enabling merge queue functionality in github.