### PR TITLE
in `create_or_update_sample_tables`, use the `sample_original` from demux  as the key value for rows rather than `sample` (i.e. use IDs with forward slashes not dashes)

### DIFF
--- a/pipes/WDL/tasks/tasks_terra.wdl
+++ b/pipes/WDL/tasks/tasks_terra.wdl
@@ -525,7 +525,7 @@ task create_or_update_sample_tables {
     # grab the meta_by_filename values to create new sample->library (sample_set->sample) mappings
     sample_to_libraries = {}
     for library_id, data in library_meta_dict.items():
-        sample_id = data['sample']
+        sample_id = data['sample_original']
         sample_to_libraries.setdefault(sample_id, [])
         if library_id in df_library.index:
             sample_to_libraries[sample_id].append(library_id)


### PR DESCRIPTION
in `create_or_update_sample_tables`, use the `sample_original` from demux  as the key value for rows rather than `sample` (i.e. use IDs with forward slashes not dashes)