### PR TITLE
scaffolding regression fixes plus docker updates

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -23,10 +23,10 @@ import wdl_aid
 sys.path.insert(0, os.path.dirname(os.path.abspath('.')))
 
 # -- Mock out the heavyweight pip packages, esp those that require C ----
-import mock
-MOCK_MODULES = []
-for mod_name in MOCK_MODULES:
-    sys.modules[mod_name] = mock.Mock()
+#import mock
+#MOCK_MODULES = []
+#for mod_name in MOCK_MODULES:
+#    sys.modules[mod_name] = mock.Mock()
 
 # -- Obtain GIT version --
 def _git_version():

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,6 @@
 jinja2==3.1.4 # https://github.com/readthedocs/readthedocs.org/issues/9037#issuecomment-1077818554
 Sphinx==7.4.7 #override sphinx pinning done by RTD: https://docs.readthedocs.io/en/stable/build-default-versions.html#external-dependencies
-#sphinx-argparse==0.5.2
+sphinx-argparse==0.5.2
 sphinx-rtd-theme==2.0.0
 PyYAML==6.0.1
 #mock==5.0.1

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,9 +1,9 @@
-jinja2==3.1.2 # https://github.com/readthedocs/readthedocs.org/issues/9037#issuecomment-1077818554
-Sphinx==5.3.0 #override sphinx pinning done by RTD: https://docs.readthedocs.io/en/stable/build-default-versions.html#external-dependencies
-sphinx-argparse
-sphinx-rtd-theme==1.1.1
-PyYAML==6.0
-mock==5.0.1
+jinja2==3.1.4 # https://github.com/readthedocs/readthedocs.org/issues/9037#issuecomment-1077818554
+Sphinx==7.4.7 #override sphinx pinning done by RTD: https://docs.readthedocs.io/en/stable/build-default-versions.html#external-dependencies
+#sphinx-argparse==0.5.2
+sphinx-rtd-theme==2.0.0
+PyYAML==6.0.1
+#mock==5.0.1
 recommonmark
-miniwdl==1.8.0
+#miniwdl==1.12.1
 wdl-aid==1.0.0

--- a/github_actions_ci/install-pip-docs.sh
+++ b/github_actions_ci/install-pip-docs.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 echo "pip installing test-related packages (Sphinx, etc.)"
-pip install -r docs/requirements.txt
+pip install --quiet -r docs/requirements.txt
 
 # list what was installed
 pip freeze

--- a/github_actions_ci/install-pip-docs.sh
+++ b/github_actions_ci/install-pip-docs.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 echo "pip installing test-related packages (Sphinx, etc.)"
-pip install --quiet -r docs/requirements.txt
+pip install -r docs/requirements.txt
 
 # list what was installed
 pip freeze

--- a/github_actions_ci/install-wdl.sh
+++ b/github_actions_ci/install-wdl.sh
@@ -12,9 +12,10 @@ fetch_jar_from_github () {
 	ln -s $_jar_fname $_tool_name.jar
 }
 
-fetch_jar_from_github broadinstitute cromwell womtool 86
-fetch_jar_from_github broadinstitute cromwell cromwell 86
+fetch_jar_from_github broadinstitute cromwell womtool 87
+fetch_jar_from_github broadinstitute cromwell cromwell 87
 fetch_jar_from_github dnanexus dxWDL dxWDL v1.50
+fetch_jar_from_github dnanexus dxCompiler dxCompiler 2.11.6
 
 TGZ=dx-toolkit-v0.311.0-ubuntu-20.04-amd64.tar.gz
 echo "Fetching $TGZ"

