### PR TITLE
increase default instance memory for kraken2 task 72 -> 90GB

### DIFF
--- a/pipes/WDL/tasks/tasks_metagenomics.wdl
+++ b/pipes/WDL/tasks/tasks_metagenomics.wdl
@@ -318,6 +318,7 @@ task kraken2 {
     docker: docker
     memory: machine_mem_gb + " GB"
     cpu: 16
+    cpuPlatform: "Intel Ice Lake"
     disks:  "local-disk " + disk_size + " LOCAL"
     disk: disk_size + " GB" # TESs
     dx_instance_type: "mem3_ssd1_v2_x8"

--- a/pipes/WDL/tasks/tasks_metagenomics.wdl
+++ b/pipes/WDL/tasks/tasks_metagenomics.wdl
@@ -212,7 +212,7 @@ task kraken2 {
     Float? confidence_threshold
     Int?   min_base_qual
 
-    Int    machine_mem_gb = 72
+    Int    machine_mem_gb = 90
     String docker = "quay.io/broadinstitute/viral-classify:2.2.4.0"
   }
 


### PR DESCRIPTION
To address OOM failures running kraken2 with the JHU standard PlusPF database, this PR increases the default amount of memory requested for the instance used for the kraken2 task, from 72 to 90GB.
 