### PR TITLE
dockstore updates

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -4,12 +4,12 @@ workflows:
     subclass: WDL
     primaryDescriptorPath: /pipes/WDL/workflows/align_and_count_multiple_report.wdl
     testParameterFiles:
-      - empty.json
+      - /empty.json
   - name: align_and_count
     subclass: WDL
     primaryDescriptorPath: /pipes/WDL/workflows/align_and_count.wdl
     testParameterFiles:
-      - empty.json
+      - /empty.json
   - name: align_and_plot
     subclass: WDL
     primaryDescriptorPath: /pipes/WDL/workflows/align_and_plot.wdl
@@ -29,7 +29,7 @@ workflows:
     subclass: WDL
     primaryDescriptorPath: /pipes/WDL/workflows/augur_export_only.wdl
     testParameterFiles:
-      - empty.json
+      - /empty.json
   - name: augur_from_assemblies
     subclass: WDL
     primaryDescriptorPath: /pipes/WDL/workflows/augur_from_assemblies.wdl
@@ -44,32 +44,32 @@ workflows:
     subclass: WDL
     primaryDescriptorPath: /pipes/WDL/workflows/augur_from_mltree.wdl
     testParameterFiles:
-      - empty.json
+      - /empty.json
   - name: augur_from_msa
     subclass: WDL
     primaryDescriptorPath: /pipes/WDL/workflows/augur_from_msa.wdl
     testParameterFiles:
-      - empty.json
+      - /empty.json
   - name: augur_from_msa_with_subsampler
     subclass: WDL
     primaryDescriptorPath: /pipes/WDL/workflows/augur_from_msa_with_subsampler.wdl
     testParameterFiles:
-      - empty.json
+      - /empty.json
   - name: bams_multiqc
     subclass: WDL
     primaryDescriptorPath: /pipes/WDL/workflows/bams_multiqc.wdl
     testParameterFiles:
-      - empty.json
+      - /empty.json
   - name: beast_gpu
     subclass: WDL
     primaryDescriptorPath: /pipes/WDL/workflows/beast_gpu.wdl
     testParameterFiles:
-      - empty.json
+      - /empty.json
   - name: classify_kaiju
     subclass: WDL
     primaryDescriptorPath: /pipes/WDL/workflows/classify_kaiju.wdl
     testParameterFiles:
-      - empty.json
+      - /empty.json
   - name: classify_kraken2
     subclass: WDL
     primaryDescriptorPath: /pipes/WDL/workflows/classify_kraken2.wdl
@@ -79,57 +79,57 @@ workflows:
     subclass: WDL
     primaryDescriptorPath: /pipes/WDL/workflows/classify_krakenuniq.wdl
     testParameterFiles:
-      - empty.json
+      - /empty.json
   - name: classify_multi
     subclass: WDL
     primaryDescriptorPath: /pipes/WDL/workflows/classify_multi.wdl
     testParameterFiles:
-      - empty.json
+      - /empty.json
   - name: classify_single
     subclass: WDL
     primaryDescriptorPath: /pipes/WDL/workflows/classify_single.wdl
     testParameterFiles:
-      - empty.json
+      - /empty.json
   - name: contigs
     subclass: WDL
     primaryDescriptorPath: /pipes/WDL/workflows/contigs.wdl
     testParameterFiles:
-      - empty.json
+      - /empty.json
   - name: coverage_table
     subclass: WDL
     primaryDescriptorPath: /pipes/WDL/workflows/coverage_table.wdl
     testParameterFiles:
-      - empty.json
+      - /empty.json
   - name: demux_metag
     subclass: WDL
     primaryDescriptorPath: /pipes/WDL/workflows/demux_metag.wdl
     testParameterFiles:
-      - empty.json
+      - /empty.json
   - name: demux_only
     subclass: WDL
     primaryDescriptorPath: /pipes/WDL/workflows/demux_only.wdl
     testParameterFiles:
-      - empty.json
+      - /empty.json
   - name: demux_deplete
     subclass: WDL
     primaryDescriptorPath: /pipes/WDL/workflows/demux_deplete.wdl
     testParameterFiles:
-      - empty.json
+      - /empty.json
   - name: demux_deplete_and_table_insert
     subclass: WDL
     primaryDescriptorPath: /pipes/WDL/workflows/demux_deplete_and_table_insert.wdl
     testParameterFiles:
