### PR TITLE
create_enterics_qc_viz simplify and improve portability

### DIFF
--- a/pipes/WDL/workflows/create_enterics_qc_viz.wdl
+++ b/pipes/WDL/workflows/create_enterics_qc_viz.wdl
@@ -40,6 +40,13 @@ task create_viz {
     }
 
     command {
+
+        echo "Length of sample_ids: ${#sample_ids[@]}"
+        echo "Length of gambit_predicted_taxon: ${#gambit_predicted_taxon[@]}"
+        echo "Length of est_coverage_clean: ${#est_coverage_clean[@]}"
+        echo "Length of number_contigs: ${#number_contigs[@]}"
+        echo "Length of assembly_length: ${#assembly_length[@]}"
+        
         python3 /scripts/create_enterics_visualizations_html.py -s "~{sep='" "' sample_ids}" \
                                                                 -g "~{sep='" "' gambit_predicted_taxon}" \
                                                                 -ecc ~{sep=' ' est_coverage_clean} \

--- a/pipes/WDL/workflows/create_enterics_qc_viz.wdl
+++ b/pipes/WDL/workflows/create_enterics_qc_viz.wdl
@@ -39,14 +39,14 @@ task create_viz {
         thresholds_file: {description: "JSON file containing custom thresholds"}
     }
 
-    command {
+    command <<<
 
         echo "Length of sample_ids: ${#sample_ids[@]}"
         echo "Length of gambit_predicted_taxon: ${#gambit_predicted_taxon[@]}"
         echo "Length of est_coverage_clean: ${#est_coverage_clean[@]}"
         echo "Length of number_contigs: ${#number_contigs[@]}"
         echo "Length of assembly_length: ${#assembly_length[@]}"
-        
+
         python3 /scripts/create_enterics_visualizations_html.py -s "~{sep='" "' sample_ids}" \
                                                                 -g "~{sep='" "' gambit_predicted_taxon}" \
                                                                 -ecc ~{sep=' ' est_coverage_clean} \
@@ -54,7 +54,7 @@ task create_viz {
                                                                 -al ~{sep=' ' assembly_length} \
                                                                 ~{'-o "' + output_filename + '"'} \
                                                                 ~{'-t "' + thresholds_file + '"'}
-    }
+    >>>
 
     runtime {
         docker: docker

--- a/pipes/WDL/workflows/create_enterics_qc_viz.wdl
+++ b/pipes/WDL/workflows/create_enterics_qc_viz.wdl
@@ -41,12 +41,12 @@ task create_viz {
 
     command <<<
 
-        echo "Length of sample_ids: ${#sample_ids[@]}"
-        echo "Length of gambit_predicted_taxon: ${#gambit_predicted_taxon[@]}"
-        echo "Length of est_coverage_clean: ${#est_coverage_clean[@]}"
-        echo "Length of number_contigs: ${#number_contigs[@]}"
-        echo "Length of assembly_length: ${#assembly_length[@]}"
-
+        python3 -c "print('Length of sample_ids:', len('${sep=' ' sample_ids}'.split()))"
+        python3 -c "print('Length of gambit_predicted_taxon:', len('${sep=' ' gambit_predicted_taxon}'.split()))"
+        python3 -c "print('Length of est_coverage_clean:', len('${sep=' ' est_coverage_clean}'.split()))"
+        python3 -c "print('Length of number_contigs:', len('${sep=' ' number_contigs}'.split()))"
+        python3 -c "print('Length of assembly_length:', len('${sep=' ' assembly_length}'.split()))"
+        
         python3 /scripts/create_enterics_visualizations_html.py -s "~{sep='" "' sample_ids}" \
                                                                 -g "~{sep='" "' gambit_predicted_taxon}" \
                                                                 -ecc ~{sep=' ' est_coverage_clean} \

--- a/pipes/WDL/workflows/create_enterics_qc_viz.wdl
+++ b/pipes/WDL/workflows/create_enterics_qc_viz.wdl
@@ -15,6 +15,7 @@ workflow CreateEntericsQCViz {
 }
 
 task create_viz {
+    
     input {
         Array[String]   sample_ids
         Array[String]   gambit_predicted_taxon
@@ -40,7 +41,6 @@ task create_viz {
     }
 
     command {
-
         python3 /scripts/create_enterics_visualizations_html.py -s "~{sep='" "' sample_ids}" \
                                                                 -g "~{sep='" "' gambit_predicted_taxon}" \
                                                                 -ecc ~{sep=' ' est_coverage_clean} \

--- a/pipes/WDL/workflows/create_enterics_qc_viz.wdl
+++ b/pipes/WDL/workflows/create_enterics_qc_viz.wdl
@@ -1,18 +1,12 @@
 version 1.0
 
-import "../tasks/tasks_terra.wdl" as terra
-
 workflow CreateEntericsQCViz {
 
     meta {
         allowNestedInputs: true
     }
 
-    call terra.check_terra_env
     call create_viz {
-        input:
-            workspace_name = check_terra_env.workspace_name,
-            workspace_project = check_terra_env.workspace_namespace
     }
 
     output {
@@ -23,34 +17,34 @@ workflow CreateEntericsQCViz {
 task create_viz {
     input {
         Array[String]   sample_ids
-        String          workspace_name
-        String          workspace_project
-        String          input_table_name
-
-        String          grouping_column_name            =   "gambit_predicted_taxon"
-        String          output_filename                 =   "QC_visualizations.html"
+        Array[String]   gambit_predicted_taxon
+        Array[String]   est_coverage_clean
+        Array[String]   number_contigs
+        Array[String]   assembly_length
 
         File?           thresholds_file
 
-        String          docker                           =   "us-central1-docker.pkg.dev/pgs-automation/enterics-visualizations/create_visualization_html:v4"       
+        String          output_filename                  =   "QC_visualizations.html"
+
+        String          docker                           =   "us-central1-docker.pkg.dev/pgs-automation/enterics-visualizations/create_visualization_html:v5"       
     }
 
     parameter_meta {
-        sample_ids: {description: "selected rows of data from data table which will be used for plotting"}
-        input_table_name: {description: "name of the Terra data table - root entity type - from where input data is selected"}
-        workspace_name: {description: "name of Terra workspace where data lives"}
-        workspace_project: {description: "name of Terra project associated with Terra workspace"}
-        grouping_column_name: {description: "name of column to be used for grouping/coloring - ex. gambit_predicted_taxon (organism)"}
+        sample_ids: {description: "selected samples of data"}
+        gambit_predicted_taxon: {description: "predicted gambits for selected samples"}
+        est_coverage_clean: {description: "estimated coverage metrics for selected samples"}
+        number_contigs: {description: "number contigs metrics for selected samples"}
+        assembly_length: {description: "assembly length metrics for selected samples"}
         output_filename: {description: "name of output file containing visualizations"}
         thresholds_file: {description: "JSON file containing custom thresholds"}
     }
 
     command {
         python3 /scripts/create_enterics_visualizations_html.py -s "~{sep='" "' sample_ids}" \
-                                                                -dt "~{input_table_name}" \
-                                                                -w "~{workspace_name}" \
-                                                                -bp "~{workspace_project}" \
-                                                                ~{'-g "' + grouping_column_name + '"'} \
+                                                                -g "~{sep='" "' gambit_predicted_taxon}" \
+                                                                -ecc ~{sep=' ' est_coverage_clean} \
+                                                                -nc ~{sep=' ' number_contigs} \
+                                                                -al ~{sep=' ' assembly_length} \
                                                                 ~{'-o "' + output_filename + '"'} \
                                                                 ~{'-t "' + thresholds_file + '"'}
     }

--- a/pipes/WDL/workflows/create_enterics_qc_viz.wdl
+++ b/pipes/WDL/workflows/create_enterics_qc_viz.wdl
@@ -39,14 +39,8 @@ task create_viz {
         thresholds_file: {description: "JSON file containing custom thresholds"}
     }
 
-    command <<<
+    command {
 
-        python3 -c "print('Length of sample_ids:', len('${sep=' ' sample_ids}'.split()))"
-        python3 -c "print('Length of gambit_predicted_taxon:', len('${sep=' ' gambit_predicted_taxon}'.split()))"
-        python3 -c "print('Length of est_coverage_clean:', len('${sep=' ' est_coverage_clean}'.split()))"
-        python3 -c "print('Length of number_contigs:', len('${sep=' ' number_contigs}'.split()))"
-        python3 -c "print('Length of assembly_length:', len('${sep=' ' assembly_length}'.split()))"
-        
         python3 /scripts/create_enterics_visualizations_html.py -s "~{sep='" "' sample_ids}" \
                                                                 -g "~{sep='" "' gambit_predicted_taxon}" \
                                                                 -ecc ~{sep=' ' est_coverage_clean} \
@@ -54,7 +48,7 @@ task create_viz {
                                                                 -al ~{sep=' ' assembly_length} \
                                                                 ~{'-o "' + output_filename + '"'} \
                                                                 ~{'-t "' + thresholds_file + '"'}
-    >>>
+    }
 
     runtime {
         docker: docker


### PR DESCRIPTION
Change `create_enterics_qc_viz` from taking Terra (GCP-only) project/workspace/table names and reading the data points directly via the FISS API to taking the data points as WDL inputs. This improves portability (to ToA and non-Terra environments) and eliminates a frequent opportunity for user error.