### PR TITLE
update enterics visualization docker image

### DIFF
--- a/pipes/WDL/workflows/create_enterics_qc_viz.wdl
+++ b/pipes/WDL/workflows/create_enterics_qc_viz.wdl
@@ -25,7 +25,7 @@ task create_viz {
 
         File?           thresholds_file
 
-        String          docker                           =   "us-central1-docker.pkg.dev/pgs-automation/enterics-visualizations/create_visualization_html:v3"       
+        String          docker                           =   "us-central1-docker.pkg.dev/pgs-automation/enterics-visualizations/create_visualization_html:v4"       
     }
 
     parameter_meta {


### PR DESCRIPTION
we found another bug in the enterics visualization python script — this PR updates the WDL to include the new, debugged docker image