### PR TITLE
classify_single: parameterize taxa to deplete

### DIFF
--- a/pipes/WDL/tasks/tasks_16S_amplicon.wdl
+++ b/pipes/WDL/tasks/tasks_16S_amplicon.wdl
@@ -9,7 +9,7 @@ task qiime_import_from_bam {
         Int    memory_mb = 7000
         Int     cpu = 5
         Int     disk_size_gb = ceil(2*20) + 5
-        String  docker     = "quay.io/broadinstitute/qiime2" 
+        String  docker     = "quay.io/broadinstitute/qiime2:latest"
     }
     parameter_meta {
         reads_bam: {
@@ -86,7 +86,7 @@ task trim_reads {
         Int     memory_mb = 2000
         Int     cpu = 4
         Int     disk_size_gb = ceil(2*size(reads_qza, "GiB")) + 5
-        String  docker          = "quay.io/broadinstitute/qiime2" 
+        String  docker          = "quay.io/broadinstitute/qiime2:latest"
     }
     parameter_meta {
         reads_qza: {
@@ -160,7 +160,7 @@ task join_paired_ends {
         Int     memory_mb = 2000
         Int     cpu = 1
         Int     disk_size_gb = ceil(2*size(trimmed_reads_qza, "GiB")) + 50
-        String  docker = "quay.io/broadinstitute/qiime2"
+        String  docker = "quay.io/broadinstitute/qiime2:latest"
     }
     parameter_meta{
         trimmed_reads_qza: {
@@ -210,7 +210,7 @@ task deblur {
         Int     memory_mb = 2000
         Int     cpu = 1
         Int     disk_size_gb = ceil(2*size(joined_end_reads_qza, "GiB")) + 5
-        String  docker = "quay.io/broadinstitute/qiime2"
+        String  docker = "quay.io/broadinstitute/qiime2:latest"
     }
     parameter_meta {
         joined_end_reads_qza: {
@@ -288,7 +288,7 @@ task train_classifier {
         Int     memory_mb = 2000
         Int     cpu = 1
         Int     disk_size_gb = ceil(2*size(otu_ref, "GiB")) + 5
-        String  docker = "quay.io/broadinstitute/qiime2"
+        String  docker = "quay.io/broadinstitute/qiime2:latest"
     }
     parameter_meta{
         otu_ref: {
@@ -372,7 +372,7 @@ task tax_analysis {
         Int     memory_mb = 5
         Int     cpu = 1
         Int     disk_size_gb = 375
-        String  docker = "quay.io/broadinstitute/qiime2"
+        String  docker = "quay.io/broadinstitute/qiime2:latest"
     }
     parameter_meta{ 
         trained_classifier: {

--- a/pipes/WDL/tasks/tasks_read_utils.wdl
+++ b/pipes/WDL/tasks/tasks_read_utils.wdl
@@ -173,10 +173,10 @@ task merge_and_reheader_bams {
       String       out_basename = basename(in_bams[0], ".bam")
 
       String       docker = "quay.io/broadinstitute/viral-core:2.3.1"
+      Int          disk_size = 750
+      Int          machine_mem_gb = 4
     }
     
-    Int disk_size = 750
-
     command <<<
         set -ex -o pipefail
 
@@ -224,7 +224,7 @@ task merge_and_reheader_bams {
 
     runtime {
         docker: docker
-        memory: "3 GB"
+        memory: machine_mem_gb + " GB"
         cpu: 2
         disks:  "local-disk " + disk_size + " LOCAL"
         disk: disk_size + " GB" # TES

--- a/pipes/WDL/workflows/classify_single.wdl
+++ b/pipes/WDL/workflows/classify_single.wdl
@@ -23,6 +23,9 @@ workflow classify_single {
 
         File kraken2_db_tgz
         File krona_taxonomy_db_kraken2_tgz
+
+        Array[String] deplete_taxonomic_names  = ["Vertebrata"]
+        Array[String] unwanted_taxonomic_names = ["Vertebrata", "other sequences", "Bacteria"]
     }
 
     parameter_meta {
@@ -96,7 +99,7 @@ workflow classify_single {
             classified_reads_txt_gz = kraken2.kraken2_reads_report,
             ncbi_taxonomy_db_tgz    = ncbi_taxdump_tgz,
             exclude_taxa            = true,
-            taxonomic_names         = ["Vertebrata"],
+            taxonomic_names         = deplete_taxonomic_names,
             out_filename_suffix     = "hs_depleted"
     }
     call reports.fastqc as fastqc_cleaned {
@@ -108,7 +111,7 @@ workflow classify_single {
             classified_reads_txt_gz = kraken2.kraken2_reads_report,
             ncbi_taxonomy_db_tgz    = ncbi_taxdump_tgz,
             exclude_taxa            = true,
-            taxonomic_names         = ["Vertebrata", "other sequences", "Bacteria"],
+            taxonomic_names         = unwanted_taxonomic_names,
             out_filename_suffix     = "acellular"
     }
     call read_utils.rmdup_ubam {

--- a/pipes/WDL/workflows/classify_single.wdl
+++ b/pipes/WDL/workflows/classify_single.wdl
@@ -24,8 +24,8 @@ workflow classify_single {
         File kraken2_db_tgz
         File krona_taxonomy_db_kraken2_tgz
 
-        Array[String] deplete_taxonomic_names  = ["Vertebrata"]
-        Array[String] unwanted_taxonomic_names = ["Vertebrata", "other sequences", "Bacteria"]
+        Array[String] taxa_to_dehost         = ["Vertebrata"]
+        Array[String] taxa_to_avoid_assembly = ["Vertebrata", "other sequences", "Bacteria"]
     }
 
     parameter_meta {
@@ -99,7 +99,7 @@ workflow classify_single {
             classified_reads_txt_gz = kraken2.kraken2_reads_report,
             ncbi_taxonomy_db_tgz    = ncbi_taxdump_tgz,
             exclude_taxa            = true,
-            taxonomic_names         = deplete_taxonomic_names,
+            taxonomic_names         = taxa_to_dehost,
             out_filename_suffix     = "hs_depleted"
     }
     call reports.fastqc as fastqc_cleaned {
@@ -111,7 +111,7 @@ workflow classify_single {
             classified_reads_txt_gz = kraken2.kraken2_reads_report,
             ncbi_taxonomy_db_tgz    = ncbi_taxdump_tgz,
             exclude_taxa            = true,
-            taxonomic_names         = unwanted_taxonomic_names,
+            taxonomic_names         = taxa_to_avoid_assembly,
             out_filename_suffix     = "acellular"
     }
     call read_utils.rmdup_ubam {


### PR DESCRIPTION
The modern WDL spec has clarified that the end user can never override assignments to task inputs made in workflow code. This means that `classify_single`'s two invocations of the `metagenomics.filter_bam_to_taxa` task (with different default input values for each call) has inputs that are not user-editable as we intended. The only workaround appears to be to promote these task inputs to boilerplate workflow inputs that have default values (and are overridable by the end user).