-      - empty.json
+      - /empty.json
   - name: demux_plus
     subclass: WDL
     primaryDescriptorPath: /pipes/WDL/workflows/demux_plus.wdl
     testParameterFiles:
-      - empty.json
+      - /empty.json
   - name: deplete_only
     subclass: WDL
     primaryDescriptorPath: /pipes/WDL/workflows/deplete_only.wdl
     testParameterFiles:
-      - empty.json
+      - /empty.json
   - name: detect_cross_contamination
     subclass: WDL
     primaryDescriptorPath: /pipes/WDL/workflows/detect_cross_contamination.wdl
@@ -138,22 +138,22 @@ workflows:
     subclass: WDL
     primaryDescriptorPath: /pipes/WDL/workflows/detect_cross_contamination_precalled_vcfs.wdl
     testParameterFiles:
-      - empty.json
+      - /empty.json
   - name: diff_genome_sets
     subclass: WDL
     primaryDescriptorPath: /pipes/WDL/workflows/diff_genome_sets.wdl
     testParameterFiles:
-      - empty.json
+      - /empty.json
   - name: downsample
     subclass: WDL
     primaryDescriptorPath: /pipes/WDL/workflows/downsample.wdl
     testParameterFiles:
-      - empty.json
+      - /empty.json
   - name: dump_gcloud_env_info
     subclass: WDL
     primaryDescriptorPath: /pipes/WDL/workflows/dump_gcloud_env_info.wdl
     testParameterFiles:
-      - empty.json
+      - /empty.json
   - name: fastq_to_ubam
     subclass: WDL
     primaryDescriptorPath: /pipes/WDL/workflows/fastq_to_ubam.wdl
@@ -163,22 +163,22 @@ workflows:
     subclass: WDL
     primaryDescriptorPath: /pipes/WDL/workflows/fetch_annotations.wdl
     testParameterFiles:
-      - empty.json
+      - /empty.json
   - name: fetch_sra_to_bam
     subclass: WDL
     primaryDescriptorPath: /pipes/WDL/workflows/fetch_sra_to_bam.wdl
     testParameterFiles:
-      - empty.json
+      - /empty.json
   - name: filter_classified_bam_to_taxa
     subclass: WDL
     primaryDescriptorPath: /pipes/WDL/workflows/filter_classified_bam_to_taxa.wdl
     testParameterFiles:
-      - empty.json
+      - /empty.json
   - name: filter_sequences
     subclass: WDL
     primaryDescriptorPath: /pipes/WDL/workflows/filter_sequences.wdl
     testParameterFiles:
-      - empty.json
+      - /empty.json
   - name: genbank
     subclass: WDL
     primaryDescriptorPath: /pipes/WDL/workflows/genbank.wdl
@@ -188,122 +188,122 @@ workflows:
     subclass: WDL
     primaryDescriptorPath: /pipes/WDL/workflows/isnvs_merge_to_vcf.wdl
     testParameterFiles:
-      - empty.json
+      - /empty.json
   - name: isnvs_lofreq
     subclass: WDL
     primaryDescriptorPath: /pipes/WDL/workflows/isnvs_lofreq.wdl
     testParameterFiles:
-      - empty.json
+      - /empty.json
   - name: isnvs_one_sample
     subclass: WDL
     primaryDescriptorPath: /pipes/WDL/workflows/isnvs_one_sample.wdl
     testParameterFiles:
-      - empty.json
+      - /empty.json
   - name: kraken2_build
     subclass: WDL
     primaryDescriptorPath: /pipes/WDL/workflows/kraken2_build.wdl
     testParameterFiles:
-      - empty.json
+      - /empty.json
   - name: mafft_and_snp
     subclass: WDL
     primaryDescriptorPath: /pipes/WDL/workflows/mafft_and_snp.wdl
     testParameterFiles:
-      - empty.json
+      - /empty.json
   - name: mafft_and_snp_annotated
     subclass: WDL
     primaryDescriptorPath: /pipes/WDL/workflows/mafft_and_snp_annotated.wdl
     testParameterFiles:
-      - empty.json
+      - /empty.json
   - name: mafft_and_trim
     subclass: WDL
     primaryDescriptorPath: /pipes/WDL/workflows/mafft_and_trim.wdl
     testParameterFiles:
-      - empty.json
+      - /empty.json
   - name: mafft
     subclass: WDL
     primaryDescriptorPath: /pipes/WDL/workflows/mafft.wdl
     testParameterFiles:
