### PR TITLE
scaffold_and_refine_multitaxa -- more thorough assembly outputs

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -374,6 +374,11 @@ workflows:
     primaryDescriptorPath: /pipes/WDL/workflows/terra_table_to_tsv.wdl
     testParameterFiles:
       - /empty.json
+  - name: terra_tsv_to_table
+    subclass: WDL
+    primaryDescriptorPath: /pipes/WDL/workflows/terra_tsv_to_table.wdl
+    testParameterFiles:
+      - /empty.json
   - name: terra_update_assemblies
     subclass: WDL
     primaryDescriptorPath: /pipes/WDL/workflows/terra_update_assemblies.wdl
@@ -394,13 +399,11 @@ workflows:
     primaryDescriptorPath: /pipes/WDL/workflows/bam_to_qiime.wdl
     testParameterFiles:
       - /empty.json
-
   - name: create_enterics_qc_viz
     subclass: WDL
     primaryDescriptorPath: /pipes/WDL/workflows/create_enterics_qc_viz.wdl
     testParameterFiles:
       - /empty.json
-
   - name: create_enterics_qc_viz_general
     subclass: WDL
     primaryDescriptorPath: /pipes/WDL/workflows/create_enterics_qc_viz_general.wdl

--- a/pipes/WDL/tasks/tasks_nextstrain.wdl
+++ b/pipes/WDL/tasks/tasks_nextstrain.wdl
@@ -1147,6 +1147,8 @@ task augur_mafft_align {
 
         String  docker = "nextstrain/base:build-20230905T192825Z"
         Int     disk_size = 750
+        Int     mem_size = 180
+        Int     cpus = 64
     }
     command <<<
         set -e
@@ -1165,8 +1167,8 @@ task augur_mafft_align {
     >>>
     runtime {
         docker: docker
-        memory: "180 GB"
-        cpu :   64
+        memory: mem_size + " GB"
+        cpu :   cpus
         disks:  "local-disk " + disk_size + " LOCAL"
         disk: disk_size + " GB" # TES
         preemptible: 0

--- a/pipes/WDL/workflows/assemble_refbased.wdl
+++ b/pipes/WDL/workflows/assemble_refbased.wdl
@@ -63,6 +63,7 @@ workflow assemble_refbased {
         Array[File]+ reads_unmapped_bams
         File         reference_fasta
         String       sample_name = basename(reads_unmapped_bams[0], '.bam')
+        String?      sample_original_name
 
         String       aligner="minimap2"
         File?        novocraft_license
@@ -150,7 +151,8 @@ workflow assemble_refbased {
             reads_aligned_bam = aligned_trimmed_bam,
             min_coverage      = min_coverage,
             major_cutoff      = major_cutoff,
-            sample_name       = sample_name
+            out_basename      = sample_name,
+            sample_name       = select_first([sample_original_name, sample_name])
     }
 
     scatter(reads_unmapped_bam in reads_unmapped_bams) {

--- a/pipes/WDL/workflows/scaffold_and_refine_multitaxa.wdl
+++ b/pipes/WDL/workflows/scaffold_and_refine_multitaxa.wdl
@@ -149,16 +149,20 @@ workflow scaffold_and_refine_multitaxa {
         }
 
         if (assembly_length_unambiguous > 0) {
-            scatter(h in assembly_header) {
-                String stat_by_taxon = stats_by_taxon[h]
-            }
+            Map[String, String] stats_by_taxon_nonzero = stats_by_taxon
+        }
+    }
+
+    scatter(stat in select_all(stats_by_taxon_nonzero)) {
+        scatter(h in assembly_header) {
+            String stat_by_taxon = stat[h]
         }
     }
  
     ### summary stats
     call utils.concatenate {
       input:
-        infiles     = [write_tsv([assembly_header]), write_tsv(select_all(stat_by_taxon))],
+        infiles     = [write_tsv([assembly_header]), write_tsv(stat_by_taxon)],
         output_name = "assembly_metadata-~{sample_id}.tsv"
     }
 

--- a/pipes/WDL/workflows/scaffold_and_refine_multitaxa.wdl
+++ b/pipes/WDL/workflows/scaffold_and_refine_multitaxa.wdl
@@ -108,7 +108,7 @@ workflow scaffold_and_refine_multitaxa {
         Float  percent_reference_covered = 1.0 * assembly_length_unambiguous / scaffold.reference_length
         File   assembly_fasta = select_first([refine.assembly_fasta, ref_based.assembly_fasta])
         Map[String, String] stats_by_taxon = {
-            "entity:assembly_id" : sample_id + ":" + taxid,
+            "entity:assembly_id" : sample_id + "-" + taxid,
             "assembly_name" :      tax_name + ": " + sample_original_name,
             "sample_id" :          sample_id,
             "sample_name" :        sample_original_name,

--- a/pipes/WDL/workflows/terra_tsv_to_table.wdl
+++ b/pipes/WDL/workflows/terra_tsv_to_table.wdl
@@ -11,5 +11,11 @@ workflow terra_tsv_to_table {
         email:  "viral-ngs@broadinstitute.org"
     }
 
-    call terra.upload_entities_tsv
+    call terra.check_terra_env
+
+    call terra.upload_entities_tsv {
+        input:
+            workspace_name   = check_terra_env.workspace_name,
+            terra_project    = check_terra_env.workspace_namespace
+    }
 }

--- a/pipes/WDL/workflows/terra_tsv_to_table.wdl
+++ b/pipes/WDL/workflows/terra_tsv_to_table.wdl
@@ -1,0 +1,15 @@
+version 1.0
+
+#DX_SKIP_WORKFLOW
+
+import "../tasks/tasks_terra.wdl" as terra
+
+workflow terra_tsv_to_table {
+    meta {
+        description: "Upload tsv file to Terra data table: insert-or-update on existing rows/columns"
+        author: "Broad Viral Genomics"
+        email:  "viral-ngs@broadinstitute.org"
+    }
+
+    call terra.upload_entities_tsv
+}


### PR DESCRIPTION
Fleshing out more of that assembly_stats_by_taxon tsv output with a number of additional useful outputs, making it ready for 1) TSV import into Terra as a new table and 2) downstream processing for genbank and data release.

Adds new workflow `terra_tsv_to_table` that simply calls the `terra.upload_entities_tsv` task