### PR TITLE
Fixing duplicate inputs bug

### DIFF
--- a/pipes/WDL/workflows/create_enterics_qc_viz.wdl
+++ b/pipes/WDL/workflows/create_enterics_qc_viz.wdl
@@ -62,7 +62,7 @@ task create_viz {
         String           input_table_name
 
         String           grouping_column_name            =   "gambit_predicted_taxon"
-        String           output_filename                 =   "QC_visualizations.pdf"
+        String           output_filename                 =   "QC_visualizations.html"
 
         String?          custom_est_coverage_thresholds
         String?          custom_contig_thresholds

--- a/pipes/WDL/workflows/create_enterics_qc_viz.wdl
+++ b/pipes/WDL/workflows/create_enterics_qc_viz.wdl
@@ -35,7 +35,19 @@ workflow CreateEntericsQCViz {
         String?         custom_mean_q_thresholds
     }
 
-    call create_viz
+    call create_viz{
+        input:
+            sample_ids                      =   sample_ids,
+            workspace_name                  =   workspace_name,
+            workspace_project               =   workspace_project,
+            input_table_name                =   input_table_name,
+            grouping_column_name            =   grouping_column_name,
+            output_filename                 =   output_filename,
+            custom_est_coverage_thresholds  =   custom_est_coverage_thresholds,
+            custom_contig_thresholds        =   custom_contig_thresholds,
+            custom_assembly_thresholds      =   custom_assembly_thresholds,
+            custom_mean_q_thresholds        =   custom_mean_q_thresholds
+    }
 
     output {
         File    visualization_html     =   create_viz.html
@@ -44,20 +56,20 @@ workflow CreateEntericsQCViz {
 
 task create_viz {
     input {
-        Array[String]   sample_ids
-        String          workspace_name
-        String          workspace_project
-        String          input_table_name
+        Array[String]    sample_ids
+        String           workspace_name
+        String           workspace_project
+        String           input_table_name
 
         String           grouping_column_name            =   "gambit_predicted_taxon"
         String           output_filename                 =   "QC_visualizations.pdf"
 
-        String?         custom_est_coverage_thresholds
-        String?         custom_contig_thresholds
-        String?         custom_assembly_thresholds
-        String?         custom_mean_q_thresholds
+        String?          custom_est_coverage_thresholds
+        String?          custom_contig_thresholds
+        String?          custom_assembly_thresholds
+        String?          custom_mean_q_thresholds
 
-        String          docker                          =   "us-central1-docker.pkg.dev/pgs-automation/enterics-visualizations/create_visualization_html:v1"       
+        String           docker                          =   "us-central1-docker.pkg.dev/pgs-automation/enterics-visualizations/create_visualization_html:v1"       
     }
 
     command {

--- a/pipes/WDL/workflows/create_enterics_qc_viz.wdl
+++ b/pipes/WDL/workflows/create_enterics_qc_viz.wdl
@@ -6,6 +6,31 @@ workflow CreateEntericsQCViz {
         allowNestedInputs: true
     }
 
+    call create_viz
+
+    output {
+        File    visualization_html     =   create_viz.html
+    }
+}
+
+task create_viz {
+    input {
+        Array[String]   sample_ids
+        String          workspace_name
+        String          workspace_project
+        String          input_table_name
+
+        String          grouping_column_name            =   "gambit_predicted_taxon"
+        String          output_filename                 =   "QC_visualizations.html"
+
+        String?         custom_est_coverage_thresholds
+        String?         custom_contig_thresholds
+        String?         custom_assembly_thresholds
+        String?         custom_mean_q_thresholds
+
+        String          docker                           =   "us-central1-docker.pkg.dev/pgs-automation/enterics-visualizations/create_visualization_html:v1"       
+    }
+
     parameter_meta {
         sample_ids: {description: "selected rows of data from data table which will be used for plotting"}
         input_table_name: {description: "name of the Terra data table - root entity type - from where input data is selected"}
@@ -17,59 +42,6 @@ workflow CreateEntericsQCViz {
         custom_contig_thresholds: {description: "json string with custom number contig thresholds"}
         custom_assembly_thresholds: {description: "json string with custom assembly length thresholds"}
         custom_mean_q_thresholds: {description: "json string with custom mean q thresholds"}
-    }
-
-    input {
-
-        Array[String]   sample_ids
-        String          input_table_name
-        String          workspace_name
-        String          workspace_project
-
-        String?         grouping_column_name
-        String?         output_filename
-
-        String?         custom_est_coverage_thresholds
-        String?         custom_contig_thresholds
-        String?         custom_assembly_thresholds
-        String?         custom_mean_q_thresholds
-    }
-
-    call create_viz{
-        input:
-            sample_ids                      =   sample_ids,
-            workspace_name                  =   workspace_name,
-            workspace_project               =   workspace_project,
-            input_table_name                =   input_table_name,
-            grouping_column_name            =   grouping_column_name,
-            output_filename                 =   output_filename,
-            custom_est_coverage_thresholds  =   custom_est_coverage_thresholds,
-            custom_contig_thresholds        =   custom_contig_thresholds,
-            custom_assembly_thresholds      =   custom_assembly_thresholds,
-            custom_mean_q_thresholds        =   custom_mean_q_thresholds
-    }
-
-    output {
-        File    visualization_html     =   create_viz.html
-    }
-}
-
-task create_viz {
-    input {
-        Array[String]    sample_ids
-        String           workspace_name
-        String           workspace_project
-        String           input_table_name
-
-        String           grouping_column_name            =   "gambit_predicted_taxon"
-        String           output_filename                 =   "QC_visualizations.html"
-
-        String?          custom_est_coverage_thresholds
-        String?          custom_contig_thresholds
-        String?          custom_assembly_thresholds
-        String?          custom_mean_q_thresholds
-
-        String           docker                          =   "us-central1-docker.pkg.dev/pgs-automation/enterics-visualizations/create_visualization_html:v1"       
     }
 
     command {
@@ -90,6 +62,6 @@ task create_viz {
     }
 
     output {
-        File html = "~{output_filename}"
+        File html = output_filename
     }
 }


### PR DESCRIPTION
With the changed that were made in the previous PR re. nested inputs, the resulting WDL led to duplicates in the Terra workflow setup UI (see attached screenshot). This preserves stylistic edits made while insuring inputs only appear once in the Terra UI. I could not find a workaround that did not involve passing in all of the inputs after `call create_vis`.
![Screenshot 2024-02-15 at 2 45 56 PM] (https://github.com/broadinstitute/viral-pipelines/assets/78126657/c294b272-5c98-487c-9f4c-4d161db44e67)