--- a/pipes/WDL/tasks/tasks_assembly.wdl
+++ b/pipes/WDL/tasks/tasks_assembly.wdl
@@ -15,7 +15,7 @@ task assemble {
       String   sample_name = basename(basename(reads_unmapped_bam, ".bam"), ".taxfilt")
       
       Int?     machine_mem_gb
-      String   docker = "quay.io/broadinstitute/viral-assemble:2.3.1.4"
+      String   docker = "quay.io/broadinstitute/viral-assemble:2.3.2.0"
     }
     parameter_meta{
       reads_unmapped_bam: {
@@ -115,7 +115,7 @@ task select_references {
     Int?          skani_s
     Int?          skani_c
 
-    String        docker = "quay.io/broadinstitute/viral-assemble:2.3.1.4"
+    String        docker = "quay.io/broadinstitute/viral-assemble:2.3.2.0"
     Int           machine_mem_gb = 4
     Int           cpu = 2
     Int           disk_size = 100
@@ -206,7 +206,7 @@ task scaffold {
       Float?       scaffold_min_pct_contig_aligned
 
       Int?         machine_mem_gb
-      String       docker="quay.io/broadinstitute/viral-assemble:2.3.1.4"
+      String       docker="quay.io/broadinstitute/viral-assemble:2.3.2.0"
 
       # do this in multiple steps in case the input doesn't actually have "assembly1-x" in the name
       String       sample_name = basename(basename(contigs_fasta, ".fasta"), ".assembly1-spades")
@@ -583,7 +583,7 @@ task align_reads {
     Boolean  skip_mark_dupes = false
 
     Int?     machine_mem_gb
-    String   docker = "quay.io/broadinstitute/viral-core:2.3.1"
+    String   docker = "quay.io/broadinstitute/viral-core:2.3.2"
 
     String   sample_name = basename(basename(basename(reads_unmapped_bam, ".bam"), ".taxfilt"), ".clean")
   }
@@ -720,7 +720,7 @@ task refine_assembly_with_aligned_reads {
       Int      min_coverage = 3
 
       Int      machine_mem_gb = 15
-      String   docker = "quay.io/broadinstitute/viral-assemble:2.3.1.4"
+      String   docker = "quay.io/broadinstitute/viral-assemble:2.3.2.0"
     }
 
     Int disk_size = 375
@@ -845,7 +845,7 @@ task refine_2x_and_plot {
       String? plot_coverage_novoalign_options = "-r Random -l 40 -g 40 -x 20 -t 100 -k"
 
       Int?    machine_mem_gb
-      String  docker = "quay.io/broadinstitute/viral-assemble:2.3.1.4"
+      String  docker = "quay.io/broadinstitute/viral-assemble:2.3.2.0"
 
       # do this in two steps in case the input doesn't actually have "cleaned" in the name
       String  sample_name = basename(basename(reads_unmapped_bam, ".bam"), ".cleaned")
@@ -981,7 +981,7 @@ task run_discordance {
       String out_basename = "run"
       Int    min_coverage = 4
 
-      String docker = "quay.io/broadinstitute/viral-core:2.3.1"
+      String docker = "quay.io/broadinstitute/viral-core:2.3.2"
     }
     parameter_meta {
       reads_aligned_bam: {

--- a/pipes/WDL/tasks/tasks_demux.wdl
+++ b/pipes/WDL/tasks/tasks_demux.wdl
@@ -6,7 +6,7 @@ task merge_tarballs {
     String       out_filename
 
     Int?         machine_mem_gb
-    String       docker = "quay.io/broadinstitute/viral-core:2.3.1"
+    String       docker = "quay.io/broadinstitute/viral-core:2.3.2"
   }
 
   Int disk_size = 2625
@@ -163,7 +163,7 @@ task illumina_demux {
 
     Int?    machine_mem_gb
     Int     disk_size = 2625
-    String  docker = "quay.io/broadinstitute/viral-core:2.3.1"
+    String  docker = "quay.io/broadinstitute/viral-core:2.3.2"
   }
 
   parameter_meta {

--- a/pipes/WDL/tasks/tasks_interhost.wdl
+++ b/pipes/WDL/tasks/tasks_interhost.wdl
@@ -351,7 +351,7 @@ task index_ref {
     File?  novocraft_license
 
     Int?   machine_mem_gb
-    String docker = "quay.io/broadinstitute/viral-core:2.3.1"
+    String docker = "quay.io/broadinstitute/viral-core:2.3.2"
   }
 
   Int disk_size = 100

--- a/pipes/WDL/tasks/tasks_megablast.wdl
+++ b/pipes/WDL/tasks/tasks_megablast.wdl
@@ -12,7 +12,7 @@ task trim_rmdup_subsamp {
         Int machine_mem_gb = 128
         Int cpu = 16
         Int disk_size_gb = 100 
-        String docker ="quay.io/broadinstitute/viral-assemble:2.3.1.4"
+        String docker ="quay.io/broadinstitute/viral-assemble:2.3.2.0"
     }
     parameter_meta {
         inBam: {

--- a/pipes/WDL/tasks/tasks_ncbi.wdl
+++ b/pipes/WDL/tasks/tasks_ncbi.wdl
@@ -1010,3 +1010,68 @@ task vadr {
   }
 }
 
+task sequence_rename_by_species {
+  meta {
+    description: "Rename sequences based on species-specific naming conventions for many viral taxa."
+  }
+  input {
+    String sample_id
+    String organism_name
+    File   biosample_attributes
+    String taxid
+    File   taxdump_tgz
+
+    String docker = "quay.io/broadinstitute/viral-classify:2.2.4.0"
+  }
+  command <<<
+    set -e
+    mkdir -p taxdump
+    read_utils.py extract_tarball "~{taxdump_tgz}" taxdump
+    python3 << CODE
+    import metagenomics
+    taxdb = metagenomics.TaxonomyDb(tax_dir='taxdump', load_nodes=True, load_gis=False)
+    taxid = int('~{taxid}')
+    ancestors = taxdb.get_ordered_ancestors(taxid)
+
+
+    if any(node == 3052310 for node in [taxid] + ancestors):
+      # LASV
+      pass
+    elif any(node == 186538 for node in [taxid] + ancestors):
+      # ZEBOV
+      pass
+    elif any(node == 11250 for node in [taxid] + ancestors):
+      # RSV -- no real convention! Some coalescence around this:
+      # <type>/<host lowercase>/Country/ST-Institution-LabID/Year
+      # e.g. RSV-A/human/USA/MA-Broad-1234/2020
+      pass
+    elif any(node == 2697049 for node in [taxid] + ancestors):
+      # SARS-CoV-2
+      # SARS-CoV-2/<host lowercase>/Country/ST-Institution-LabID/Year
+      # e.g. SARS-CoV-2/human/USA/MA-Broad-1234/2020
+      pass
+    elif any((node == 11320 or node == 11520) for node in [taxid] + ancestors):
+      # Flu A or B
+      # <type>/<hostname if not human>/<geoloc>/seqUID/year
+      # e.g. A/Massachusetts/Broad_MGH-1234/2001 or A/chicken/Hokkaido/TU25-3/2022 or B/Rhode Island/RISHL-1234/2024
+      pass
+    elif any(node == 12059 for node in [taxid] + ancestors):
+      # Enterovirus (including rhinos)
+      pass
+    else:
+      # everything else
+      pass
+
+    CODE
+  >>>
+  output {
+    String assembly_name_genbank = read_string("assembly_name_genbank")
+  }
+  runtime {
+    docker: docker
+    memory: "1 GB"
+    cpu: 1
+    dx_instance_type: "mem1_ssd1_v2_x2"
+    maxRetries: 2
+  }
+}

--- a/pipes/WDL/tasks/tasks_ncbi.wdl
+++ b/pipes/WDL/tasks/tasks_ncbi.wdl
@@ -192,7 +192,7 @@ task structured_comments {
 
     File?  filter_to_ids
 
-    String docker = "quay.io/broadinstitute/viral-core:2.3.1"
+    String docker = "quay.io/broadinstitute/viral-core:2.3.2"
   }
   String out_base = basename(assembly_stats_tsv, '.txt')
   command <<<
@@ -272,7 +272,7 @@ task rename_fasta_header {
 
     String out_basename = basename(genome_fasta, ".fasta")
 
-    String docker = "quay.io/broadinstitute/viral-core:2.3.1"
+    String docker = "quay.io/broadinstitute/viral-core:2.3.2"
   }
   command {
     set -e
@@ -437,7 +437,7 @@ task sra_meta_prep {
     Boolean     paired
 
     String      out_name = "sra_metadata.tsv"
-    String      docker="quay.io/broadinstitute/viral-core:2.3.1"
+    String      docker="quay.io/broadinstitute/viral-core:2.3.2"
   }
   Int disk_size = 100
   parameter_meta {

--- a/pipes/WDL/tasks/tasks_ncbi.wdl
+++ b/pipes/WDL/tasks/tasks_ncbi.wdl
@@ -1021,7 +1021,7 @@ task sequence_rename_by_species {
     String taxid
     File   taxdump_tgz
 
-    String docker = "quay.io/broadinstitute/viral-classify:2.2.4.0"
+    String docker = "quay.io/broadinstitute/viral-classify:2.2.4.2"
   }
   command <<<
     set -e

--- a/pipes/WDL/tasks/tasks_nextstrain.wdl
+++ b/pipes/WDL/tasks/tasks_nextstrain.wdl
@@ -323,7 +323,7 @@ task derived_cols {
         String?       lab_highlight_loc
         Array[File]   table_map = []
 
-        String        docker = "quay.io/broadinstitute/viral-core:2.3.1"
+        String        docker = "quay.io/broadinstitute/viral-core:2.3.2"
         Int           disk_size = 50
     }
     parameter_meta {
@@ -891,7 +891,7 @@ task filter_sequences_to_list {
 
         String       out_fname = sub(sub(basename(sequences, ".zst"), ".vcf", ".filtered.vcf"), ".fasta$", ".filtered.fasta")
         # Prior docker image: "nextstrain/base:build-20240318T173028Z"
-        String       docker = "quay.io/broadinstitute/viral-core:2.3.1"
+        String       docker = "quay.io/broadinstitute/viral-core:2.3.2"
         Int          disk_size = 750
     }
     parameter_meta {

--- a/pipes/WDL/tasks/tasks_read_utils.wdl
+++ b/pipes/WDL/tasks/tasks_read_utils.wdl
@@ -84,7 +84,7 @@ task group_bams_by_sample {
 task get_bam_samplename {
   input {
     File    bam
-    String  docker = "quay.io/broadinstitute/viral-core:2.3.1"
+    String  docker = "quay.io/broadinstitute/viral-core:2.3.2"
   }
   Int   disk_size = round(size(bam, "GB")) + 50
   command <<<
@@ -111,7 +111,7 @@ task get_sample_meta {
   input {
     Array[File] samplesheets_extended
 
-    String      docker = "quay.io/broadinstitute/viral-core:2.3.1"
+    String      docker = "quay.io/broadinstitute/viral-core:2.3.2"
   }
   Int disk_size = 50
   command <<<
@@ -172,7 +172,7 @@ task merge_and_reheader_bams {
       File?        reheader_table
       String       out_basename = basename(in_bams[0], ".bam")
 
-      String       docker = "quay.io/broadinstitute/viral-core:2.3.1"
+      String       docker = "quay.io/broadinstitute/viral-core:2.3.2"
       Int          disk_size = 750
       Int          machine_mem_gb = 4
     }
@@ -244,7 +244,7 @@ task rmdup_ubam {
     String  method = "mvicuna"
 
     Int     machine_mem_gb = 7
-    String  docker = "quay.io/broadinstitute/viral-core:2.3.1"
+    String  docker = "quay.io/broadinstitute/viral-core:2.3.2"
   }
 
   Int disk_size = 375
@@ -303,7 +303,7 @@ task downsample_bams {
     Boolean      deduplicateAfter = false
 
     Int?         machine_mem_gb
-    String       docker = "quay.io/broadinstitute/viral-core:2.3.1"
+    String       docker = "quay.io/broadinstitute/viral-core:2.3.2"
   }
 
   Int disk_size = 750
@@ -367,7 +367,7 @@ task FastqToUBAM {
     String? sequencing_center
     String? additional_picard_options
 
-    String  docker = "quay.io/broadinstitute/viral-core:2.3.1"
+    String  docker = "quay.io/broadinstitute/viral-core:2.3.2"
   }
   Int disk_size = 375
   parameter_meta {
@@ -418,7 +418,7 @@ task read_depths {
     File      aligned_bam
 
     String    out_basename = basename(aligned_bam, '.bam')
-    String    docker = "quay.io/broadinstitute/viral-core:2.3.1"
+    String    docker = "quay.io/broadinstitute/viral-core:2.3.2"
   }
   Int disk_size = 200
   command <<<

--- a/pipes/WDL/tasks/tasks_reports.wdl
+++ b/pipes/WDL/tasks/tasks_reports.wdl
@@ -72,7 +72,8 @@ task alignment_metrics {
     echo -e "sample_sanitized\tbam\tamplicon_set\tamplicon_idx\tamplicon_left\tamplicon_right\tFREADS\tFDEPTH\tFPCOV\tFAMP" > "~{out_basename}.ampliconstats_parsed.txt"
     if [ -n "~{primers_bed}" ]; then
       # samtools ampliconstats
-      cat "~{primers_bed}" | sort -k 1 -k 4 -t $'\t' > primers-sorted_for_samtools.bed
+      cat "~{primers_bed}" | sort -k 1,1 -k 4,4 -t $'\t' > primers-sorted_for_samtools.bed
+      set +e # there are just some weird bed files out there -- let them fail silently
       samtools ampliconstats -s -@ $(nproc) \
         ~{'-d ' + min_coverage} \
         ~{'-l ' + max_amp_len} \

--- a/pipes/WDL/tasks/tasks_reports.wdl
+++ b/pipes/WDL/tasks/tasks_reports.wdl
@@ -14,7 +14,7 @@ task alignment_metrics {
     Int    max_amp_len=5000
     Int    max_amplicons=500
 
-    Int    machine_mem_gb=13
+    Int    machine_mem_gb=32
     String docker = "quay.io/broadinstitute/viral-core:2.3.1"
   }
 
@@ -108,10 +108,10 @@ task alignment_metrics {
   runtime {
     docker: docker
     memory: machine_mem_gb + " GB"
-    cpu: 2
+    cpu: 4
     disks:  "local-disk " + disk_size + " HDD"
     disk: disk_size + " GB" # TES
-    dx_instance_type: "mem1_ssd1_v2_x2"
+    dx_instance_type: "mem3_ssd1_v2_x4"
     maxRetries: 2
   }
 }

--- a/pipes/WDL/tasks/tasks_reports.wdl
+++ b/pipes/WDL/tasks/tasks_reports.wdl
@@ -72,7 +72,7 @@ task alignment_metrics {
     echo -e "sample_sanitized\tbam\tamplicon_set\tamplicon_idx\tamplicon_left\tamplicon_right\tFREADS\tFDEPTH\tFPCOV\tFAMP" > "~{out_basename}.ampliconstats_parsed.txt"
     if [ -n "~{primers_bed}" ]; then
       # samtools ampliconstats
-      cat "~{primers_bed}" | sort -k 4 -t $'\t' > primers-sorted_for_samtools.bed
+      cat "~{primers_bed}" | sort -k 1 -k 4 -t $'\t' > primers-sorted_for_samtools.bed
       samtools ampliconstats -s -@ $(nproc) \
         ~{'-d ' + min_coverage} \
         ~{'-l ' + max_amp_len} \

--- a/pipes/WDL/tasks/tasks_reports.wdl
+++ b/pipes/WDL/tasks/tasks_reports.wdl
@@ -15,7 +15,7 @@ task alignment_metrics {
     Int    max_amplicons=500
 
     Int    machine_mem_gb=32
-    String docker = "quay.io/broadinstitute/viral-core:2.3.1"
+    String docker = "quay.io/broadinstitute/viral-core:2.3.2"
   }
 
   String out_basename = basename(aligned_bam, ".bam")
@@ -137,7 +137,7 @@ task plot_coverage {
     String? plotXLimits # of the form "min max" (ints, space between)
     String? plotYLimits # of the form "min max" (ints, space between)
 
-    String  docker = "quay.io/broadinstitute/viral-core:2.3.1"
+    String  docker = "quay.io/broadinstitute/viral-core:2.3.2"
   }
 
   Int disk_size = 375
@@ -284,7 +284,7 @@ task coverage_report {
     Array[File]  mapped_bam_idx # optional.. speeds it up if you provide it, otherwise we auto-index
     String       out_report_name = "coverage_report.txt"
 
-    String       docker = "quay.io/broadinstitute/viral-core:2.3.1"
+    String       docker = "quay.io/broadinstitute/viral-core:2.3.2"
   }
 
   Int disk_size = 375
@@ -351,7 +351,7 @@ task fastqc {
   input {
     File   reads_bam
 
-    String docker = "quay.io/broadinstitute/viral-core:2.3.1"
+    String docker = "quay.io/broadinstitute/viral-core:2.3.2"
   }
   parameter_meta {
     reads_bam:{ 
@@ -399,7 +399,7 @@ task align_and_count {
     Boolean keep_duplicates_when_filtering                    = false
 
     Int?   machine_mem_gb
-    String docker = "quay.io/broadinstitute/viral-core:2.3.1"
+    String docker = "quay.io/broadinstitute/viral-core:2.3.2"
   }
 
   String  reads_basename=basename(reads_bam, ".bam")
@@ -504,7 +504,7 @@ task align_and_count_summary {
 
     String       output_prefix = "count_summary"
 
-    String       docker = "quay.io/broadinstitute/viral-core:2.3.1"
+    String       docker = "quay.io/broadinstitute/viral-core:2.3.2"
   }
 
   Int disk_size = 100
@@ -686,7 +686,7 @@ task compare_two_genomes {
     File   genome_two
     String out_basename
 
-    String docker = "quay.io/broadinstitute/viral-assemble:2.3.1.4"
+    String docker = "quay.io/broadinstitute/viral-assemble:2.3.2.0"
   }
 
   Int disk_size = 50

--- a/pipes/WDL/tasks/tasks_taxon_filter.wdl
+++ b/pipes/WDL/tasks/tasks_taxon_filter.wdl
@@ -211,7 +211,7 @@ task merge_one_per_sample {
     Boolean      rmdup = false
 
     Int          machine_mem_gb = 7
-    String       docker = "quay.io/broadinstitute/viral-core:2.3.1"
+    String       docker = "quay.io/broadinstitute/viral-core:2.3.2"
   }
 
   Int disk_size = 750

--- a/pipes/WDL/tasks/tasks_utils.wdl
+++ b/pipes/WDL/tasks/tasks_utils.wdl
@@ -359,7 +359,6 @@ task tsv_join {
 
     def open_or_compressed_open(*args, **kwargs):
         input_file = args[0]
-
         # if the file exists, try to guess the (de) compressor based on "magic numbers"
         # at the very start of the file
         if os.path.isfile(input_file):
@@ -369,16 +368,13 @@ task tsv_join {
                 if file_start.startswith(magic):
                     print("opening via {}: {}".format(compressor_open_fn.__module__,input_file))
                     return compressor_open_fn(*args, **kwargs)
-            # fall back to generic open if compression type could not be determine from magic numbers
-            return open(*args, **kwargs)
-        else:
-            # if this is a new file, try to choose the opener based on file extension
-            for ext,compressor_open_fn in extension_to_compressor.items():
-                if str(input_file).lower().endswith(ext):
-                    print("opening via {}: {}".format(compressor_open_fn.__module__,input_file))
-                    return compressor_open_fn(*args, **kwargs)
-            # fall back to generic open if compression type could not be determine from magic numbers
-            return open(*args, **kwargs)
+        # if this is a new file, or failure to map above, try to choose the opener based on file extension
+        for ext,compressor_open_fn in extension_to_compressor.items():
+            if str(input_file).lower().endswith(ext):
+                print("opening via {}: {}".format(compressor_open_fn.__module__,input_file))
+                return compressor_open_fn(*args, **kwargs)
+        # fall back to generic open if compression type could not be determined otherwise
+        return open(*args, **kwargs)
 
     # prep input readers
     out_basename = '~{out_basename}'

--- a/pipes/WDL/tasks/tasks_utils.wdl
+++ b/pipes/WDL/tasks/tasks_utils.wdl
@@ -331,8 +331,7 @@ task tsv_join {
     import os.path
     import gzip, lzma, bz2
     import lz4.frame # pypi library: lz4
-    import zstandard as zstd # pypi library: zstandard
-    import util.file # viral-core
+    import zstandard # pypi library: zstandard
 
     # magic bytes from here:
     # https://en.wikipedia.org/wiki/List_of_file_signatures
@@ -341,7 +340,7 @@ task tsv_join {
         b"\xfd\x37\x7a\x58\x5a\x00": lzma.open,      # .xz
         b"\x42\x5a\x68":             bz2.open,       # .bz2
         b"\x04\x22\x4d\x18":         lz4.frame.open, # .lz4
-        b"\x28\xb5\x2f\xfd":         util.file.zstd_open   # .zst (open using function above rather than library function)
+        b"\x28\xb5\x2f\xfd":         zstandard.open  # .zst
     }
     extension_to_compressor = {
         ".gz":   gzip.open,      # .gz
@@ -349,8 +348,8 @@ task tsv_join {
         ".xz":   lzma.open,      # .xz
         ".bz2":  bz2.open,       # .bz2
         ".lz4":  lz4.frame.open, # .lz4
-        ".zst":  util.file.zstd_open,  # .zst (open using function above rather than library function)
-        ".zstd": util.file.zstd_open   # .zst (open using function above rather than library function)
+        ".zst":  zstandard.open, # .zst
+        ".zstd": zstandard.open  # .zst
     }
 
     # max number of bytes we need to identify one of the files listed above

--- a/pipes/WDL/tasks/tasks_utils.wdl
+++ b/pipes/WDL/tasks/tasks_utils.wdl
@@ -103,7 +103,7 @@ task zcat {
         { if [ -f /sys/fs/cgroup/memory.peak ]; then cat /sys/fs/cgroup/memory.peak; elif [ -f /sys/fs/cgroup/memory/memory.peak ]; then cat /sys/fs/cgroup/memory/memory.peak; elif [ -f /sys/fs/cgroup/memory/memory.max_usage_in_bytes ]; then cat /sys/fs/cgroup/memory/memory.max_usage_in_bytes; else echo "0"; fi } > MEM_BYTES
     >>>
     runtime {
-        docker: "quay.io/broadinstitute/viral-core:2.3.1"
+        docker: "quay.io/broadinstitute/viral-core:2.3.2"
         memory: "1 GB"
         cpu:    cpus
         disks:  "local-disk " + disk_size + " LOCAL"
@@ -430,7 +430,7 @@ task tsv_join {
   runtime {
     memory: "~{machine_mem_gb} GB"
     cpu: 4
-    docker: "quay.io/broadinstitute/viral-core:2.3.1"
+    docker: "quay.io/broadinstitute/viral-core:2.3.2"
     disks:  "local-disk " + disk_size + " HDD"
     disk: disk_size + " GB" # TES
     dx_instance_type: "mem1_ssd1_v2_x4"
@@ -517,7 +517,7 @@ task tsv_stack {
   input {
     Array[File]+ input_tsvs
     String       out_basename
-    String       docker = "quay.io/broadinstitute/viral-core:2.3.1"
+    String       docker = "quay.io/broadinstitute/viral-core:2.3.2"
   }
 
   Int disk_size = 50
@@ -780,7 +780,7 @@ task filter_sequences_by_length {
         File   sequences_fasta
         Int    min_non_N = 1
 
-        String docker = "quay.io/broadinstitute/viral-core:2.3.1"
+        String docker = "quay.io/broadinstitute/viral-core:2.3.2"
         Int    disk_size = 750
     }
     parameter_meta {

--- a/pipes/WDL/tasks/tasks_utils.wdl
+++ b/pipes/WDL/tasks/tasks_utils.wdl
@@ -43,8 +43,7 @@ task zcat {
         import os.path
         import gzip, lzma, bz2
         import lz4.frame # pypi library: lz4
-        import zstandard as zstd # pypi library: zstandard
-        import util.file # viral-core
+        import zstandard # pypi library: zstandard
 
         # magic bytes from here:
         # https://en.wikipedia.org/wiki/List_of_file_signatures
@@ -53,7 +52,7 @@ task zcat {
             b"\xfd\x37\x7a\x58\x5a\x00": lzma.open,      # .xz
             b"\x42\x5a\x68":             bz2.open,       # .bz2
             b"\x04\x22\x4d\x18":         lz4.frame.open, # .lz4
-            b"\x28\xb5\x2f\xfd":         util.file.zstd_open   # .zst (open using function above rather than library function)
+            b"\x28\xb5\x2f\xfd":         zstandard.open  # .zst
         }
         extension_to_compressor = {
             ".gz":   gzip.open,      # .gz
@@ -61,8 +60,8 @@ task zcat {
             ".xz":   lzma.open,      # .xz
             ".bz2":  bz2.open,       # .bz2
             ".lz4":  lz4.frame.open, # .lz4
-            ".zst":  util.file.zstd_open,  # .zst (open using function above rather than library function)
-            ".zstd": util.file.zstd_open   # .zst (open using function above rather than library function)
+            ".zst":  zstandard.open, # .zst
+            ".zstd": zstandard.open  # .zst
         }
 
         # max number of bytes we need to identify one of the files listed above

--- a/pipes/WDL/tasks/tasks_utils.wdl
+++ b/pipes/WDL/tasks/tasks_utils.wdl
@@ -359,6 +359,7 @@ task tsv_join {
 
     def open_or_compressed_open(*args, **kwargs):
         input_file = args[0]
+
         # if the file exists, try to guess the (de) compressor based on "magic numbers"
         # at the very start of the file
         if os.path.isfile(input_file):
@@ -368,13 +369,16 @@ task tsv_join {
                 if file_start.startswith(magic):
                     print("opening via {}: {}".format(compressor_open_fn.__module__,input_file))
                     return compressor_open_fn(*args, **kwargs)
-        # if this is a new file, or failure to map above, try to choose the opener based on file extension
-        for ext,compressor_open_fn in extension_to_compressor.items():
-            if str(input_file).lower().endswith(ext):
-                print("opening via {}: {}".format(compressor_open_fn.__module__,input_file))
-                return compressor_open_fn(*args, **kwargs)
-        # fall back to generic open if compression type could not be determined otherwise
-        return open(*args, **kwargs)
+            # fall back to generic open if compression type could not be determine from magic numbers
+            return open(*args, **kwargs)
+        else:
+            # if this is a new file, try to choose the opener based on file extension
+            for ext,compressor_open_fn in extension_to_compressor.items():
+                if str(input_file).lower().endswith(ext):
+                    print("opening via {}: {}".format(compressor_open_fn.__module__,input_file))
+                    return compressor_open_fn(*args, **kwargs)
+            # fall back to generic open if compression type could not be determine from magic numbers
+            return open(*args, **kwargs)
 
     # prep input readers
     out_basename = '~{out_basename}'

--- a/pipes/WDL/workflows/mafft.wdl
+++ b/pipes/WDL/workflows/mafft.wdl
@@ -9,11 +9,10 @@ workflow mafft {
         email:  "viral-ngs@broadinstitute.org"
     }
 
-    call interhost.multi_align_mafft
+    call interhost.multi_align_mafft_ref
 
     output {
-        File        sampleNamesFile     = multi_align_mafft.sampleNamesFile
-        Array[File] alignments_by_chr   = multi_align_mafft.alignments_by_chr
-        String      viral_phylo_version = multi_align_mafft.viralngs_version
+        #File        sampleNamesFile     = multi_align_mafft_ref.sampleNamesFile
+        Array[File] alignments_by_chr   = multi_align_mafft_ref.alignments_by_chr
     }
 }

--- a/pipes/WDL/workflows/terra_tsv_to_table.wdl
+++ b/pipes/WDL/workflows/terra_tsv_to_table.wdl
@@ -20,7 +20,7 @@ workflow terra_tsv_to_table {
 
     call utils.cat_except_headers {
         input:
-            infiles = tsv_files,
+            infiles = select_all(tsv_files),
             out_filename = "terra_upload.tsv"
     }
 

--- a/requirements-modules.txt
+++ b/requirements-modules.txt
@@ -1,5 +1,5 @@
-broadinstitute/viral-core=2.3.1
-broadinstitute/viral-assemble=2.3.1.4
+broadinstitute/viral-core=2.3.2
+broadinstitute/viral-assemble=2.3.2.0
 broadinstitute/viral-classify=2.2.4.2
 broadinstitute/viral-phylo=2.1.20.2
 broadinstitute/py3-bio=0.1.2


### PR DESCRIPTION
This PR:
1. fixes a bug #543 introduced recently that causes different/unintended failure modes in `assemble_denovo` on [example exercises](https://github.com/broadinstitute/viral-workshops/blob/main/veme-ngs/denovo.md). This PR now has the `scaffold` task fallback to old brute-force reference selection if ANI-based reference selection fails to find any matches at all. This will work fine (same as before) in most historically-normal use cases, but will not behave well if given a very large array of reference genomes to choose from. (this change does not impact the behavior of `scaffold_and_refine_multitaxa` which does not pass multiple references to the `scaffold` task anyway.
2. Updates viral-core and viral-assemble docker images to latest (2.3.2 and 2.3.2.0)
3. Updates cromwell, womtool, and dxCompiler versions for build
4. minor cleanups to docbuild
5. drops any direct use of `util.file.zstd_open` in favor of `zstandard.open`
6. increase default RAM for `reports.alignment_metrics`
7. bugfix some bed file sorting for `samtools ampliconstats` in the case of multi-segment targets -- also allow `samtools ampliconstats` to fail silently in the case that it's getting too picky about the bed file
8. change the `mafft` workflow to use `multi_align_mafft_ref` instead of `multi_align_mafft`
9. make the `terra_tsv_to_table` workflow resilient to non-existent TSVs in its input array, to simplify running it on a Terra table full of tsvs that may or may not exist
10. Some initial WiP code for multi-species genbank prep, not far along yet.