### PR TITLE
demux_deplete: allow multiple biosample attribute files

### DIFF
--- a/pipes/WDL/workflows/demux_deplete.wdl
+++ b/pipes/WDL/workflows/demux_deplete.wdl
@@ -186,7 +186,7 @@ workflow demux_deplete {
     if (length(flatten(select_all([biosample_map_tsvs]))) > 0) {
         #### merge biosample attribute tsvs (iff provided with more than one)
         if (length(flatten(select_all([biosample_map_tsvs]))) > 1) {
-            call utils.tsv_join as biosample_map_tsv_join{
+            call utils.tsv_join as biosample_map_tsv_join {
                 input:
                     input_tsvs   = flatten([select_first([biosample_map_tsvs,[]])]),
                     id_col       = 'accession',
@@ -198,7 +198,7 @@ workflow demux_deplete {
         #### biosample metadata mapping
         call ncbi.biosample_to_table {
             input:
-                biosample_attributes_tsv = select_first(flatten([[biosample_map_tsv_join.out_tsv], biosample_map_tsvs])),
+                biosample_attributes_tsv = select_first([biosample_map_tsv_join.out_tsv, biosample_map_tsvs]),
                 cleaned_bam_filepaths    = select_all(cleaned_bam_passing),
                 demux_meta_json          = meta_filename.merged_json
         }
@@ -207,7 +207,7 @@ workflow demux_deplete {
         call ncbi.sra_meta_prep {
             input:
                 cleaned_bam_filepaths = select_all(cleaned_bam_passing),
-                biosample_map         = select_first(flatten([[biosample_map_tsv_join.out_tsv], biosample_map_tsvs])),
+                biosample_map         = select_first([biosample_map_tsv_join.out_tsv, biosample_map_tsvs]),
                 library_metadata      = samplesheet_rename_ids.new_sheet,
                 platform              = "ILLUMINA",
                 paired                = (illumina_demux.run_info[0]['indexes'] == '2'),

--- a/pipes/WDL/workflows/demux_deplete.wdl
+++ b/pipes/WDL/workflows/demux_deplete.wdl
@@ -183,9 +183,9 @@ workflow demux_deplete {
         Pair[String,Int] count_cleaned = (basename(raw_reads, '.bam'), read_count_post_depletion)
     }
 
-    if (length(flatten(select_all([biosample_map]))) > 0) {
+    if (length(flatten(select_all([biosample_map_tsvs]))) > 0) {
         #### merge biosample attribute tsvs (iff provided with more than one)
-        if(length(biosample_map_tsvs)>1) {
+        if (length(flatten(select_all([biosample_map_tsvs]))) > 1) {
             call utils.tsv_join as biosample_map_tsv_join{
                 input:
                     input_tsvs   = flatten([select_first([biosample_map_tsvs,[]])]),

--- a/pipes/WDL/workflows/demux_deplete.wdl
+++ b/pipes/WDL/workflows/demux_deplete.wdl
@@ -235,7 +235,7 @@ workflow demux_deplete {
                 read_counts_cleaned_json     = write_json(count_cleaned)
             }
 
-            if (length(flatten(select_all([biosample_map]))) > 0) {
+            if (length(flatten(select_all([biosample_map_tsvs]))) > 0) {
                 call terra.upload_entities_tsv as terra_load_biosample_data {
                     input:
                         workspace_name   = check_terra_env.workspace_name,

--- a/pipes/WDL/workflows/demux_deplete.wdl
+++ b/pipes/WDL/workflows/demux_deplete.wdl
@@ -7,6 +7,7 @@ import "../tasks/tasks_ncbi.wdl" as ncbi
 import "../tasks/tasks_reports.wdl" as reports
 import "../tasks/tasks_taxon_filter.wdl" as taxon_filter
 import "../tasks/tasks_terra.wdl" as terra
+import "../tasks/tasks_utils.wdl" as utils
 
 workflow demux_deplete {
     meta {

--- a/pipes/WDL/workflows/sarscov2_illumina_full.wdl
+++ b/pipes/WDL/workflows/sarscov2_illumina_full.wdl
@@ -90,7 +90,7 @@ workflow sarscov2_illumina_full {
     call demux_deplete.demux_deplete {
         input:
             flowcell_tgz                    = flowcell_tgz,
-            biosample_map_tsvs              = biosample_merge.out_tsv,
+            biosample_map_tsvs              = [biosample_merge.out_tsv],
             instrument_model_user_specified = instrument_model,
             sra_title                       = sra_title,
             read_structure                  = read_structure,

--- a/pipes/WDL/workflows/sarscov2_illumina_full.wdl
+++ b/pipes/WDL/workflows/sarscov2_illumina_full.wdl
@@ -90,7 +90,7 @@ workflow sarscov2_illumina_full {
     call demux_deplete.demux_deplete {
         input:
             flowcell_tgz                    = flowcell_tgz,
-            biosample_map                   = biosample_merge.out_tsv,
+            biosample_map_tsvs              = biosample_merge.out_tsv,
             instrument_model_user_specified = instrument_model,
             sra_title                       = sra_title,
             read_structure                  = read_structure,


### PR DESCRIPTION
demux_deplete: allow multiple biosample attribute files

This modifies the `demux_deplete` workflow so it can accept multiple files with each containing biosample metadata/map info. This new behavior is useful for the scenario where a flowcell contains samples for which multiple BioSample submissions have been made that separately (ex. one for each of several attribute package types; or submissions made gradually over time). If more than one file is provided, the the data will be merged via a full left outer join via tasks_utils.wdl::tsv_join()

**Note: This is a breaking change for workflows importing the `demux_deplete` workflow as a sub-workflow, since the input `biosample_map` has been renamed to `biosample_map_tsvs`.**