### PR TITLE
Make create_enterics_qc_viz whitespace tolerant

### DIFF
--- a/pipes/WDL/workflows/create_enterics_qc_viz.wdl
+++ b/pipes/WDL/workflows/create_enterics_qc_viz.wdl
@@ -1,12 +1,19 @@
 version 1.0
 
+import "../tasks/tasks_terra.wdl" as terra
+
 workflow CreateEntericsQCViz {
 
     meta {
         allowNestedInputs: true
     }
 
-    call create_viz
+    call terra.check_terra_env
+    call create_viz {
+        input:
+            workspace_name = check_terra_env.workspace_name,
+            workspace_project = check_terra_env.workspace_namespace
+    }
 
     output {
         File    visualization_html     =   create_viz.html

--- a/pipes/WDL/workflows/create_enterics_qc_viz.wdl
+++ b/pipes/WDL/workflows/create_enterics_qc_viz.wdl
@@ -39,13 +39,13 @@ task create_viz {
     }
 
     command {
-        python3 /scripts/create_enterics_visualizations_html.py -s ~{sep=' ' sample_ids} \
-                                                                -dt ~{input_table_name} \
-                                                                -w ~{workspace_name} \
-                                                                -bp ~{workspace_project} \
-                                                                ~{"-g" + grouping_column_name} \
-                                                                ~{"-o" + output_filename} \
-                                                                ~{"-t" + thresholds_file}
+        python3 /scripts/create_enterics_visualizations_html.py -s "~{sep='" "' sample_ids}" \
+                                                                -dt "~{input_table_name}" \
+                                                                -w "~{workspace_name}" \
+                                                                -bp "~{workspace_project}" \
+                                                                ~{'-g "' + grouping_column_name + '"'} \
+                                                                ~{'-o "' + output_filename + '"'} \
+                                                                ~{'-t "' + thresholds_file + '"'}
     }
 
     runtime {


### PR DESCRIPTION
Bugfix: `create_enterics_qc_viz` broke on whitespace on any WDL inputs. This PR makes it resilient to whitespace on all inputs (at least as far as the WDL is concerned). This is particularly important for some user-immutable strings like `workspace_name`, `project_name`, `input_table_name`, etc.

Also remove user input for `workspace_name` and `project_name` and autodetect instead.