### PR TITLE
In align_and_count, change default to count only properly-paired reads

### DIFF
--- a/pipes/WDL/tasks/tasks_reports.wdl
+++ b/pipes/WDL/tasks/tasks_reports.wdl
@@ -392,7 +392,7 @@ task align_and_count {
     File   ref_db
     Int    topNHits = 3
 
-    Boolean filter_bam_to_proper_primary_mapped_reads         = false
+    Boolean filter_bam_to_proper_primary_mapped_reads         = true
     Boolean do_not_require_proper_mapped_pairs_when_filtering = false
     Boolean keep_singletons_when_filtering                    = false
     Boolean keep_duplicates_when_filtering                    = false


### PR DESCRIPTION
Change the input, `filter_bam_to_proper_primary_mapped_reads`, in `align_and_count` to a default value of `true`; this changes the behavior of the task. Before filtering was available as an optional operation in `align_and_count`, reads were not filtered to proper pairs and later on the value of `filter_bam_to_proper_primary_mapped_reads=false` maintained the no-filter approach. With this commit, only properly-paired mapped reads are counted in `align_and_count`.