-      - empty.json
+      - /empty.json
   - name: merge_bams
     subclass: WDL
     primaryDescriptorPath: /pipes/WDL/workflows/merge_bams.wdl
     testParameterFiles:
-      - empty.json
+      - /empty.json
   - name: merge_metagenomics
     subclass: WDL
     primaryDescriptorPath: /pipes/WDL/workflows/merge_metagenomics.wdl
     testParameterFiles:
-      - empty.json
+      - /empty.json
   - name: merge_tar_chunks
     subclass: WDL
     primaryDescriptorPath: /pipes/WDL/workflows/merge_tar_chunks.wdl
     testParameterFiles:
-      - empty.json
+      - /empty.json
   - name: merge_vcfs_and_annotate
     subclass: WDL
     primaryDescriptorPath: /pipes/WDL/workflows/merge_vcfs_and_annotate.wdl
     testParameterFiles:
-      - empty.json
+      - /empty.json
   - name: merge_vcfs
     subclass: WDL
     primaryDescriptorPath: /pipes/WDL/workflows/merge_vcfs.wdl
     testParameterFiles:
-      - empty.json
+      - /empty.json
   - name: metagenomic_denovo
     subclass: WDL
     primaryDescriptorPath: /pipes/WDL/workflows/metagenomic_denovo.wdl
     testParameterFiles:
-      - empty.json
+      - /empty.json
   - name: multiqc_only
     subclass: WDL
     primaryDescriptorPath: /pipes/WDL/workflows/multiqc_only.wdl
     testParameterFiles:
-      - empty.json
+      - /empty.json
   - name: nextclade_single
     subclass: WDL
     primaryDescriptorPath: /pipes/WDL/workflows/nextclade_single.wdl
     testParameterFiles:
-      - empty.json
+      - /empty.json
   - name: populate_library_and_sample_tables_from_flowcell
     subclass: WDL
     primaryDescriptorPath: /pipes/WDL/workflows/populate_library_and_sample_tables_from_flowcell.wdl
     testParameterFiles:
-      - empty.json
+      - /empty.json
   - name: reconstruct_from_alignments
     subclass: WDL
     primaryDescriptorPath: /pipes/WDL/workflows/reconstruct_from_alignments.wdl
     testParameterFiles:
-      - empty.json
+      - /empty.json
   - name: sarscov2_batch_relineage
     subclass: WDL
     primaryDescriptorPath: /pipes/WDL/workflows/sarscov2_batch_relineage.wdl
     testParameterFiles:
-      - empty.json
+      - /empty.json
   - name: sarscov2_biosample_load
     subclass: WDL
     primaryDescriptorPath: /pipes/WDL/workflows/sarscov2_biosample_load.wdl
     testParameterFiles:
-      - empty.json
+      - /empty.json
   - name: sarscov2_data_release
     subclass: WDL
     primaryDescriptorPath: /pipes/WDL/workflows/sarscov2_data_release.wdl
     testParameterFiles:
-      - empty.json
+      - /empty.json
   - name: sarscov2_genbank
     subclass: WDL
     primaryDescriptorPath: /pipes/WDL/workflows/sarscov2_genbank.wdl
     testParameterFiles:
-      - empty.json
+      - /empty.json
   - name: sarscov2_genbank_ingest
     subclass: WDL
     primaryDescriptorPath: /pipes/WDL/workflows/sarscov2_genbank_ingest.wdl
     testParameterFiles:
-      - empty.json    
+      - /empty.json    
   - name: sarscov2_illumina_full
     subclass: WDL
     primaryDescriptorPath: /pipes/WDL/workflows/sarscov2_illumina_full.wdl
     testParameterFiles:
-      - empty.json
+      - /empty.json
   - name: sarscov2_lineages
     subclass: WDL
     primaryDescriptorPath: /pipes/WDL/workflows/sarscov2_lineages.wdl
@@ -313,96 +313,96 @@ workflows:
     subclass: WDL
     primaryDescriptorPath: /pipes/WDL/workflows/calc_bam_read_depths.wdl
     testParameterFiles:
-      - empty.json
+      - /empty.json
   - name: sarscov2_gisaid_ingest
     subclass: WDL
     primaryDescriptorPath: /pipes/WDL/workflows/sarscov2_gisaid_ingest.wdl
     testParameterFiles:
-      - empty.json
+      - /empty.json
   - name: sarscov2_nextclade_multi
     subclass: WDL
     primaryDescriptorPath: /pipes/WDL/workflows/sarscov2_nextclade_multi.wdl
     testParameterFiles:
-      - empty.json
+      - /empty.json
   - name: sarscov2_nextstrain
     subclass: WDL
     primaryDescriptorPath: /pipes/WDL/workflows/sarscov2_nextstrain.wdl
     testParameterFiles:
-      - empty.json
+      - /empty.json
   - name: sarscov2_nextstrain_aligned_input
     subclass: WDL
     primaryDescriptorPath: /pipes/WDL/workflows/sarscov2_nextstrain_aligned_input.wdl
     testParameterFiles:
-      - empty.json
+      - /empty.json
   - name: sarscov2_sequencing_reports
     subclass: WDL
     primaryDescriptorPath: /pipes/WDL/workflows/sarscov2_sequencing_reports.wdl
     testParameterFiles:
-      - empty.json
+      - /empty.json
   - name: sarscov2_sra_to_genbank
     subclass: WDL
     primaryDescriptorPath: /pipes/WDL/workflows/sarscov2_sra_to_genbank.wdl
     testParameterFiles:
-      - empty.json
+      - /empty.json
   - name: scaffold_and_refine
     subclass: WDL
     primaryDescriptorPath: /pipes/WDL/workflows/scaffold_and_refine.wdl
     testParameterFiles:
-      - empty.json
+      - /empty.json
   - name: scaffold_and_refine_multitaxa
     subclass: WDL
     primaryDescriptorPath: /pipes/WDL/workflows/scaffold_and_refine_multitaxa.wdl
     testParameterFiles:
-      - empty.json
+      - /empty.json
   - name: subsample_by_casecounts
     subclass: WDL
     primaryDescriptorPath: /pipes/WDL/workflows/subsample_by_casecounts.wdl
     testParameterFiles:
-      - empty.json
+      - /empty.json
   - name: subsample_by_metadata
     subclass: WDL
     primaryDescriptorPath: /pipes/WDL/workflows/subsample_by_metadata.wdl
     testParameterFiles:
-      - empty.json
+      - /empty.json
   - name: subsample_by_metadata_with_focal
     subclass: WDL
     primaryDescriptorPath: /pipes/WDL/workflows/subsample_by_metadata_with_focal.wdl
     testParameterFiles:
-      - empty.json
+      - /empty.json
   - name: terra_table_to_tsv
     subclass: WDL
     primaryDescriptorPath: /pipes/WDL/workflows/terra_table_to_tsv.wdl
     testParameterFiles:
-      - empty.json
+      - /empty.json
   - name: terra_update_assemblies
     subclass: WDL
     primaryDescriptorPath: /pipes/WDL/workflows/terra_update_assemblies.wdl
     testParameterFiles:
-      - empty.json
+      - /empty.json
   - name: trimal
     subclass: WDL
     primaryDescriptorPath: /pipes/WDL/workflows/trimal.wdl
     testParameterFiles:
-      - empty.json
+      - /empty.json
   - name: classify_qiime2_multi
     subclass: WDL
     primaryDescriptorPath: /pipes/WDL/workflows/classify_qiime2_multi.wdl
     testParameterFiles:
-      - empty.json
+      - /empty.json
   - name: qiime_import_bam
     subclass: WDL
     primaryDescriptorPath: /pipes/WDL/workflows/bam_to_qiime.wdl
     testParameterFiles:
-      - empty.json
+      - /empty.json
 
   - name: create_enterics_qc_viz
     subclass: WDL
     primaryDescriptorPath: /pipes/WDL/workflows/create_enterics_qc_viz.wdl
     testParameterFiles:
-      - empty.json
+      - /empty.json
 
   - name: create_enterics_qc_viz_general
     subclass: WDL
     primaryDescriptorPath: /pipes/WDL/workflows/create_enterics_qc_viz_general.wdl
     testParameterFiles:
-      - empty.json
+      - /empty.json


### PR DESCRIPTION
Update `.dockstore.yml` file to be compliant with [latest requirements from Dockstore](https://discuss.dockstore.org/t/relative-file-paths-in-dockstore-yml-now-deemed-as-invalid/8029) regarding file paths in the yml file, even for stub/fake/non-existent files. See https://github.com/dockstore/dockstore/issues/5806