### PR TITLE
demux_deplete: make depletion optional, load biosample metadata to tables

### DIFF
--- a/pipes/WDL/tasks/tasks_ncbi.wdl
+++ b/pipes/WDL/tasks/tasks_ncbi.wdl
@@ -609,10 +609,10 @@ task biosample_to_table {
           row['biosample_accession'] = row.get('accession')
           biosample_attributes.append(row)
           for k,v in row.items():
-            if v and (k not in biosample_headers) and h not in ('message'):
-              if h == 'accession':
-                h = 'biosample_accession'
-              biosample_headers.append(h)
+            if v and (k not in biosample_headers) and k not in ('message'):
+              if k == 'accession':
+                k = 'biosample_accession'
+              biosample_headers.append(k)
     print("biosample headers ({}): {}".format(len(biosample_headers), biosample_headers))
     print("biosample rows ({})".format(len(biosample_attributes)))
 

--- a/pipes/WDL/tasks/tasks_ncbi.wdl
+++ b/pipes/WDL/tasks/tasks_ncbi.wdl
@@ -616,7 +616,7 @@ task biosample_to_table {
     print("biosample rows ({})".format(len(biosample_attributes)))
 
     # write reformatted table
-    with open('~{base}.entities.tsv', wt) as outf:
+    with open('~{base}.entities.tsv', 'wt') as outf:
       writer = csv.DictWriter(outf, delimiter='\t', fieldnames=["~{sanitized_id_col}"]+biosample_headers, quoting=csv.QUOTE_MINIMAL)
       writer.writeheader()
       for row in biosample_attributes:

--- a/pipes/WDL/tasks/tasks_ncbi.wdl
+++ b/pipes/WDL/tasks/tasks_ncbi.wdl
@@ -602,16 +602,16 @@ task biosample_to_table {
 
     # load biosample metadata
     biosample_attributes = []
-    biosample_headers = []
+    biosample_headers = ['biosample_accession']
     with open('~{biosample_attributes_tsv}', 'rt') as inf:
       for row in csv.DictReader(inf, delimiter='\t'):
         if row['sample_name'] in sample_names_seen and row['message'] == "Successfully loaded":
           row['biosample_accession'] = row.get('accession')
           biosample_attributes.append(row)
           for k,v in row.items():
-            if v and (k not in biosample_headers) and k not in ('message'):
-              if k == 'accession':
-                k = 'biosample_accession'
+            if v.strip().lower() in ('missing', 'na', 'not applicable', 'not collected', ''):
+              v = None
+            if v and (k not in biosample_headers) and k not in ('message', 'accession'):
               biosample_headers.append(k)
     print("biosample headers ({}): {}".format(len(biosample_headers), biosample_headers))
     print("biosample rows ({})".format(len(biosample_attributes)))
@@ -623,7 +623,7 @@ task biosample_to_table {
       for row in biosample_attributes:
         outrow = {h: row[h] for h in biosample_headers}
         outrow["~{sanitized_id_col}"] = sample_to_sanitized[row['sample_name']]
-        writer.writerow(row)
+        writer.writerow(outrow)
     CODE
   >>>
   output {

--- a/pipes/WDL/tasks/tasks_ncbi.wdl
+++ b/pipes/WDL/tasks/tasks_ncbi.wdl
@@ -607,7 +607,7 @@ task biosample_to_table {
         if row['sample_name'] in sample_names_seen and row['message'] == "Successfully loaded":
           row['biosample_accession'] = row.get('accession')
           biosample_attributes.append(row)
-          for k,v in row.items()
+          for k,v in row.items():
             if v and (k not in biosample_headers) and h not in ('message'):
               if h == 'accession':
                 h = 'biosample_accession'

--- a/pipes/WDL/tasks/tasks_ncbi.wdl
+++ b/pipes/WDL/tasks/tasks_ncbi.wdl
@@ -591,8 +591,8 @@ task biosample_to_table {
 
     # load list of bams surviving filters
     bam_fnames = list(os.path.basename(x) for x in '~{sep="*" cleaned_bam_filepaths}'.split('*'))
-    bam_fnames = list(x[:-len('.bam')] for x in bam_fnames if x.endswith('.bam'))
-    bam_fnames = list(x[:-len('.cleaned')] for x in bam_fnames if x.endswith('.cleaned'))
+    bam_fnames = list(x[:-len('.bam')] if x.endswith('.bam') else x for x in bam_fnames)
+    bam_fnames = list(x[:-len('.cleaned')] if x.endswith('.cleaned') else x for x in bam_fnames)
     print("bam basenames ({}): {}".format(len(bam_fnames), bam_fnames))
     sample_to_sanitized = {demux_meta_by_file.get(x, {}).get('sample_original'): demux_meta_by_file.get(x, {}).get('sample') for x in bam_fnames}
     if None in sample_to_sanitized:

--- a/pipes/WDL/tasks/tasks_ncbi.wdl
+++ b/pipes/WDL/tasks/tasks_ncbi.wdl
@@ -566,9 +566,10 @@ task biosample_to_table {
     Array[File] cleaned_bam_filepaths
     File        demux_meta_json
 
-    String  sanitized_id_col = "entity:sample_id"
+    String  sample_table_name  = "sample"
     String  docker = "python:slim"
   }
+  String  sanitized_id_col = "entity:~{sample_table_name}_id"
   String base = basename(basename(biosample_attributes_tsv, ".txt"), ".tsv")
   parameter_meta {
     cleaned_bam_filepaths: {

--- a/pipes/WDL/tasks/tasks_ncbi.wdl
+++ b/pipes/WDL/tasks/tasks_ncbi.wdl
@@ -593,6 +593,7 @@ task biosample_to_table {
     bam_fnames = list(os.path.basename(x) for x in '~{sep="*" cleaned_bam_filepaths}'.split('*'))
     bam_fnames = list(x[:-len('.bam')] for x in bam_fnames if x.endswith('.bam'))
     bam_fnames = list(x[:-len('.cleaned')] for x in bam_fnames if x.endswith('.cleaned'))
+    print("bam basenames ({}): {}".format(len(bam_fnames), bam_fnames))
     sample_to_sanitized = {demux_meta_by_file.get(x, {}).get('sample_original'): demux_meta_by_file.get(x, {}).get('sample') for x in bam_fnames}
     if None in sample_to_sanitized:
       del sample_to_sanitized[None]

--- a/pipes/WDL/tasks/tasks_ncbi.wdl
+++ b/pipes/WDL/tasks/tasks_ncbi.wdl
@@ -598,7 +598,7 @@ task biosample_to_table {
     if None in sample_to_sanitized:
       del sample_to_sanitized[None]
     sample_names_seen = sample_to_sanitized.keys()
-    print("samples seen ({}): {}".format(len(sample_names_seen), sample_names_seen))
+    print("samples seen ({}): {}".format(len(sample_names_seen), sorted(sample_names_seen)))
 
     # load biosample metadata
     biosample_attributes = []
@@ -615,6 +615,8 @@ task biosample_to_table {
               biosample_headers.append(k)
     print("biosample headers ({}): {}".format(len(biosample_headers), biosample_headers))
     print("biosample rows ({})".format(len(biosample_attributes)))
+    samples_seen_without_biosample = set(sample_names_seen) - set(row['sample_name'] for row in biosample_attributes)
+    print("samples seen in bams without biosample entries ({}): {}".format(len(samples_seen_without_biosample), sorted(samples_seen_without_biosample)))
 
     # write reformatted table
     with open('~{base}.entities.tsv', 'wt') as outf:

--- a/pipes/WDL/tasks/tasks_reports.wdl
+++ b/pipes/WDL/tasks/tasks_reports.wdl
@@ -456,6 +456,8 @@ task align_and_count {
 
     TOTAL_COUNT_OF_TOP_HIT=$(grep -E "^($TOP_HIT)" "~{reads_basename}.count.~{ref_basename}.txt" | cut -f3 | tee TOTAL_COUNT_OF_TOP_HIT)
     TOTAL_COUNT_OF_LESSER_HITS=$((grep -vE "^(\*|$TOP_HIT)" "~{reads_basename}.count.~{ref_basename}.txt" || echo "0" ) | cut -f3 | paste -sd+ - | bc -l | tee TOTAL_COUNT_OF_LESSER_HITS)
+    echo $TOTAL_COUNT_OF_TOP_HIT | tee TOTAL_COUNT_OF_TOP_HIT
+    echo $TOTAL_COUNT_OF_LESSER_HITS | tee TOTAL_COUNT_OF_LESSER_HITS
 
     if [ $TOTAL_COUNT_OF_LESSER_HITS -ne 0 -o $TOTAL_COUNT_OF_TOP_HIT -ne 0 ]; then
       PCT_MAPPING_TO_LESSER_HITS=$( echo "scale=3; 100 * $TOTAL_COUNT_OF_LESSER_HITS / ($TOTAL_COUNT_OF_LESSER_HITS + $TOTAL_COUNT_OF_TOP_HIT)" | \
@@ -466,6 +468,7 @@ task align_and_count {
     fi
 
     TOTAL_READS_IN_INPUT=$(samtools view -c "~{reads_basename}.bam")
+    echo $TOTAL_READS_IN_INPUT | tee TOTAL_READS_IN_INPUT
     if [ $TOTAL_READS_IN_INPUT -eq 0 ]; then
       echo "no reads in input bam"
       PCT_OF_INPUT_READS_MAPPED=$(echo "0" | tee "~{reads_basename}.count.~{ref_basename}.pct_total_reads_mapped.txt")
@@ -480,7 +483,11 @@ task align_and_count {
     
     File   report_top_hits  = "~{reads_basename}.count.~{ref_basename}.top_~{topNHits}_hits.txt"
     String top_hit_id       = read_string("~{reads_basename}.count.~{ref_basename}.top.txt")
-    
+
+    Int    reads_total          = read_int("TOTAL_READS_IN_INPUT")
+    Int    reads_mapped_top_hit = read_int("TOTAL_COUNT_OF_TOP_HIT")
+    Int    reads_mapped         = read_int("TOTAL_COUNT_OF_LESSER_HITS") + read_int("TOTAL_COUNT_OF_TOP_HIT")
+
     String pct_total_reads_mapped    = read_string('~{reads_basename}.count.~{ref_basename}.pct_total_reads_mapped.txt')
     String pct_lesser_hits_of_mapped = read_string('~{reads_basename}.count.~{ref_basename}.pct_lesser_hits_of_mapped.txt')
     

--- a/pipes/WDL/tasks/tasks_reports.wdl
+++ b/pipes/WDL/tasks/tasks_reports.wdl
@@ -393,7 +393,7 @@ task align_and_count {
     File   ref_db
     Int    topNHits = 3
 
-    Boolean filter_bam_to_proper_primary_mapped_reads         = false
+    Boolean filter_bam_to_proper_primary_mapped_reads         = true
     Boolean do_not_require_proper_mapped_pairs_when_filtering = false
     Boolean keep_singletons_when_filtering                    = false
     Boolean keep_duplicates_when_filtering                    = false

--- a/pipes/WDL/tasks/tasks_terra.wdl
+++ b/pipes/WDL/tasks/tasks_terra.wdl
@@ -377,7 +377,6 @@ task create_or_update_sample_tables {
 
     String workspace_namespace
     String workspace_name
-    String workspace_bucket
 
     Array[String]  raw_reads_unaligned_bams
     Array[String]  cleaned_reads_unaligned_bams
@@ -397,7 +396,6 @@ task create_or_update_sample_tables {
     
     workspace_project = '~{workspace_namespace}'
     workspace_name    = '~{workspace_name}'
-    workspace_bucket  = '~{workspace_bucket}'
 
     # import required packages.
     import os
@@ -409,7 +407,7 @@ task create_or_update_sample_tables {
     from ast import literal_eval
     from io import StringIO
 
-    print(workspace_project + "\n" + workspace_name + "\n" + "bucket: " + workspace_bucket)
+    print(workspace_project + "\n" + workspace_name + "\n")
 
     # create tsv to populate library table with raw_bam and cleaned_bam columns
     print(f"creating library->bam mapping tsv files from file input")
@@ -425,6 +423,7 @@ task create_or_update_sample_tables {
     df_library_bams = pd.merge(df_library_table_raw_bams, df_library_table_clean_bams, on="entity:library_id", how="outer")
     library_bams_tsv = flowcell_data_id + "-all_bams.tsv"
     df_library_bams.to_csv(library_bams_tsv, sep="\t", index=False)
+    print("libraries in bams: {}".format(df_library_bams.index))
 
     # # update sample_set with new set memberships and flowcell metadata
 
@@ -492,7 +491,7 @@ task create_or_update_sample_tables {
     library_meta_fname = "library_metadata.tsv"
     with open(library_meta_fname, 'wt') as outf:
       outf.write("entity:")
-      copy_cols = ["sample_original", "spike_in", "control", "batch_lib", "run", "lane", "library_id_per_sample", "library_strategy", "library_source", "library_selection", "design_description"]
+      copy_cols = ["sample_original", "spike_in", "control", "batch_lib", "library", "lane", "library_id_per_sample", "library_strategy", "library_source", "library_selection", "design_description"]
       out_header = ['library_id'] + copy_cols
       print(f"library_metadata.tsv output header: {out_header}")
       writer = csv.DictWriter(outf, out_header, delimiter='\t', dialect=csv.unix_dialect, quoting=csv.QUOTE_MINIMAL)
@@ -501,7 +500,7 @@ task create_or_update_sample_tables {
       out_rows = []
       for library in library_meta_dict.values():
           out_row = {col: library.get(col, '') for col in copy_cols}
-          out_row['library_id'] = library['library']
+          out_row['library_id'] = library['run']
           out_rows.append(out_row)
       writer.writerows(out_rows)
 

--- a/pipes/WDL/tasks/tasks_terra.wdl
+++ b/pipes/WDL/tasks/tasks_terra.wdl
@@ -379,11 +379,10 @@ task create_or_update_sample_tables {
     String workspace_name
     String workspace_bucket
 
-    Array[String]? raw_reads_unaligned_bams
-    Array[String]? cleaned_reads_unaligned_bams
+    Array[String]  raw_reads_unaligned_bams
+    Array[String]  cleaned_reads_unaligned_bams
 
-    File?                           meta_by_filename_json
-    File?                           meta_by_sample_json
+    File           meta_by_filename_json
 
     String  docker = "quay.io/broadinstitute/viral-core:2.2.4" #skip-global-version-pin
   }
@@ -400,12 +399,8 @@ task create_or_update_sample_tables {
     workspace_name    = '~{workspace_name}'
     workspace_bucket  = '~{workspace_bucket}'
 
-    raw_reads_unaligned_bams_list_filepath     = '~{if defined(raw_reads_unaligned_bams) then write_lines(select_first([raw_reads_unaligned_bams, []])) else ""}'
-    cleaned_reads_unaligned_bams_list_filepath = '~{if defined(cleaned_reads_unaligned_bams) then write_lines(select_first([cleaned_reads_unaligned_bams, []])) else ""}'
-
     # import required packages.
     import os
-    import argparse
     import collections
     import json
     import csv
@@ -433,57 +428,26 @@ task create_or_update_sample_tables {
         return (headers, rows)
 
     # # populate sample table from run outputs
+
     # In particular, popualte the raw_bam and cleaned_bam columns
+    # create tsvs for row insertion based on input bam lists
+    print(f"creating library->bam mapping tsv files from file input")
 
-    def get_bam_lists_for_flowcell_from_live_table(project, workspace, runID):
-        # API call to get flowcell_data table
-        response = fapi.get_entities_tsv(project, workspace, "flowcell", model="flexible")
+    raw_bams_list = '~{sep="*" raw_reads_unaligned_bams}'.split('*')
+    raw_library_id_list     = [bam.split("/")[-1].replace(".bam", "") for bam in raw_bams_list]
+    df_library_table        = pd.DataFrame({"entity:library_id" : raw_library_id_list, "raw_bam" : raw_bams_list})
+    raw_library_fname       = flowcell_data_id + "-raw_bams.tsv"
+    df_library_table.to_csv(raw_library_fname, sep="\t", index=False)
 
-        # read API response into data frame
-        df = pd.read_csv(StringIO(response.text), sep="\t", index_col="entity:flowcell_id")
-
-        # create library.tsv data frame (entity:library_id)
-        cleaned_bams_list       = literal_eval(df.cleaned_reads_unaligned_bams[runID])
-        raw_bams_list           = literal_eval(df.raw_reads_unaligned_bams[runID])
-
-        return (cleaned_bams_list,raw_bams_list)
-
-    def create_library_to_bam_tsvs(cleaned_bams_list, raw_bams_list, runID):
-        cleaned_library_id_list = [bam.split("/")[-1].replace(".bam", "").replace(".cleaned", "") for bam in cleaned_bams_list]
-        df_library_table        = pd.DataFrame({"entity:library_id" : cleaned_library_id_list,
-                                        "cleaned_bam" : cleaned_bams_list})
-        cleaned_library_fname   = runID + "_cleaned_bams.tsv"
-        df_library_table.to_csv(cleaned_library_fname, sep="\t", index=False)
-
-        # create library.tsv data frame (entity:library_id)
-        raw_library_id_list     = [bam.split("/")[-1].replace(".bam", "") for bam in raw_bams_list]
-        df_library_table        = pd.DataFrame({"entity:library_id" : raw_library_id_list,
-                                        "raw_bam" : raw_bams_list})
-        raw_library_fname       = runID + "_raw_bams.tsv"
-        df_library_table.to_csv(raw_library_fname, sep="\t", index=False)
-        
-        return (cleaned_library_fname, raw_library_fname)
-
-    #   IF optional input bam file lists passed in 
-    #      create tsvs for row insertion based on them
-    #   ELSE
-    #      create tsvs based on data from live data table
-    #
-    if ( (os.path.exists(raw_reads_unaligned_bams_list_filepath) and os.path.getsize(raw_reads_unaligned_bams_list_filepath)) > 0 and
-         (os.path.exists(cleaned_reads_unaligned_bams_list_filepath) and os.path.getsize(cleaned_reads_unaligned_bams_list_filepath)) > 0 ):
-        print(f"creating library->bam mapping tsv files from file input")
-        with open(raw_reads_unaligned_bams_list_filepath) as raw_reads_unaligned_bams_list_fp, open(cleaned_reads_unaligned_bams_list_filepath) as cleaned_reads_unaligned_bams_list_fp:
-            cleaned_bams_list,raw_bams_list = ( cleaned_reads_unaligned_bams_list_fp.read().splitlines(),
-                                                raw_reads_unaligned_bams_list_fp.read().splitlines() )
-    else:
-        print(f"creating library->bam mapping tsv files from live table data (no file lists passed in to task)")
-        cleaned_bams_list,raw_bams_list = get_bam_lists_for_flowcell_from_live_table(workspace_project, workspace_name, flowcell_data_id)
+    cleaned_bams_list = '~{sep="*" cleaned_reads_unaligned_bams}'.split('*')
+    cleaned_library_id_list = [bam.split("/")[-1].replace(".bam", "").replace(".cleaned", "") for bam in cleaned_bams_list]
+    df_library_table        = pd.DataFrame({"entity:library_id" : cleaned_library_id_list, "cleaned_bam" : cleaned_bams_list})
+    cleaned_library_fname   = flowcell_data_id + "-cleaned_bams.tsv"
+    df_library_table.to_csv(cleaned_library_fname, sep="\t", index=False)
 
     # call the create_tsv function and save files to data tables
-    tsv_list = create_library_to_bam_tsvs(cleaned_bams_list, raw_bams_list, flowcell_data_id)
-
+    tsv_list = [cleaned_library_fname, raw_library_fname]
     print (f"wrote outputs to {tsv_list}")
-
     for tsv in tsv_list:
         # ToDo: check whether subject to race condition (and if so, implement via async/promises)
         response = fapi.upload_entities_tsv(workspace_project, workspace_name, tsv, model="flexible")
@@ -495,10 +459,7 @@ task create_or_update_sample_tables {
 
     # # update sample_set with new set memberships and flowcell metadata
 
-    # columns to copy from flowcell_data to library table
-    copy_cols = ["sample_original", "spike_in"]
-
-    # API call to get existing sample_set mappings
+    # API call to get existing sample->library mappings
     header, rows = get_entities_to_table(workspace_project, workspace_name, "sample")
     df_sample = pd.DataFrame.from_records(rows, columns=header, index="sample_id")
 
@@ -506,31 +467,24 @@ task create_or_update_sample_tables {
     header, rows = get_entities_to_table(workspace_project, workspace_name, "library")
     df_library = pd.DataFrame.from_records(rows, columns=header, index="library_id")
 
-    #   if meta_by_filename_json specified and size>0 bytes
-    #       parse as json, pass to for loop below
-    #   else
-    #       get data from live table 
-    if ( len('~{default="" meta_by_filename_json}')>0 and 
-        os.path.getsize('~{meta_by_filename_json}') > 0 ):
-
-        library_meta_dict = {}
-        with open('~{meta_by_filename_json}',"r") as meta_fp:
-            library_meta_dict = json.load(meta_fp)
-    else:
-        # API call to get flowcell_data table
-        header, rows = get_entities_to_table(workspace_project, workspace_name, "flowcell")
-        df_flowcell = pd.DataFrame.from_records(rows, columns=header, index="flowcell_id")
-        library_meta_dict = df_flowcell.meta_by_filename[flowcell_data_id]
+    # load library metadata from json
+    with open('~{meta_by_filename_json}',"r") as meta_fp:
+        library_meta_dict = json.load(meta_fp)
+    print("json describes {} libraries".format(len(library_meta_dict)))
 
     # grab the meta_by_filename values to create new sample->library (sample_set->sample) mappings
     sample_to_libraries = {}
+    libraries_already_in_table = set()
     for library_id, data in library_meta_dict.items():
         sample_id = data['sample']
         sample_to_libraries.setdefault(sample_id, [])
         if library_id in df_library.index:
             sample_to_libraries[sample_id].append(library_id)
+            libraries_already_in_table.add(library_id)
         else:
             print (f"missing {library_id} from library table")
+    print("json describes {} unique samples".format(len(sample_to_libraries)))
+    print("json describes {} libraries already present in Terra table and {} new to Terra table".format(len(libraries_already_in_table), len(library_meta_dict) - len(libraries_already_in_table)))
 
     # merge in new sample->library mappings with any pre-existing sample->library mappings
     if len(df_sample)>0:
@@ -552,45 +506,23 @@ task create_or_update_sample_tables {
     with open(sample_fname, 'wt') as outf:
         outf.write('entity:sample_id\tlibraries\n')
         for sample_id, libraries in sample_to_libraries.items():
-            #for library_id in sorted(libraries):
             outf.write(f'{sample_id}\t{json.dumps([{"entityType":"library","entityName":library_name} for library_name in libraries])}\n')
 
-    #   if meta_by_filename_json specified and size>0 bytes
-    #       parse as json, pass to for loop below
-    #   else
-    #       get data from live table 
-    if ( len('~{default="" meta_by_sample_json}')>0 and 
-        os.path.getsize('~{meta_by_sample_json}') > 0 ):
-        
-        sample = {}
-        with open('~{meta_by_sample_json}',"r") as meta_fp:
-            meta_by_library_all = json.load(meta_fp)
-    else:
-        # API call to get flowcell_data table
-        header, rows = get_entities_to_table(workspace_project, workspace_name, "flowcell")
-        df_flowcell = pd.DataFrame.from_records(rows, columns=header, index="flowcell_id")
-        # grab the meta_by_sample values from one row in the flowcell_data table
-        meta_by_library_all = df_flowcell.meta_by_sample[flowcell_data_id]
-
-    # grab all the library IDs
-    header, rows = get_entities_to_table(workspace_project, workspace_name, "library")
-    out_rows = []
-    out_header = ['library_id'] + copy_cols
-    print(f"out_header {out_header}")
-    for row in rows:
-        out_row = {'library_id': row['library_id']}
-
-        for sample_id,sample_library_metadata in meta_by_library_all.items():
-            if sample_library_metadata["library"] in row['library_id']:
-                for col in copy_cols:
-                    out_row[col] = sample_library_metadata.get(col, '')
-                out_rows.append(out_row)
-
-    library_meta_fname = "sample_metadata.tsv"
+    # prepare library metadata
+    library_meta_fname = "library_metadata.tsv"
     with open(library_meta_fname, 'wt') as outf:
       outf.write("entity:")
+      copy_cols = ["sample_original", "spike_in", "control", "batch_lib", "run", "lane", "library_id_per_sample", "library_strategy", "library_source", "library_selection", "design_description"]
+      out_header = ['library_id'] + copy_cols
+      print(f"library_metadata.tsv output header: {out_header}")
       writer = csv.DictWriter(outf, out_header, delimiter='\t', dialect=csv.unix_dialect, quoting=csv.QUOTE_MINIMAL)
       writer.writeheader()
+
+      out_rows = []
+      for library in library_meta_dict.values():
+          out_row = {col: library.get(col, '') for col in copy_cols}
+          out_row['library_id'] = library['library']
+          out_rows.append(out_row)
       writer.writerows(out_rows)
 
     # write them to the Terra table!
@@ -612,6 +544,10 @@ task create_or_update_sample_tables {
     maxRetries: 2
   }
   output {
+    File library_metadata_tsv = "library_metadata.tsv"
+    File sample_membership_tsv = "sample_membership.tsv"
+    File library_cleaned_bams_tsv = "~{flowcell_run_id}-cleaned_bams.tsv"
+    File library_raw_bams_tsv = "~{flowcell_run_id}-raw_bams.tsv"
     File stdout_log = stdout()
     File stderr_log = stderr()
     Int  max_ram_gb = ceil(read_float("MEM_BYTES")/1000000000)

--- a/pipes/WDL/tasks/tasks_terra.wdl
+++ b/pipes/WDL/tasks/tasks_terra.wdl
@@ -473,10 +473,11 @@ task create_or_update_sample_tables {
     if len(df_sample)>0:
         print(df_sample.index)
         for sample_id in sample_to_libraries.keys():
-            if sample_id in df_sample.index:
+            if sample_id in df_sample.index and "libraries" in df_sample.columns:
                 print (f"sample {sample_id} pre-exists in Terra table, merging with new members")
                 #sample_set_to_samples[set_id].extend(df_sample_set.samples[set_id])
-                already_associated_libraries = [entity["entityName"] for entity in df_sample.libraries[sample_id]]
+                already_associated_libraries = [entity.get("entityName") for entity in df_sample.libraries[sample_id]]
+                already_associated_libraries = [lib for lib in already_associated_libraries if lib]
                 
                 print(f"already_associated_libraries {already_associated_libraries}")
                 print(f"sample_to_libraries[sample_id] {sample_to_libraries[sample_id]}")

--- a/pipes/WDL/tasks/tasks_terra.wdl
+++ b/pipes/WDL/tasks/tasks_terra.wdl
@@ -473,7 +473,7 @@ task create_or_update_sample_tables {
     with open(sample_fname, 'wt') as outf:
         outf.write('entity:sample_id\tlibraries\n')
         for sample_id, libraries in sample_to_libraries.items():
-            if sample_id in df_sample.index and "libraries" in df_sample.columns and df_sample.libraries[sample_id]:
+            if sample_id in df_sample.index and "libraries" in df_sample.columns and df_sample.libraries[sample_id] and pd.notna(df_sample.libraries[sample_id]):
                 # merge in new sample->library mappings with any pre-existing sample->library mappings
                 print(f"sample: {sample_id} - pre-existing library entries json: {df_sample.libraries[sample_id]}")
                 already_associated_libraries = [entity["entityName"] for entity in df_sample.libraries[sample_id] if entity.get("entityName")]

--- a/pipes/WDL/tasks/tasks_terra.wdl
+++ b/pipes/WDL/tasks/tasks_terra.wdl
@@ -410,7 +410,7 @@ task create_or_update_sample_tables {
     from ast import literal_eval
     from io import StringIO
 
-    print(workspace_project + "\n" + workspace_name + "\n")
+    print(workspace_project + "\n" + workspace_name)
 
     # create tsv to populate library table with raw_bam and cleaned_bam columns
     print(f"creating library->bam mapping tsv files from file input")
@@ -486,10 +486,12 @@ task create_or_update_sample_tables {
                 sample_to_libraries[sample_id] = list(set(sample_to_libraries[sample_id]))
 
     sample_fname = 'sample_membership.tsv'
+    print("checkpoint 1")
     with open(sample_fname, 'wt') as outf:
         outf.write('entity:sample_id\tlibraries\n')
         for sample_id, libraries in sample_to_libraries.items():
             outf.write(f'{sample_id}\t{json.dumps([{"entityType":"library","entityName":library_name} for library_name in libraries])}\n')
+    print("checkpoint 2")
 
     # create tsv to populate library table with metadata from json
     library_meta_fname = "library_metadata.tsv"

--- a/pipes/WDL/tasks/tasks_terra.wdl
+++ b/pipes/WDL/tasks/tasks_terra.wdl
@@ -423,7 +423,8 @@ task create_or_update_sample_tables {
     df_library_bams = pd.merge(df_library_table_raw_bams, df_library_table_clean_bams, on="entity:library_id", how="outer")
     library_bams_tsv = flowcell_data_id + "-all_bams.tsv"
     df_library_bams.to_csv(library_bams_tsv, sep="\t", index=False)
-    print("libraries in bams: {}".format(df_library_bams.index))
+    libraries_in_bams = set(df_library_bams["entity:library_id"])
+    print("libraries in bams: {}".format(libraries_in_bams))
 
     # # update sample_set with new set memberships and flowcell metadata
 
@@ -438,7 +439,7 @@ task create_or_update_sample_tables {
     for library_id, data in library_meta_dict.items():
         sample_id = data['sample']
         sample_to_libraries.setdefault(sample_id, [])
-        if library_id in df_library_bams.index:
+        if library_id in libraries_in_bams:
             sample_to_libraries[sample_id].append(library_id)
             libraries_in_bams.add(library_id)
         else:

--- a/pipes/WDL/tasks/tasks_terra.wdl
+++ b/pipes/WDL/tasks/tasks_terra.wdl
@@ -475,6 +475,7 @@ task create_or_update_sample_tables {
         for sample_id, libraries in sample_to_libraries.items():
             if sample_id in df_sample.index and "libraries" in df_sample.columns and df_sample.libraries[sample_id]:
                 # merge in new sample->library mappings with any pre-existing sample->library mappings
+                print(f"sample: {sample_id} - pre-existing library entries json: {df_sample.libraries[sample_id]}")
                 already_associated_libraries = [entity["entityName"] for entity in df_sample.libraries[sample_id] if entity.get("entityName")]
                 libraries = list(set(libraries + already_associated_libraries))
                 print (f"sample {sample_id} pre-exists in Terra table, merging old members {already_associated_libraries} with new members {libraries}")

--- a/pipes/WDL/tasks/tasks_terra.wdl
+++ b/pipes/WDL/tasks/tasks_terra.wdl
@@ -283,6 +283,9 @@ task upload_entities_tsv {
 
     String        docker = "schaluvadi/pathogen-genomic-surveillance:api-wdl"
   }
+  meta {
+    volatile: true
+  }
   command {
     set -e
     python3<<CODE
@@ -423,8 +426,8 @@ task create_or_update_sample_tables {
     df_library_bams = pd.merge(df_library_table_raw_bams, df_library_table_clean_bams, on="entity:library_id", how="outer")
     library_bams_tsv = flowcell_data_id + "-all_bams.tsv"
     df_library_bams.to_csv(library_bams_tsv, sep="\t", index=False)
-    libraries_in_bams = set(df_library_bams["entity:library_id"])
-    print("libraries in bams: {}".format(libraries_in_bams))
+    library_bam_names = set(df_library_bams["entity:library_id"])
+    print("libraries in bams: {}".format(len(library_bam_names)))
 
     # # update sample_set with new set memberships and flowcell metadata
 
@@ -439,7 +442,7 @@ task create_or_update_sample_tables {
     for library_id, data in library_meta_dict.items():
         sample_id = data['sample']
         sample_to_libraries.setdefault(sample_id, [])
-        if library_id in libraries_in_bams:
+        if library_id in library_bam_names:
             sample_to_libraries[sample_id].append(library_id)
             libraries_in_bams.add(library_id)
         else:
@@ -471,7 +474,7 @@ task create_or_update_sample_tables {
         print(df_sample.index)
         for sample_id in sample_to_libraries.keys():
             if sample_id in df_sample.index:
-                print (f"sample_set {sample_id} pre-exists in Terra table, merging with new members")
+                print (f"sample {sample_id} pre-exists in Terra table, merging with new members")
                 #sample_set_to_samples[set_id].extend(df_sample_set.samples[set_id])
                 already_associated_libraries = [entity["entityName"] for entity in df_sample.libraries[sample_id]]
                 

--- a/pipes/WDL/workflows/demux_deplete.wdl
+++ b/pipes/WDL/workflows/demux_deplete.wdl
@@ -211,7 +211,6 @@ workflow demux_deplete {
                 flowcell_run_id     = illumina_demux.run_info[0]['run_id'],
                 workspace_name      = check_terra_env.workspace_name,
                 workspace_namespace = check_terra_env.workspace_namespace,
-                workspace_bucket    = check_terra_env.workspace_bucket_path,
 
                 raw_reads_unaligned_bams     = flatten(illumina_demux.raw_reads_unaligned_bams),
                 cleaned_reads_unaligned_bams = select_all(cleaned_bam_passing),

--- a/pipes/WDL/workflows/demux_deplete.wdl
+++ b/pipes/WDL/workflows/demux_deplete.wdl
@@ -280,5 +280,7 @@ workflow demux_deplete {
         Map[String,String] run_info                          = illumina_demux.run_info[0]
         File               run_info_json                     = illumina_demux.run_info_json[0]
         String             run_id                            = illumina_demux.run_info[0]['run_id']
+
+        String      demux_viral_core_version                 = illumina_demux.viralngs_version[0]
     }
 }

--- a/pipes/WDL/workflows/demux_deplete.wdl
+++ b/pipes/WDL/workflows/demux_deplete.wdl
@@ -215,12 +215,11 @@ workflow demux_deplete {
 
                 raw_reads_unaligned_bams     = flatten(illumina_demux.raw_reads_unaligned_bams),
                 cleaned_reads_unaligned_bams = select_all(cleaned_bam_passing),
-                meta_by_filename_json        = meta_filename.merged_json,
-                meta_by_sample_json          = meta_sample.merged_json
+                meta_by_filename_json        = meta_filename.merged_json
             }
 
             if(defined(biosample_map)) {
-                call terra.upload_entities_tsv {
+                call terra.upload_entities_tsv as terra_load_biosample_data {
                     input:
                         workspace_name   = check_terra_env.workspace_name,
                         terra_project    = check_terra_env.workspace_namespace,

--- a/pipes/WDL/workflows/demux_deplete.wdl
+++ b/pipes/WDL/workflows/demux_deplete.wdl
@@ -178,6 +178,22 @@ workflow demux_deplete {
         }
     }
 
+    if(defined(biosample_map)) {
+        #### SRA submission prep
+        call ncbi.sra_meta_prep {
+            input:
+                cleaned_bam_filepaths = select_all(cleaned_bam_passing),
+                biosample_map         = select_first([biosample_map]),
+                library_metadata      = samplesheet_rename_ids.new_sheet,
+                platform              = "ILLUMINA",
+                paired                = (illumina_demux.run_info[0]['indexes'] == '2'),
+
+                out_name              = "sra_metadata-~{illumina_demux.run_info[0]['run_id']}.tsv",
+                instrument_model      = select_first(flatten([[instrument_model_user_specified],[illumina_demux.run_info[0]['sequencer_model']]])),
+                title                 = select_first([sra_title])
+        }
+    }
+
     if(insert_demux_outputs_into_terra_tables){
         call terra.check_terra_env
 
@@ -194,22 +210,6 @@ workflow demux_deplete {
                 meta_by_filename_json        = meta_filename.merged_json,
                 meta_by_sample_json          = meta_sample.merged_json
             }
-        }
-    }
-
-    #### SRA submission prep
-    if(defined(biosample_map)) {
-        call ncbi.sra_meta_prep {
-            input:
-                cleaned_bam_filepaths = select_all(cleaned_bam_passing),
-                biosample_map         = select_first([biosample_map]),
-                library_metadata      = samplesheet_rename_ids.new_sheet,
-                platform              = "ILLUMINA",
-                paired                = (illumina_demux.run_info[0]['indexes'] == '2'),
-
-                out_name              = "sra_metadata-~{illumina_demux.run_info[0]['run_id']}.tsv",
-                instrument_model      = select_first(flatten([[instrument_model_user_specified],[illumina_demux.run_info[0]['sequencer_model']]])),
-                title                 = select_first([sra_title])
         }
     }
 

--- a/pipes/WDL/workflows/demux_deplete.wdl
+++ b/pipes/WDL/workflows/demux_deplete.wdl
@@ -280,7 +280,5 @@ workflow demux_deplete {
         Map[String,String] run_info                          = illumina_demux.run_info[0]
         File               run_info_json                     = illumina_demux.run_info_json[0]
         String             run_id                            = illumina_demux.run_info[0]['run_id']
-        
-        String      demux_viral_core_version                 = illumina_demux.viralngs_version[0]
     }
 }

--- a/pipes/WDL/workflows/populate_library_and_sample_tables_from_flowcell.wdl
+++ b/pipes/WDL/workflows/populate_library_and_sample_tables_from_flowcell.wdl
@@ -23,8 +23,7 @@ workflow populate_library_and_sample_tables_from_flowcell {
           input:
             flowcell_run_id     = flowcell_run_id,
             workspace_name      = check_terra_env.workspace_name,
-            workspace_namespace = check_terra_env.workspace_namespace,
-            workspace_bucket    = check_terra_env.workspace_bucket_path
+            workspace_namespace = check_terra_env.workspace_namespace
         }
     }
 }

--- a/pipes/WDL/workflows/scaffold_and_refine_multitaxa.wdl
+++ b/pipes/WDL/workflows/scaffold_and_refine_multitaxa.wdl
@@ -1,7 +1,6 @@
 version 1.0
 
 import "../tasks/tasks_assembly.wdl" as assembly
-import "../tasks/tasks_metagenomics.wdl" as metagenomics
 import "../tasks/tasks_ncbi.wdl" as ncbi
 import "../tasks/tasks_reports.wdl" as reports
 import "../tasks/tasks_utils.wdl" as utils
@@ -17,7 +16,7 @@ workflow scaffold_and_refine_multitaxa {
 
     input {
         String  sample_id
-        Array[String] sample_names
+        String? sample_name
         File    reads_unmapped_bam
         File    contigs_fasta
 
@@ -25,7 +24,7 @@ workflow scaffold_and_refine_multitaxa {
     }
 
     Int    min_scaffold_unambig = 10 # in base-pairs; any scaffolded assembly < this length will not be refined/polished
-    String sample_original_name = flatten([sample_names, [sample_id]])[0]
+    String sample_original_name = select_first([sample_name, sample_id])
 
     # download (multi-segment) genomes for each reference, fasta filename = colon-concatenated accession list
     scatter(taxon in read_tsv(taxid_to_ref_accessions_tsv)) {


### PR DESCRIPTION
This PR:
 - closes #532 - percolates biosample metadata to Terra `sample` table in `demux_deplete`
 - percolates more samplesheet metadata to `library` table in `demux_deplete`
 - makes host depletion fully optional in `demux_deplete` (ie, works properly if all depletion database `Array[File]`s are empty / not specified)
 - marks the terra.upload_entities_tsv task as `volatile`
 - change default behavior of `reports.align_and_count` (used for spike-in counting) to only count proper primary mapped reads

The terra-specific bits have been tested live in a [dev workspace](https://app.terra.bio/#workspaces/broad-viral-surveillance/dpark%20viral%20respiratory%20tech%20dev).