### PR TITLE
scaffolding and reference selection based on ANI

### DIFF
--- a/pipes/WDL/tasks/tasks_assembly.wdl
+++ b/pipes/WDL/tasks/tasks_assembly.wdl
@@ -274,7 +274,7 @@ task scaffold {
           "~{sample_name}.refs_skani_dist.top.tsv" \
           "~{sample_name}.ref_clusters.tsv" \
           --loglevel=DEBUG
-        CHOSEN_REF_FASTA=$(cut -f 1 "~{sample_name}.refs_skani_dist.full.tsv" | tail +2)
+        CHOSEN_REF_FASTA=$(cut -f 1 "~{sample_name}.refs_skani_dist.full.tsv" | tail +2 | head -1)
         cut -f 3 "~{sample_name}.refs_skani_dist.full.tsv" | tail +2 | head -1 > SKANI_ANI
         cut -f 4 "~{sample_name}.refs_skani_dist.full.tsv" | tail +2 | head -1 > SKANI_REF_AF
         cut -f 5 "~{sample_name}.refs_skani_dist.full.tsv" | tail +2 | head -1 > SKANI_CONTIGS_AF

--- a/pipes/WDL/tasks/tasks_assembly.wdl
+++ b/pipes/WDL/tasks/tasks_assembly.wdl
@@ -15,7 +15,7 @@ task assemble {
       String   sample_name = basename(basename(reads_unmapped_bam, ".bam"), ".taxfilt")
       
       Int?     machine_mem_gb
-      String   docker = "quay.io/broadinstitute/viral-assemble:2.3.0.0"
+      String   docker = "quay.io/broadinstitute/viral-assemble:2.3.1.0"
     }
     parameter_meta{
       reads_unmapped_bam: {
@@ -122,7 +122,7 @@ task scaffold {
       Float?       scaffold_min_pct_contig_aligned
 
       Int?         machine_mem_gb
-      String       docker="quay.io/broadinstitute/viral-assemble:2.3.0.0"
+      String       docker="quay.io/broadinstitute/viral-assemble:2.3.1.0"
 
       # do this in multiple steps in case the input doesn't actually have "assembly1-x" in the name
       String       sample_name = basename(basename(contigs_fasta, ".fasta"), ".assembly1-spades")
@@ -586,7 +586,7 @@ task refine_assembly_with_aligned_reads {
       Int      min_coverage = 3
 
       Int      machine_mem_gb = 15
-      String   docker = "quay.io/broadinstitute/viral-assemble:2.3.0.0"
+      String   docker = "quay.io/broadinstitute/viral-assemble:2.3.1.0"
     }
 
     Int disk_size = 375
@@ -711,7 +711,7 @@ task refine_2x_and_plot {
       String? plot_coverage_novoalign_options = "-r Random -l 40 -g 40 -x 20 -t 100 -k"
 
       Int?    machine_mem_gb
-      String  docker = "quay.io/broadinstitute/viral-assemble:2.3.0.0"
+      String  docker = "quay.io/broadinstitute/viral-assemble:2.3.1.0"
 
       # do this in two steps in case the input doesn't actually have "cleaned" in the name
       String  sample_name = basename(basename(reads_unmapped_bam, ".bam"), ".cleaned")

--- a/pipes/WDL/tasks/tasks_assembly.wdl
+++ b/pipes/WDL/tasks/tasks_assembly.wdl
@@ -275,6 +275,9 @@ task scaffold {
           "~{sample_name}.ref_clusters.tsv" \
           --loglevel=DEBUG
         CHOSEN_REF_FASTA=$(cut -f 1 "~{sample_name}.refs_skani_dist.top.tsv" | tail +2)
+        cut -f 3 "~{sample_name}.refs_skani_dist.top.tsv" | tail +2 > SKANI_ANI
+        cut -f 4 "~{sample_name}.refs_skani_dist.top.tsv" | tail +2 > SKANI_REF_AF
+        cut -f 5 "~{sample_name}.refs_skani_dist.top.tsv" | tail +2 > SKANI_CONTIGS_AF
 
         assembly.py order_and_orient \
           "~{contigs_fasta}" \
@@ -344,6 +347,9 @@ task scaffold {
         File   scaffolding_chosen_ref                = "~{sample_name}.scaffolding_chosen_ref.fasta"
         File   scaffolding_stats                     = "~{sample_name}.refs_skani_dist.full.tsv"
         File   scaffolding_alt_contigs               = "~{sample_name}.scaffolding_alt_contigs.fasta"
+        Float  skani_ani                             = read_float("SKANI_ANI")
+        Float  skani_ref_aligned_frac                = read_float("SKANI_REF_AF")
+        Float  skani_contigs_aligned_frac            = read_float("SKANI_CONTIGS_AF")
         String viralngs_version                      = read_string("VERSION")
     }
 

--- a/pipes/WDL/tasks/tasks_assembly.wdl
+++ b/pipes/WDL/tasks/tasks_assembly.wdl
@@ -137,7 +137,8 @@ task select_references {
       with open("~{contigs_basename}.ref_clusters.basenames.tsv", 'w') as outf:
         for line in inf:
           fnames = line.strip().split('\t')
-          outf.write('\t'.join(os.path.basename(f, '.fasta') for f in fnames) + '\n')
+          fnames = list([f[:-6] if f.endswith('.fasta') else f for f in map(os.path.basename, fnames)])
+          outf.write('\t'.join(fnames) + '\n')
     CODE
 
     # create top-hits output files

--- a/pipes/WDL/tasks/tasks_assembly.wdl
+++ b/pipes/WDL/tasks/tasks_assembly.wdl
@@ -274,10 +274,10 @@ task scaffold {
           "~{sample_name}.refs_skani_dist.top.tsv" \
           "~{sample_name}.ref_clusters.tsv" \
           --loglevel=DEBUG
-        CHOSEN_REF_FASTA=$(cut -f 1 "~{sample_name}.refs_skani_dist.top.tsv" | tail +2)
-        cut -f 3 "~{sample_name}.refs_skani_dist.top.tsv" | tail +2 > SKANI_ANI
-        cut -f 4 "~{sample_name}.refs_skani_dist.top.tsv" | tail +2 > SKANI_REF_AF
-        cut -f 5 "~{sample_name}.refs_skani_dist.top.tsv" | tail +2 > SKANI_CONTIGS_AF
+        CHOSEN_REF_FASTA=$(cut -f 1 "~{sample_name}.refs_skani_dist.full.tsv" | tail +2)
+        cut -f 3 "~{sample_name}.refs_skani_dist.full.tsv" | tail +2 | head -1 > SKANI_ANI
+        cut -f 4 "~{sample_name}.refs_skani_dist.full.tsv" | tail +2 | head -1 > SKANI_REF_AF
+        cut -f 5 "~{sample_name}.refs_skani_dist.full.tsv" | tail +2 | head -1 > SKANI_CONTIGS_AF
 
         assembly.py order_and_orient \
           "~{contigs_fasta}" \

--- a/pipes/WDL/tasks/tasks_assembly.wdl
+++ b/pipes/WDL/tasks/tasks_assembly.wdl
@@ -15,7 +15,7 @@ task assemble {
       String   sample_name = basename(basename(reads_unmapped_bam, ".bam"), ".taxfilt")
       
       Int?     machine_mem_gb
-      String   docker = "quay.io/broadinstitute/viral-assemble:2.3.1.2"
+      String   docker = "quay.io/broadinstitute/viral-assemble:2.3.1.3"
     }
     parameter_meta{
       reads_unmapped_bam: {
@@ -111,7 +111,7 @@ task select_references {
     Array[File]   reference_genomes_fastas
     File          contigs_fasta
 
-    String        docker = "quay.io/broadinstitute/viral-assemble:2.3.1.2"
+    String        docker = "quay.io/broadinstitute/viral-assemble:2.3.1.3"
     Int           machine_mem_gb = 4
     Int           cpu = 2
     Int           disk_size = 100
@@ -143,7 +143,7 @@ task select_references {
           basefnames = list([f[:-6] if f.endswith('.fasta') else f for f in map(os.path.basename, fnames)])
           outf.write('\t'.join(basefnames) + '\n')
 
-          with tarfile.open(os.path.join("clusters", basefnames[0] + "." + str(len(basefnames))  + ".tar.gz"), "w:gz") as tarball:
+          with tarfile.open(os.path.join("clusters", basefnames[0] + "-" + str(len(basefnames))  + ".tar.gz"), "w:gz") as tarball:
             for f in fnames:
               shutil.copy(f, ".")
               tarball.add(os.path.basename(f))
@@ -195,7 +195,7 @@ task scaffold {
       Float?       scaffold_min_pct_contig_aligned
 
       Int?         machine_mem_gb
-      String       docker="quay.io/broadinstitute/viral-assemble:2.3.1.2"
+      String       docker="quay.io/broadinstitute/viral-assemble:2.3.1.3"
 
       # do this in multiple steps in case the input doesn't actually have "assembly1-x" in the name
       String       sample_name = basename(basename(contigs_fasta, ".fasta"), ".assembly1-spades")
@@ -677,7 +677,7 @@ task refine_assembly_with_aligned_reads {
       Int      min_coverage = 3
 
       Int      machine_mem_gb = 15
-      String   docker = "quay.io/broadinstitute/viral-assemble:2.3.1.2"
+      String   docker = "quay.io/broadinstitute/viral-assemble:2.3.1.3"
     }
 
     Int disk_size = 375
@@ -802,7 +802,7 @@ task refine_2x_and_plot {
       String? plot_coverage_novoalign_options = "-r Random -l 40 -g 40 -x 20 -t 100 -k"
 
       Int?    machine_mem_gb
-      String  docker = "quay.io/broadinstitute/viral-assemble:2.3.1.2"
+      String  docker = "quay.io/broadinstitute/viral-assemble:2.3.1.3"
 
       # do this in two steps in case the input doesn't actually have "cleaned" in the name
       String  sample_name = basename(basename(reads_unmapped_bam, ".bam"), ".cleaned")

--- a/pipes/WDL/tasks/tasks_assembly.wdl
+++ b/pipes/WDL/tasks/tasks_assembly.wdl
@@ -15,7 +15,7 @@ task assemble {
       String   sample_name = basename(basename(reads_unmapped_bam, ".bam"), ".taxfilt")
       
       Int?     machine_mem_gb
-      String   docker = "quay.io/broadinstitute/viral-assemble:2.3.1.1"
+      String   docker = "quay.io/broadinstitute/viral-assemble:2.3.1.2"
     }
     parameter_meta{
       reads_unmapped_bam: {
@@ -111,7 +111,7 @@ task select_references {
     Array[File]   reference_genomes_fastas
     File          contigs_fasta
 
-    String        docker = "quay.io/broadinstitute/viral-assemble:2.3.1.1"
+    String        docker = "quay.io/broadinstitute/viral-assemble:2.3.1.2"
     Int           machine_mem_gb = 4
     Int           cpu = 2
     Int           disk_size = 100
@@ -186,7 +186,7 @@ task scaffold {
       Float?       scaffold_min_pct_contig_aligned
 
       Int?         machine_mem_gb
-      String       docker="quay.io/broadinstitute/viral-assemble:2.3.1.1"
+      String       docker="quay.io/broadinstitute/viral-assemble:2.3.1.2"
 
       # do this in multiple steps in case the input doesn't actually have "assembly1-x" in the name
       String       sample_name = basename(basename(contigs_fasta, ".fasta"), ".assembly1-spades")
@@ -666,7 +666,7 @@ task refine_assembly_with_aligned_reads {
       Int      min_coverage = 3
 
       Int      machine_mem_gb = 15
-      String   docker = "quay.io/broadinstitute/viral-assemble:2.3.1.1"
+      String   docker = "quay.io/broadinstitute/viral-assemble:2.3.1.2"
     }
 
     Int disk_size = 375
@@ -791,7 +791,7 @@ task refine_2x_and_plot {
       String? plot_coverage_novoalign_options = "-r Random -l 40 -g 40 -x 20 -t 100 -k"
 
       Int?    machine_mem_gb
-      String  docker = "quay.io/broadinstitute/viral-assemble:2.3.1.1"
+      String  docker = "quay.io/broadinstitute/viral-assemble:2.3.1.2"
 
       # do this in two steps in case the input doesn't actually have "cleaned" in the name
       String  sample_name = basename(basename(reads_unmapped_bam, ".bam"), ".cleaned")

--- a/pipes/WDL/tasks/tasks_assembly.wdl
+++ b/pipes/WDL/tasks/tasks_assembly.wdl
@@ -15,7 +15,7 @@ task assemble {
       String   sample_name = basename(basename(reads_unmapped_bam, ".bam"), ".taxfilt")
       
       Int?     machine_mem_gb
-      String   docker = "quay.io/broadinstitute/viral-assemble:2.3.1.0"
+      String   docker = "quay.io/broadinstitute/viral-assemble:2.3.1.1"
     }
     parameter_meta{
       reads_unmapped_bam: {
@@ -111,7 +111,7 @@ task select_references {
     Array[File]   reference_genomes_fastas
     File          contigs_fasta
 
-    String        docker = "quay.io/broadinstitute/viral-assemble:2.3.1.0"
+    String        docker = "quay.io/broadinstitute/viral-assemble:2.3.1.1"
     Int           machine_mem_gb = 4
     Int           cpu = 2
     Int           disk_size = 100
@@ -185,7 +185,7 @@ task scaffold {
       Float?       scaffold_min_pct_contig_aligned
 
       Int?         machine_mem_gb
-      String       docker="quay.io/broadinstitute/viral-assemble:2.3.1.0"
+      String       docker="quay.io/broadinstitute/viral-assemble:2.3.1.1"
 
       # do this in multiple steps in case the input doesn't actually have "assembly1-x" in the name
       String       sample_name = basename(basename(contigs_fasta, ".fasta"), ".assembly1-spades")
@@ -665,7 +665,7 @@ task refine_assembly_with_aligned_reads {
       Int      min_coverage = 3
 
       Int      machine_mem_gb = 15
-      String   docker = "quay.io/broadinstitute/viral-assemble:2.3.1.0"
+      String   docker = "quay.io/broadinstitute/viral-assemble:2.3.1.1"
     }
 
     Int disk_size = 375
@@ -790,7 +790,7 @@ task refine_2x_and_plot {
       String? plot_coverage_novoalign_options = "-r Random -l 40 -g 40 -x 20 -t 100 -k"
 
       Int?    machine_mem_gb
-      String  docker = "quay.io/broadinstitute/viral-assemble:2.3.1.0"
+      String  docker = "quay.io/broadinstitute/viral-assemble:2.3.1.1"
 
       # do this in two steps in case the input doesn't actually have "cleaned" in the name
       String  sample_name = basename(basename(reads_unmapped_bam, ".bam"), ".cleaned")

--- a/pipes/WDL/tasks/tasks_reports.wdl
+++ b/pipes/WDL/tasks/tasks_reports.wdl
@@ -674,7 +674,7 @@ task compare_two_genomes {
     File   genome_two
     String out_basename
 
-    String docker = "quay.io/broadinstitute/viral-assemble:2.3.0.0"
+    String docker = "quay.io/broadinstitute/viral-assemble:2.3.1.0"
   }
 
   Int disk_size = 50

--- a/pipes/WDL/tasks/tasks_reports.wdl
+++ b/pipes/WDL/tasks/tasks_reports.wdl
@@ -674,7 +674,7 @@ task compare_two_genomes {
     File   genome_two
     String out_basename
 
-    String docker = "quay.io/broadinstitute/viral-assemble:2.3.1.0"
+    String docker = "quay.io/broadinstitute/viral-assemble:2.3.1.1"
   }
 
   Int disk_size = 50

--- a/pipes/WDL/tasks/tasks_reports.wdl
+++ b/pipes/WDL/tasks/tasks_reports.wdl
@@ -674,7 +674,7 @@ task compare_two_genomes {
     File   genome_two
     String out_basename
 
-    String docker = "quay.io/broadinstitute/viral-assemble:2.3.1.1"
+    String docker = "quay.io/broadinstitute/viral-assemble:2.3.1.2"
   }
 
   Int disk_size = 50

--- a/pipes/WDL/tasks/tasks_reports.wdl
+++ b/pipes/WDL/tasks/tasks_reports.wdl
@@ -674,7 +674,7 @@ task compare_two_genomes {
     File   genome_two
     String out_basename
 
-    String docker = "quay.io/broadinstitute/viral-assemble:2.3.1.2"
+    String docker = "quay.io/broadinstitute/viral-assemble:2.3.1.3"
   }
 
   Int disk_size = 50

--- a/pipes/WDL/tasks/tasks_utils.wdl
+++ b/pipes/WDL/tasks/tasks_utils.wdl
@@ -170,7 +170,7 @@ task tar_extract {
         disk: disk_size + " GB" # TES
         dx_instance_type: "mem1_ssd1_v2_x2"
         maxRetries: 2
-        preemptible: true
+        preemptible: 1
     }
     output {
         Array[File] files = glob("unpack/*")

--- a/pipes/WDL/tasks/tasks_utils.wdl
+++ b/pipes/WDL/tasks/tasks_utils.wdl
@@ -148,6 +148,35 @@ task sed {
     }
 }
 
+task tar_extract {
+    meta {
+        description: "Extract a tar file"
+    }
+    input {
+        File   tar_file
+        Int    disk_size = 375
+        String tar_opts = "-z"
+    }
+    command <<<
+        mkdir -p unpack
+        cd unpack
+        tar -xv ~{tar_opts} -f "~{tar_file}"
+    >>>
+    runtime {
+        docker: "quay.io/broadinstitute/viral-baseimage:0.2.0"
+        memory: "2 GB"
+        cpu:    1
+        disks:  "local-disk " + disk_size + " LOCAL"
+        disk: disk_size + " GB" # TES
+        dx_instance_type: "mem1_ssd1_v2_x2"
+        maxRetries: 2
+        preemptible: true
+    }
+    output {
+        Array[File] files = glob("unpack/*")
+    }
+}
+
 task fasta_to_ids {
     meta {
         description: "Return the headers only from a fasta file"

--- a/pipes/WDL/tasks/tasks_utils.wdl
+++ b/pipes/WDL/tasks/tasks_utils.wdl
@@ -202,6 +202,7 @@ task fetch_row_from_tsv {
     String        idx_col
     String        idx_val
     Array[String] set_default_keys = []
+    Array[String] add_header = []
   }
   Int disk_size = 50
   command <<<
@@ -209,8 +210,11 @@ task fetch_row_from_tsv {
     import csv, gzip, json
     open_or_gzopen = lambda *args, **kwargs: gzip.open(*args, **kwargs) if args[0].endswith('.gz') else open(*args, **kwargs)
     out_dict = {}
+    fieldnames = "~{sep='*' add_header}".split("*")
+    if not fieldnames:
+      fieldnames = None
     with open_or_gzopen('~{tsv}', 'rt') as inf:
-      for row in csv.DictReader(inf, delimiter='\t'):
+      for row in csv.DictReader(inf, delimiter='\t', fieldnames=fieldnames):
         if row.get('~{idx_col}') == '~{idx_val}':
           out_dict = row
           break

--- a/pipes/WDL/workflows/scaffold_and_refine_multitaxa.wdl
+++ b/pipes/WDL/workflows/scaffold_and_refine_multitaxa.wdl
@@ -125,7 +125,7 @@ workflow scaffold_and_refine_multitaxa {
             "skani_this_cluster_num_refs" : length(ref_cluster),
             "skani_dist_tsv" :              scaffold.scaffolding_stats,
             "scaffolding_ani" :             scaffold.skani_ani,
-            "scaffolding_pct_ref_cov" :     scaffold.skani_ref_af,
+            "scaffolding_pct_ref_cov" :     scaffold.skani_ref_aligned_frac,
 
             "intermediate_gapfill_fasta" :            scaffold.intermediate_gapfill_fasta,
             "assembly_preimpute_length_unambiguous" : scaffold.assembly_preimpute_length_unambiguous,

--- a/pipes/WDL/workflows/scaffold_and_refine_multitaxa.wdl
+++ b/pipes/WDL/workflows/scaffold_and_refine_multitaxa.wdl
@@ -21,10 +21,6 @@ workflow scaffold_and_refine_multitaxa {
         File    reads_unmapped_bam
 
         File    taxid_to_ref_accessions_tsv
-        File?   focal_report_tsv
-        File?   ncbi_taxdump_tgz
-
-        # Float    min_pct_reference_covered = 0.1
     }
 
     Int    min_scaffold_unambig = 10

--- a/pipes/WDL/workflows/scaffold_and_refine_multitaxa.wdl
+++ b/pipes/WDL/workflows/scaffold_and_refine_multitaxa.wdl
@@ -53,7 +53,7 @@ workflow scaffold_and_refine_multitaxa {
     }
 
     # assemble and produce stats for every reference cluster
-    Array[String] assembly_header = ["entity:assembly_id", "assembly_name", "sample_id", "sample_name", "taxid", "tax_name", "assembly_fasta", "aligned_only_reads_bam", "coverage_plot", "assembly_length", "assembly_length_unambiguous", "reads_aligned", "mean_coverage", "percent_reference_covered", "scaffolding_num_segments_recovered", "reference_num_segments_required", "reference_length", "reference_accessions", "skani_num_ref_clusters", "skani_this_cluster_num_refs", "skani_dist_tsv", "intermediate_gapfill_fasta", "assembly_preimpute_length_unambiguous", "replicate_concordant_sites", "replicate_discordant_snps", "replicate_discordant_indels", "replicate_discordant_vcf", "isnvsFile", "aligned_bam", "coverage_tsv", "read_pairs_aligned", "bases_aligned", "coverage_genbank", "assembly_method", "sample"]
+    Array[String] assembly_header = ["entity:assembly_id", "assembly_name", "sample_id", "sample_name", "taxid", "tax_name", "assembly_fasta", "aligned_only_reads_bam", "coverage_plot", "assembly_length", "assembly_length_unambiguous", "reads_aligned", "mean_coverage", "percent_reference_covered", "scaffolding_num_segments_recovered", "reference_num_segments_required", "reference_length", "reference_accessions", "skani_num_ref_clusters", "skani_this_cluster_num_refs", "skani_dist_tsv", "scaffolding_ani", "scaffolding_pct_ref_cov", "intermediate_gapfill_fasta", "assembly_preimpute_length_unambiguous", "replicate_concordant_sites", "replicate_discordant_snps", "replicate_discordant_indels", "replicate_discordant_vcf", "isnvsFile", "aligned_bam", "coverage_tsv", "read_pairs_aligned", "bases_aligned", "coverage_genbank", "assembly_method", "sample"]
     scatter(ref_cluster in select_references.matched_reference_clusters_fastas) {
         call assembly.scaffold {
             input:
@@ -123,7 +123,9 @@ workflow scaffold_and_refine_multitaxa {
 
             "skani_num_ref_clusters" :      length(select_references.matched_reference_clusters_basenames),
             "skani_this_cluster_num_refs" : length(ref_cluster),
-            "skani_dist_tsv" :              select_references.skani_dist_full_tsv,
+            "skani_dist_tsv" :              scaffold.scaffolding_stats,
+            "scaffolding_ani" :             scaffold.skani_ani,
+            "scaffolding_pct_ref_cov" :     scaffold.skani_ref_af,
 
             "intermediate_gapfill_fasta" :            scaffold.intermediate_gapfill_fasta,
             "assembly_preimpute_length_unambiguous" : scaffold.assembly_preimpute_length_unambiguous,

--- a/pipes/WDL/workflows/scaffold_and_refine_multitaxa.wdl
+++ b/pipes/WDL/workflows/scaffold_and_refine_multitaxa.wdl
@@ -54,7 +54,7 @@ workflow scaffold_and_refine_multitaxa {
 
     # assemble and produce stats for every reference cluster
     Array[String] assembly_header = ["entity:assembly_id", "assembly_name", "sample_id", "sample_name", "taxid", "tax_name", "assembly_fasta", "aligned_only_reads_bam", "coverage_plot", "assembly_length", "assembly_length_unambiguous", "reads_aligned", "mean_coverage", "percent_reference_covered", "scaffolding_num_segments_recovered", "reference_num_segments_required", "reference_length", "reference_accessions", "skani_num_ref_clusters", "skani_this_cluster_num_refs", "skani_dist_tsv", "intermediate_gapfill_fasta", "assembly_preimpute_length_unambiguous", "replicate_concordant_sites", "replicate_discordant_snps", "replicate_discordant_indels", "replicate_discordant_vcf", "isnvsFile", "aligned_bam", "coverage_tsv", "read_pairs_aligned", "bases_aligned", "coverage_genbank", "assembly_method", "sample"]
-    scatter(ref_cluster in select_references.matched_reference_clusters_fastas)
+    scatter(ref_cluster in select_references.matched_reference_clusters_fastas) {
         call assembly.scaffold {
             input:
                 reads_bam = reads_unmapped_bam,

--- a/pipes/WDL/workflows/scaffold_and_refine_multitaxa.wdl
+++ b/pipes/WDL/workflows/scaffold_and_refine_multitaxa.wdl
@@ -24,7 +24,7 @@ workflow scaffold_and_refine_multitaxa {
         File    taxid_to_ref_accessions_tsv
     }
 
-    Int    min_scaffold_unambig = 10
+    Int    min_scaffold_unambig = 10 # in base-pairs; any scaffolded assembly < this length will not be refined/polished
     String sample_original_name = flatten([sample_names, [sample_id]])[0]
 
     # download (multi-segment) genomes for each reference, fasta filename = colon-concatenated accession list
@@ -101,9 +101,9 @@ workflow scaffold_and_refine_multitaxa {
         String tax_name = tax_lookup.map["taxname"]
 
         # build output tsv row
-        Int    assembly_length_unambiguous = select_first([refine.assembly_length_unambiguous])
+        Int    assembly_length_unambiguous = select_first([refine.assembly_length_unambiguous, 0])
         Float  percent_reference_covered = 1.0 * assembly_length_unambiguous / scaffold.reference_length
-        File   assembly_fasta = select_first([refine.assembly_fasta])
+        File   assembly_fasta = select_first([refine.assembly_fasta, scaffold.intermediate_gapfill_fasta])
         Map[String, String] stats_by_taxon = {
             "entity:assembly_id" : sample_id + "-" + taxid,
             "assembly_name" :      tax_name + ": " + sample_original_name,
@@ -113,12 +113,12 @@ workflow scaffold_and_refine_multitaxa {
             "tax_name" :           tax_name,
 
             "assembly_fasta" :              assembly_fasta,
-            "aligned_only_reads_bam" :      select_first([refine.align_to_self_merged_aligned_only_bam]),
-            "coverage_plot" :               select_first([refine.align_to_self_merged_coverage_plot]),
-            "assembly_length" :             select_first([refine.assembly_length]),
+            "aligned_only_reads_bam" :      select_first([refine.align_to_self_merged_aligned_only_bam, ""]),
+            "coverage_plot" :               select_first([refine.align_to_self_merged_coverage_plot, ""]),
+            "assembly_length" :             select_first([refine.assembly_length, "0"]),
             "assembly_length_unambiguous" : assembly_length_unambiguous,
-            "reads_aligned" :               select_first([refine.align_to_self_merged_reads_aligned]),
-            "mean_coverage" :               select_first([refine.align_to_self_merged_mean_coverage]),
+            "reads_aligned" :               select_first([refine.align_to_self_merged_reads_aligned, "0"]),
+            "mean_coverage" :               select_first([refine.align_to_self_merged_mean_coverage, "0"]),
             "percent_reference_covered" :   percent_reference_covered,
             "scaffolding_num_segments_recovered" : scaffold.assembly_num_segments_recovered,
             "reference_num_segments_required" : scaffold.reference_num_segments_required,
@@ -134,16 +134,16 @@ workflow scaffold_and_refine_multitaxa {
             "intermediate_gapfill_fasta" :            scaffold.intermediate_gapfill_fasta,
             "assembly_preimpute_length_unambiguous" : scaffold.assembly_preimpute_length_unambiguous,
 
-            "replicate_concordant_sites" :  select_first([refine.replicate_concordant_sites]),
-            "replicate_discordant_snps" :   select_first([refine.replicate_discordant_snps]),
-            "replicate_discordant_indels" : select_first([refine.replicate_discordant_indels]),
-            "replicate_discordant_vcf" :    select_first([refine.replicate_discordant_vcf]),
+            "replicate_concordant_sites" :  select_first([refine.replicate_concordant_sites, "0"]),
+            "replicate_discordant_snps" :   select_first([refine.replicate_discordant_snps, "0"]),
+            "replicate_discordant_indels" : select_first([refine.replicate_discordant_indels, "0"]),
+            "replicate_discordant_vcf" :    select_first([refine.replicate_discordant_vcf, ""]),
 
-            "isnvsFile" :          select_first([refine.align_to_self_isnvs_vcf]),
-            "aligned_bam" :        select_first([refine.align_to_self_merged_aligned_only_bam]),
-            "coverage_tsv" :       select_first([refine.align_to_self_merged_coverage_tsv]),
-            "read_pairs_aligned" : select_first([refine.align_to_self_merged_read_pairs_aligned]),
-            "bases_aligned" :      select_first([refine.align_to_self_merged_bases_aligned]),
+            "isnvsFile" :          select_first([refine.align_to_self_isnvs_vcf, ""]),
+            "aligned_bam" :        select_first([refine.align_to_self_merged_aligned_only_bam, ""]),
+            "coverage_tsv" :       select_first([refine.align_to_self_merged_coverage_tsv, ""]),
+            "read_pairs_aligned" : select_first([refine.align_to_self_merged_read_pairs_aligned, "0"]),
+            "bases_aligned" :      select_first([refine.align_to_self_merged_bases_aligned, "0"]),
             "coverage_genbank" :   select_first([coverage_two_col.out_tsv, ""]),
 
             "assembly_method" :    "viral-ngs/assemble_denovo",

--- a/pipes/WDL/workflows/scaffold_and_refine_multitaxa.wdl
+++ b/pipes/WDL/workflows/scaffold_and_refine_multitaxa.wdl
@@ -93,10 +93,11 @@ workflow scaffold_and_refine_multitaxa {
 
         String taxid = basename(scaffold.scaffolding_chosen_ref, ".fasta")
         call utils.fetch_row_from_tsv as tax_lookup {
-            tsv = taxid_to_ref_accessions_tsv,
-            idx_col = "taxid",
-            idx_val = taxid,
-            add_header = ["taxid", "taxname", "accessions"]
+            input:
+                tsv = taxid_to_ref_accessions_tsv,
+                idx_col = "taxid",
+                idx_val = taxid,
+                add_header = ["taxid", "taxname", "accessions"]
         }
         String tax_name = tax_lookup.map["taxname"]
         Map[String, String] stats_by_taxon = {
@@ -161,11 +162,10 @@ workflow scaffold_and_refine_multitaxa {
         File   assembly_stats_by_taxon_tsv                 = concatenate.combined
         String assembly_method                             = "viral-ngs/scaffold_and_refine_multitaxa"
 
-        ## TO DO: some summary stats on stats_by_taxon: how many rows, numbers from the best row, etc
-        #String assembly_top_taxon_id               = 
-        #String assembly_top_length_unambiguous     = 
-        #Float  assembly_top_pct_ref_cov            = 
-        #File   assembly_top_fasta                  = 
+        String assembly_top_taxon_id               = select_references.top_matches_per_cluster_basenames[0]
+        Int    skani_num_ref_clusters              = length(select_references.matched_reference_clusters_basenames)
+        File   skani_contigs_to_refs_dist_tsv      = select_references.skani_dist_full_tsv
+
         Array[String] assembly_all_taxids          = taxid
         Array[String] assembly_all_taxnames        = tax_name
         Array[Int]    assembly_all_lengths_unambig = assembly_length_unambiguous

--- a/pipes/WDL/workflows/scaffold_and_refine_multitaxa.wdl
+++ b/pipes/WDL/workflows/scaffold_and_refine_multitaxa.wdl
@@ -52,7 +52,8 @@ workflow scaffold_and_refine_multitaxa {
             # user must specify contigs_fasta
     }
 
-    Array[String] assembly_header = ["entity:assembly_id", "assembly_name", "sample_id", "sample_name", "taxid", "tax_name", "assembly_fasta", "aligned_only_reads_bam", "coverage_plot", "assembly_length", "assembly_length_unambiguous", "reads_aligned", "mean_coverage", "percent_reference_covered", "scaffolding_num_segments_recovered", "reference_num_segments_required", "reference_length", "reference_accessions", "intermediate_gapfill_fasta", "assembly_preimpute_length_unambiguous", "replicate_concordant_sites", "replicate_discordant_snps", "replicate_discordant_indels", "replicate_discordant_vcf", "isnvsFile", "aligned_bam", "coverage_tsv", "read_pairs_aligned", "bases_aligned", "coverage_genbank", "assembly_method", "sample"]
+    # assemble and produce stats for every reference cluster
+    Array[String] assembly_header = ["entity:assembly_id", "assembly_name", "sample_id", "sample_name", "taxid", "tax_name", "assembly_fasta", "aligned_only_reads_bam", "coverage_plot", "assembly_length", "assembly_length_unambiguous", "reads_aligned", "mean_coverage", "percent_reference_covered", "scaffolding_num_segments_recovered", "reference_num_segments_required", "reference_length", "reference_accessions", "skani_num_ref_clusters", "skani_this_cluster_num_refs", "skani_dist_tsv", "intermediate_gapfill_fasta", "assembly_preimpute_length_unambiguous", "replicate_concordant_sites", "replicate_discordant_snps", "replicate_discordant_indels", "replicate_discordant_vcf", "isnvsFile", "aligned_bam", "coverage_tsv", "read_pairs_aligned", "bases_aligned", "coverage_genbank", "assembly_method", "sample"]
     scatter(ref_cluster in select_references.matched_reference_clusters_fastas)
         call assembly.scaffold {
             input:
@@ -118,6 +119,10 @@ workflow scaffold_and_refine_multitaxa {
             "reference_num_segments_required" : scaffold.reference_num_segments_required,
             "reference_length" :            scaffold.reference_length,
             "reference_accessions" :        tax_lookup.map["accessions"],
+
+            "skani_num_ref_clusters" :      length(select_references.matched_reference_clusters_basenames),
+            "skani_this_cluster_num_refs" : length(ref_cluster),
+            "skani_dist_tsv" :              select_references.skani_dist_full_tsv,
 
             "intermediate_gapfill_fasta" :            scaffold.intermediate_gapfill_fasta,
             "assembly_preimpute_length_unambiguous" : scaffold.assembly_preimpute_length_unambiguous,

--- a/pipes/WDL/workflows/scaffold_and_refine_multitaxa.wdl
+++ b/pipes/WDL/workflows/scaffold_and_refine_multitaxa.wdl
@@ -19,6 +19,7 @@ workflow scaffold_and_refine_multitaxa {
         String  sample_id
         Array[String] sample_names
         File    reads_unmapped_bam
+        File    contigs_fasta
 
         File    taxid_to_ref_accessions_tsv
     }
@@ -44,8 +45,8 @@ workflow scaffold_and_refine_multitaxa {
     # subset references to those with ANI hits to contigs and cluster reference hits by any ANI similarity to each other
     call assembly.select_references {
         input:
-            reference_genomes_fastas = download_annotations.combined_fasta
-            # user must specify contigs_fasta
+            reference_genomes_fastas = download_annotations.combined_fasta,
+            contigs_fasta = contigs_fasta
     }
 
     # assemble and produce stats for every reference cluster
@@ -54,6 +55,7 @@ workflow scaffold_and_refine_multitaxa {
         call assembly.scaffold {
             input:
                 reads_bam = reads_unmapped_bam,
+                contigs_fasta = contigs_fasta,
                 reference_genome_fasta = ref_cluster,
                 min_length_fraction = 0,
                 min_unambig = 0,

--- a/pipes/WDL/workflows/scaffold_and_refine_multitaxa.wdl
+++ b/pipes/WDL/workflows/scaffold_and_refine_multitaxa.wdl
@@ -162,7 +162,7 @@ workflow scaffold_and_refine_multitaxa {
         File   assembly_stats_by_taxon_tsv                 = concatenate.combined
         String assembly_method                             = "viral-ngs/scaffold_and_refine_multitaxa"
 
-        String assembly_top_taxon_id               = select_references.top_matches_per_cluster_basenames[0]
+        #String assembly_top_taxon_id               = select_references.top_matches_per_cluster_basenames[0]
         Int    skani_num_ref_clusters              = length(select_references.matched_reference_clusters_basenames)
         File   skani_contigs_to_refs_dist_tsv      = select_references.skani_dist_full_tsv
 

--- a/pipes/WDL/workflows/terra_tsv_to_table.wdl
+++ b/pipes/WDL/workflows/terra_tsv_to_table.wdl
@@ -3,18 +3,30 @@ version 1.0
 #DX_SKIP_WORKFLOW
 
 import "../tasks/tasks_terra.wdl" as terra
+import "../tasks/tasks_utils.wdl" as utils
 
 workflow terra_tsv_to_table {
     meta {
-        description: "Upload tsv file to Terra data table: insert-or-update on existing rows/columns"
+        description: "Upload tsv files to Terra data table: insert-or-update on existing rows/columns"
         author: "Broad Viral Genomics"
         email:  "viral-ngs@broadinstitute.org"
     }
 
+    input {
+        Array[File]+ tsv_files
+    }
+
     call terra.check_terra_env
+
+    call utils.cat_except_headers {
+        input:
+            infiles = tsv_files,
+            out_filename = "terra_upload.tsv"
+    }
 
     call terra.upload_entities_tsv {
         input:
+            tsv_file         = cat_except_headers.out_tsv,
             workspace_name   = check_terra_env.workspace_name,
             terra_project    = check_terra_env.workspace_namespace
     }

--- a/requirements-modules.txt
+++ b/requirements-modules.txt
@@ -1,5 +1,5 @@
 broadinstitute/viral-core=2.3.1
-broadinstitute/viral-assemble=2.3.1.0
+broadinstitute/viral-assemble=2.3.1.1
 broadinstitute/viral-classify=2.2.4.0
 broadinstitute/viral-phylo=2.1.20.2
 broadinstitute/py3-bio=0.1.2

--- a/requirements-modules.txt
+++ b/requirements-modules.txt
@@ -1,5 +1,5 @@
 broadinstitute/viral-core=2.3.1
-broadinstitute/viral-assemble=2.3.0.0
+broadinstitute/viral-assemble=2.3.1.0
 broadinstitute/viral-classify=2.2.4.0
 broadinstitute/viral-phylo=2.1.20.2
 broadinstitute/py3-bio=0.1.2

--- a/requirements-modules.txt
+++ b/requirements-modules.txt
@@ -1,5 +1,5 @@
 broadinstitute/viral-core=2.3.1
-broadinstitute/viral-assemble=2.3.1.1
+broadinstitute/viral-assemble=2.3.1.2
 broadinstitute/viral-classify=2.2.4.0
 broadinstitute/viral-phylo=2.1.20.2
 broadinstitute/py3-bio=0.1.2

--- a/requirements-modules.txt
+++ b/requirements-modules.txt
@@ -1,5 +1,5 @@
 broadinstitute/viral-core=2.3.1
-broadinstitute/viral-assemble=2.3.1.2
+broadinstitute/viral-assemble=2.3.1.3
 broadinstitute/viral-classify=2.2.4.0
 broadinstitute/viral-phylo=2.1.20.2
 broadinstitute/py3-bio=0.1.2


### PR DESCRIPTION
This PR introduces ANI-based mechanisms for reference selection using `skani`. This:
- updates viral-assemble to 2.3.1.1
- adds a task `select_references` to tasks_assembly.wdl that selects a subset of reference genomes based on ANI similarity to a set of given contigs/MAGs. This also clusters similar reference genomes to each other based on ANI and chooses only the top reference per cluster.
- changes task `scaffold`'s behavior in task_assembly.wdl to chose a reference genome based on ANI when provided multiple reference genomes.
- changes the behavior of `scaffold_and_refine_multitaxa` to:
  - select a subset of reference genomes to scaffold against using ANI similarity to the contigs instead of a kraken-based reference selection
  - call scaffolding and refine steps on a per-reference-cluster basis instead of per-reference-taxon, forcing a choice of the most appropriate taxon of highly-related taxa
  - no longer fall-back to reference based assembly, since de novo scaffolding should always work if an ANI hit was found

This updated version of `scaffold_and_refine_multitaxa` should be far more efficient at metagenomic reference selection, produce less noisy outputs (less secondary taxon hits), still allow for diverse coinfections of unrelated taxa, and should perform well with a very large reference genome database as input.

This PR also introduces an unrelated change to modify the workflow `terra_tsv_to_table` to accept and concatenate multiple input tsv files.