### PR TITLE
add reconstructR workflow

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -259,6 +259,11 @@ workflows:
     primaryDescriptorPath: /pipes/WDL/workflows/nextclade_single.wdl
     testParameterFiles:
       - empty.json
+  - name: reconstruct_from_alignments
+    subclass: WDL
+    primaryDescriptorPath: /pipes/WDL/workflows/reconstruct_from_alignments.wdl
+    testParameterFiles:
+      - empty.json
   - name: sarscov2_batch_relineage
     subclass: WDL
     primaryDescriptorPath: /pipes/WDL/workflows/sarscov2_batch_relineage.wdl

--- a/pipes/WDL/tasks/tasks_interhost.wdl
+++ b/pipes/WDL/tasks/tasks_interhost.wdl
@@ -588,6 +588,7 @@ task reconstructr {
     cpu: cpus
     disks:  "local-disk " + disk_size + " HDD"
     disk: disk_size + " GB" # TES
+    bootDiskSizeGb: "50 GB"
     dx_instance_type: "mem1_ssd1_v2_x4"
     maxRetries: 1
   }

--- a/pipes/WDL/tasks/tasks_interhost.wdl
+++ b/pipes/WDL/tasks/tasks_interhost.wdl
@@ -574,12 +574,20 @@ task reconstructr {
 
     # compress outputs
     pigz -9 -p $(nproc) "~{out_basename}-tabulate.tsv" "~{out_basename}-decipher.tsv" "~{out_basename}-states.Rdata"
+
+    # profiling and stats
+    cat /proc/uptime | cut -f 1 -d ' ' > UPTIME_SEC
+    cat /proc/loadavg > CPU_LOAD
+    { if [ -f /sys/fs/cgroup/memory.peak ]; then cat /sys/fs/cgroup/memory.peak; elif [ -f /sys/fs/cgroup/memory/memory.peak ]; then cat /sys/fs/cgroup/memory/memory.peak; elif [ -f /sys/fs/cgroup/memory/memory.max_usage_in_bytes ]; then cat /sys/fs/cgroup/memory/memory.max_usage_in_bytes; else echo "0"; fi } > MEM_BYTES
   >>>
 
   output {
-    File tabulated_tsv_gz     = "~{out_basename}-tabulate.tsv.gz"
-    File deciphered_tsv_gz    = "~{out_basename}-decipher.tsv.gz"
-    File mcmc_states_Rdata_gz = "~{out_basename}-states.Rdata.gz"
+    File   tabulated_tsv_gz      = "~{out_basename}-tabulate.tsv.gz"
+    File   deciphered_tsv_gz     = "~{out_basename}-decipher.tsv.gz"
+    File   mcmc_states_Rdata_gz  = "~{out_basename}-states.Rdata.gz"
+    Int    max_ram_gb            = ceil(read_float("MEM_BYTES")/1000000000)
+    Int    runtime_sec           = ceil(read_float("UPTIME_SEC"))
+    String cpu_load              = read_string("CPU_LOAD")
   }
 
   runtime {

--- a/pipes/WDL/tasks/tasks_interhost.wdl
+++ b/pipes/WDL/tasks/tasks_interhost.wdl
@@ -588,7 +588,7 @@ task reconstructr {
     cpu: cpus
     disks:  "local-disk " + disk_size + " HDD"
     disk: disk_size + " GB" # TES
-    bootDiskSizeGb: "50 GB"
+    bootDiskSizeGb: 50
     dx_instance_type: "mem1_ssd1_v2_x4"
     maxRetries: 1
   }

--- a/pipes/WDL/tasks/tasks_interhost.wdl
+++ b/pipes/WDL/tasks/tasks_interhost.wdl
@@ -545,6 +545,7 @@ task reconstructr {
 
     Int          cpus = 8
     Int          machine_mem_gb = 15
+    Int          disk_size = 375
     String       docker = "ghcr.io/broadinstitute/reconstructr:main"
   }
 
@@ -552,7 +553,7 @@ task reconstructr {
     set -e -o pipefail
 
     # stage input files
-    mkdir -p input_data input_data/vcf
+    mkdir -p input_data input_data/vcf input_data/coverage
     /opt/reconstructR/scripts/cp_and_decompress.sh "~{msa_fasta}" input_data/aligned.fasta
     /opt/reconstructR/scripts/cp_and_decompress.sh "~{ref_fasta}" input_data/ref.fasta
     /opt/reconstructR/scripts/cp_and_decompress.sh "~{date_csv}" input_data/date.csv
@@ -585,6 +586,8 @@ task reconstructr {
     docker: docker
     memory: machine_mem_gb + " GB"
     cpu: cpus
+    disks:  "local-disk " + disk_size + " HDD"
+    disk: disk_size + " GB" # TES
     dx_instance_type: "mem1_ssd1_v2_x4"
     maxRetries: 1
   }

--- a/pipes/WDL/tasks/tasks_interhost.wdl
+++ b/pipes/WDL/tasks/tasks_interhost.wdl
@@ -562,7 +562,7 @@ task reconstructr {
     cp ~{sep=' ' lofreq_vcfs} input_data/vcf
 
     # run reconstructR
-    Rscript<<CODE
+    R --no-save<<CODE
       library(reconstructR)
       results <- run_mcmc(~{n_iters})
       p <- visualize(results)

--- a/pipes/WDL/tasks/tasks_ncbi_tools.wdl
+++ b/pipes/WDL/tasks/tasks_ncbi_tools.wdl
@@ -5,6 +5,7 @@ task Fetch_SRA_to_BAM {
     input {
         String  SRA_ID
 
+        String? sample_name
         Int?    machine_mem_gb
         String  docker = "quay.io/broadinstitute/ncbi-tools:2.10.7.10"
     }
@@ -26,6 +27,10 @@ task Fetch_SRA_to_BAM {
         SAMPLE=$(jq -r '.EXPERIMENT_PACKAGE_SET.EXPERIMENT_PACKAGE.SAMPLE.IDENTIFIERS.EXTERNAL_ID|select(.namespace == "BioSample")|.content' SRA.json)
         LIBRARY=$(jq -r .EXPERIMENT_PACKAGE_SET.EXPERIMENT_PACKAGE.EXPERIMENT.alias SRA.json)
         RUNDATE=$(jq -r '.EXPERIMENT_PACKAGE_SET.EXPERIMENT_PACKAGE.RUN_SET.RUN.SRAFiles|if (.SRAFile|type) == "object" then .SRAFile.date else [.SRAFile[]|select(.supertype == "Original")][0].date end' SRA.json | cut -f 1 -d ' ')
+
+        if [[ -n "~{sample_name}" ]]; then
+            SAMPLE="~{sample_name}"
+        fi
 
         if [ "$PLATFORM" = "OXFORD_NANOPORE" ]; then
             # per the SAM/BAM specification

--- a/pipes/WDL/tasks/tasks_read_utils.wdl
+++ b/pipes/WDL/tasks/tasks_read_utils.wdl
@@ -86,7 +86,7 @@ task get_bam_samplename {
     File    bam
     String  docker = "quay.io/broadinstitute/viral-core:2.1.33"
   }
-  Int   disk_size = size(bam) + 50
+  Int   disk_size = round(size(bam, "GB")) + 50
   command <<<
     set -e -o pipefail
     samtools view -H "~{bam}" | \

--- a/pipes/WDL/tasks/tasks_read_utils.wdl
+++ b/pipes/WDL/tasks/tasks_read_utils.wdl
@@ -103,7 +103,7 @@ task get_bam_samplename {
     maxRetries: 2
   }
   output {
-    String sample_name = read_string(SAMPLE_NAME)
+    String sample_name = read_string("SAMPLE_NAME")
   }
 }
 

--- a/pipes/WDL/tasks/tasks_read_utils.wdl
+++ b/pipes/WDL/tasks/tasks_read_utils.wdl
@@ -86,7 +86,7 @@ task get_bam_samplename {
     File    bam
     String  docker = "quay.io/broadinstitute/viral-core:2.1.33"
   }
-  Int   disk_size = 1.5 * size(bam) + 50
+  Int   disk_size = size(bam) + 50
   command <<<
     set -e -o pipefail
     samtools view -H "~{bam}" | \

--- a/pipes/WDL/tasks/tasks_read_utils.wdl
+++ b/pipes/WDL/tasks/tasks_read_utils.wdl
@@ -81,6 +81,32 @@ task group_bams_by_sample {
   }
 }
 
+task get_bam_samplename {
+  input {
+    File    bam
+    String  docker = "quay.io/broadinstitute/viral-core:2.1.33"
+  }
+  Int   disk_size = 1.5 * size(bam) + 50
+  command <<<
+    set -e -o pipefail
+    samtools view -H "~{bam}" | \
+      perl -lane 'if (/^\@RG\t.*SM:(\S+)/) { print "$1" }' | \
+      sort | uniq > SAMPLE_NAME
+  >>>
+  runtime {
+    docker: docker
+    memory: "1 GB"
+    cpu: 1
+    disks:  "local-disk " + disk_size + " HDD"
+    disk: disk_size + " GB" # TES
+    dx_instance_type: "mem1_ssd1_v2_x2"
+    maxRetries: 2
+  }
+  output {
+    String sample_name = read_string(SAMPLE_NAME)
+  }
+}
+
 task get_sample_meta {
   input {
     Array[File] samplesheets_extended

--- a/pipes/WDL/tasks/tasks_reports.wdl
+++ b/pipes/WDL/tasks/tasks_reports.wdl
@@ -238,7 +238,7 @@ task merge_coverage_per_position {
     # Loop through a list of file paths and read in each depth.tsv generated as part of assemble_refbased
     depths_dfs = []
     for in_tsv in ("~{sep='", "' coverage_tsvs}"):
-        sample_name = '.'.join(os.path.basename(in_tsv).split('.')[:-1])
+        sample_name = '.'.join(os.path.basename(in_tsv).split('.')[:-2])
         sample_depths_df = pd.read_csv(in_tsv, sep='\t', header=None
             ).rename(columns={0:'Ref',1:'Position',2:sample_name})
         depths_dfs.append(sample_depths_df)

--- a/pipes/WDL/tasks/tasks_reports.wdl
+++ b/pipes/WDL/tasks/tasks_reports.wdl
@@ -232,7 +232,7 @@ task merge_coverage_per_position {
     # get genome length
     genome_length = 0
     with open('~{ref_fasta}', 'rt') as inf:
-      for seq in Bio.SeqIO.parse(inf, 'fasta')
+      for seq in Bio.SeqIO.parse(inf, 'fasta'):
         genome_length += len(seq.seq.ungap())
 
     # Loop through a list of file paths and read in each depth.tsv generated as part of assemble_refbased

--- a/pipes/WDL/tasks/tasks_reports.wdl
+++ b/pipes/WDL/tasks/tasks_reports.wdl
@@ -210,6 +210,68 @@ task plot_coverage {
   }
 }
 
+task merge_coverage_per_position {
+  input {
+    Array[File]+ coverage_tsvs
+    File         ref_fasta
+
+    String       out_report_name = "coverage_report.csv"
+    Int          disk_size = 100
+    String       docker = "quay.io/broadinstitute/py3-bio:0.1.2"
+  }
+
+  command <<<
+    set -e
+
+    python3<<CODE
+      import os
+      import pandas as pd
+      from functools import reduce
+      import Bio.SeqIO
+
+      # get genome length
+      genome_length = 0
+      with open('~{ref_fasta}', 'rt') as inf:
+        for seq in Bio.SeqIO.parse(inf, 'fasta')
+          genome_length += len(seq.seq.ungap())
+
+      # Loop through a list of file paths and read in each depth.tsv generated as part of assemble_refbased
+      depths_dfs = []
+      for in_tsv in ("~{sep='", "' coverage_tsvs}"):
+          sample_name = '.'.join(os.path.basename(in_tsv).split('.')[:-1])
+          sample_depths_df = pd.read_csv(in_tsv, sep='\t', header=None
+              ).rename(columns={0:'Ref',1:'Position',2:sample_name})
+          depths_dfs.append(sample_depths_df)
+
+      # Condense all depths into a single dataframe
+      df_merged = reduce(lambda left,right:
+          pd.merge(left,right,on=['Ref','Position'],how='outer'),
+          depths_dfs)
+      df_merged = df_merged.fillna(0)
+
+      #Create dummy df that contains all positions along the genome
+      dummy_df = pd.DataFrame([range(1,genome_length)]).T.rename(columns={0:'Position'})
+      df_merged = df_merged.merge(dummy_df, on='Position', how='right').fillna(0)
+      df_merged = df_merged.drop(['Ref'], axis=1)
+      df_merged.to_csv("~{out_report_name}", index=False)
+    CODE
+  >>>
+
+  output {
+    File   coverage_multi_sample_per_position_csv  = out_report_name
+  }
+
+  runtime {
+    docker: "${docker}"
+    memory: "2 GB"
+    cpu: 2
+    disks:  "local-disk " + disk_size + " LOCAL"
+    disk: disk_size + " GB" # TES
+    dx_instance_type: "mem1_ssd2_v2_x4"
+    maxRetries: 2
+  }
+}
+
 task coverage_report {
   input {
     Array[File]+ mapped_bams

--- a/pipes/WDL/tasks/tasks_reports.wdl
+++ b/pipes/WDL/tasks/tasks_reports.wdl
@@ -224,36 +224,36 @@ task merge_coverage_per_position {
     set -e
 
     python3<<CODE
-      import os
-      import pandas as pd
-      from functools import reduce
-      import Bio.SeqIO
+    import os
+    import pandas as pd
+    from functools import reduce
+    import Bio.SeqIO
 
-      # get genome length
-      genome_length = 0
-      with open('~{ref_fasta}', 'rt') as inf:
-        for seq in Bio.SeqIO.parse(inf, 'fasta')
-          genome_length += len(seq.seq.ungap())
+    # get genome length
+    genome_length = 0
+    with open('~{ref_fasta}', 'rt') as inf:
+      for seq in Bio.SeqIO.parse(inf, 'fasta')
+        genome_length += len(seq.seq.ungap())
 
-      # Loop through a list of file paths and read in each depth.tsv generated as part of assemble_refbased
-      depths_dfs = []
-      for in_tsv in ("~{sep='", "' coverage_tsvs}"):
-          sample_name = '.'.join(os.path.basename(in_tsv).split('.')[:-1])
-          sample_depths_df = pd.read_csv(in_tsv, sep='\t', header=None
-              ).rename(columns={0:'Ref',1:'Position',2:sample_name})
-          depths_dfs.append(sample_depths_df)
+    # Loop through a list of file paths and read in each depth.tsv generated as part of assemble_refbased
+    depths_dfs = []
+    for in_tsv in ("~{sep='", "' coverage_tsvs}"):
+        sample_name = '.'.join(os.path.basename(in_tsv).split('.')[:-1])
+        sample_depths_df = pd.read_csv(in_tsv, sep='\t', header=None
+            ).rename(columns={0:'Ref',1:'Position',2:sample_name})
+        depths_dfs.append(sample_depths_df)
 
-      # Condense all depths into a single dataframe
-      df_merged = reduce(lambda left,right:
-          pd.merge(left,right,on=['Ref','Position'],how='outer'),
-          depths_dfs)
-      df_merged = df_merged.fillna(0)
+    # Condense all depths into a single dataframe
+    df_merged = reduce(lambda left,right:
+        pd.merge(left,right,on=['Ref','Position'],how='outer'),
+        depths_dfs)
+    df_merged = df_merged.fillna(0)
 
-      #Create dummy df that contains all positions along the genome
-      dummy_df = pd.DataFrame([range(1,genome_length)]).T.rename(columns={0:'Position'})
-      df_merged = df_merged.merge(dummy_df, on='Position', how='right').fillna(0)
-      df_merged = df_merged.drop(['Ref'], axis=1)
-      df_merged.to_csv("~{out_report_name}", index=False)
+    #Create dummy df that contains all positions along the genome
+    dummy_df = pd.DataFrame([range(1,genome_length)]).T.rename(columns={0:'Position'})
+    df_merged = df_merged.merge(dummy_df, on='Position', how='right').fillna(0)
+    df_merged = df_merged.drop(['Ref'], axis=1)
+    df_merged.to_csv("~{out_report_name}", index=False)
     CODE
   >>>
 

--- a/pipes/WDL/workflows/reconstruct_from_alignments.wdl
+++ b/pipes/WDL/workflows/reconstruct_from_alignments.wdl
@@ -1,0 +1,62 @@
+version 1.0
+
+import "../tasks/tasks_interhost.wdl" as interhost
+import "../tasks/tasks_intrahost.wdl" as intrahost
+import "../tasks/tasks_nextstrain.wdl" as nextstrain
+import "../tasks/tasks_reports.wdl" as reports
+import "../tasks/tasks_utils.wdl" as utils
+
+workflow reconstruct_from_alignments {
+    meta {
+        description: "TO DO"
+        author: "Broad Viral Genomics"
+        email:  "viral-ngs@broadinstitute.org"
+        allowNestedInputs: true
+    }
+
+    input {
+        Array[File]+   aligned_trimmed_bams
+        Array[File]+   assembly_fastas
+        File           ref_fasta
+    }
+
+    # create multiple sequence alignment of fastas
+    call nextstrain.mafft_one_chr as mafft {
+        input:
+            sequences = assembly_fasta,
+            ref_fasta = ref_fasta,
+            basename  = "all_samples_aligned.fasta"
+    }
+
+    # call iSNVs with lofreq and calculate coverage depths
+    scatter(bam in aligned_trimmed_bams) {
+        call intrahost.lofreq as isnvs_ref {
+            input:
+                reference_fasta = ref_fasta,
+                aligned_bam     = bam
+        }
+        call reports.plot_coverage as plot_ref_coverage {
+            input:
+                aligned_reads_bam = bam,
+                sample_name       = basename(bam, '.bam')
+        }
+    }
+
+    # TO DO: create depth_csv from plot_ref_coverage.coverage_tsv
+
+    # call reconstructR
+    call interhost.reconstructr {
+        input:
+            ref_fasta = ref_fasta,
+            lofreq_vcfs = isnvs_ref.report_vcf,
+            msa_fasta = mafft.aligned_sequences
+        # TO DO: depth_csv = something computed above
+    }
+
+    output {
+      File         msa_fasta                      = mafft.aligned_sequences
+      Array[File]  lofreq_isnvs                   = isnvs_ref.report_vcf
+      File         reconstructr_tabulated_tsv_gz  = reconstructr.tabulated_tsv_gz
+      File         reconstructr_deciphered_tsv_gz = reconstructr.deciphered_tsv_gz
+    }
+}

--- a/pipes/WDL/workflows/reconstruct_from_alignments.wdl
+++ b/pipes/WDL/workflows/reconstruct_from_alignments.wdl
@@ -23,7 +23,7 @@ workflow reconstruct_from_alignments {
     # create multiple sequence alignment of fastas
     call nextstrain.mafft_one_chr as mafft {
         input:
-            sequences = assembly_fasta,
+            sequences = assembly_fastas,
             ref_fasta = ref_fasta,
             basename  = "all_samples_aligned.fasta"
     }

--- a/pipes/WDL/workflows/reconstruct_from_alignments.wdl
+++ b/pipes/WDL/workflows/reconstruct_from_alignments.wdl
@@ -21,11 +21,16 @@ workflow reconstruct_from_alignments {
     }
 
     # create multiple sequence alignment of fastas
+    call utils.zcat {
+        input:
+            infiles     = assembly_fastas,
+            output_name = "all_assemblies.fasta.gz"
+    }
     call nextstrain.mafft_one_chr as mafft {
         input:
-            sequences = assembly_fastas,
+            sequences = zcat.combined,
             ref_fasta = ref_fasta,
-            basename  = "all_samples_aligned.fasta"
+            basename  = "mafft_msa.fasta"
     }
 
     # call iSNVs with lofreq and calculate coverage depths


### PR DESCRIPTION
Add new workflow `reconstruct_from_alignments` which uses a new tool ([reconstructR](https://github.com/broadinstitute/reconstructR)) to infer disease transmission links based on genomic (consensus genome and intrahost variation) data.

The input to this workflow includes an aligned/trimmed BAM and consensus genome (FASTA) per disease case, plus a single reference genome (FASTA, the same one the BAM files are already aligned against). This workflow will perform the necessary intrahost variant calling, multiple alignments, etc, and produce output per the reconstructR tool.