### PR TITLE
build and container updates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -116,7 +116,7 @@ jobs:
           echo "GITHUB_ACTIONS_BRANCH=$GITHUB_ACTIONS_BRANCH"
           echo "GITHUB_ACTIONS_BRANCH=$GITHUB_ACTIONS_BRANCH" >> $GITHUB_ENV
       - name: install java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'adopt'
           java-version: '11'
@@ -218,7 +218,7 @@ jobs:
           sudo rm -rf "/usr/local/share/boost"
           sudo rm -rf "$AGENT_TOOLSDIRECTORY"
       - name: install java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'adopt'
           java-version: '11'
@@ -275,7 +275,7 @@ jobs:
       - name: install python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.8'
+          python-version: '3.10'
       - name: install system dependencies
         run: |
           sudo apt-get update
@@ -284,7 +284,7 @@ jobs:
         run: |
           pip3 install miniwdl docker[tls] six
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
       - name: test with miniwdl
         shell: bash
         run: |
@@ -341,7 +341,7 @@ jobs:
         with: 
           python-version: '3.8'
       - name: install java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'adopt'
           java-version: '11'

--- a/pipes/WDL/tasks/tasks_assembly.wdl
+++ b/pipes/WDL/tasks/tasks_assembly.wdl
@@ -15,7 +15,7 @@ task assemble {
       String   sample_name = basename(basename(reads_unmapped_bam, ".bam"), ".taxfilt")
       
       Int?     machine_mem_gb
-      String   docker = "quay.io/broadinstitute/viral-assemble:2.2.4.0"
+      String   docker = "quay.io/broadinstitute/viral-assemble:2.3.0.0"
     }
     parameter_meta{
       reads_unmapped_bam: {
@@ -122,7 +122,7 @@ task scaffold {
       Float?       scaffold_min_pct_contig_aligned
 
       Int?         machine_mem_gb
-      String       docker="quay.io/broadinstitute/viral-assemble:2.2.4.0"
+      String       docker="quay.io/broadinstitute/viral-assemble:2.3.0.0"
 
       # do this in multiple steps in case the input doesn't actually have "assembly1-x" in the name
       String       sample_name = basename(basename(contigs_fasta, ".fasta"), ".assembly1-spades")
@@ -586,7 +586,7 @@ task refine_assembly_with_aligned_reads {
       Int      min_coverage = 3
 
       Int      machine_mem_gb = 15
-      String   docker = "quay.io/broadinstitute/viral-assemble:2.2.4.0"
+      String   docker = "quay.io/broadinstitute/viral-assemble:2.3.0.0"
     }
 
     Int disk_size = 375
@@ -711,7 +711,7 @@ task refine_2x_and_plot {
       String? plot_coverage_novoalign_options = "-r Random -l 40 -g 40 -x 20 -t 100 -k"
 
       Int?    machine_mem_gb
-      String  docker = "quay.io/broadinstitute/viral-assemble:2.2.4.0"
+      String  docker = "quay.io/broadinstitute/viral-assemble:2.3.0.0"
 
       # do this in two steps in case the input doesn't actually have "cleaned" in the name
       String  sample_name = basename(basename(reads_unmapped_bam, ".bam"), ".cleaned")

--- a/pipes/WDL/tasks/tasks_reports.wdl
+++ b/pipes/WDL/tasks/tasks_reports.wdl
@@ -674,7 +674,7 @@ task compare_two_genomes {
     File   genome_two
     String out_basename
 
-    String docker = "quay.io/broadinstitute/viral-assemble:2.2.4.0"
+    String docker = "quay.io/broadinstitute/viral-assemble:2.3.0.0"
   }
 
   Int disk_size = 50

--- a/requirements-modules.txt
+++ b/requirements-modules.txt
@@ -1,5 +1,5 @@
 broadinstitute/viral-core=2.3.0
-broadinstitute/viral-assemble=2.2.4.0
+broadinstitute/viral-assemble=2.3.0.0
 broadinstitute/viral-classify=2.2.4.0
 broadinstitute/viral-phylo=2.1.20.2
 broadinstitute/py3-bio=0.1.2


### PR DESCRIPTION
This PR makes two changes:

1. update docker image for `viral-assemble` 2.2.4.0 to 2.3.0.0
2. update versions on a lot of github actions to quiet down some of the deprecation warnings during build