### PR TITLE
add build environment spec to .readthedocs.yml config

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,6 +5,13 @@
 # Required
 version: 2
 
+# build environment
+#   see: https://docs.readthedocs.io/en/stable/config-file/v2.html#build
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.10"
+
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
   builder: html
@@ -19,6 +26,5 @@ formats: all
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-  version: 3.8
   install:
     - requirements: docs/requirements.txt


### PR DESCRIPTION
This PR is attempting to fix documentation builds.

A `build.os` value is now required by readthedocs; see: 
https://blog.readthedocs.com/use-build-os-config/

This specifies ubuntu 22.04 (the most recent tagged release currently available on RTD), and python 3.10.