### PR TITLE
s/Array[File]+/Array[File?]+/g for tsv_files input in terra_tsv_to_table.wdl

### DIFF
--- a/pipes/WDL/workflows/terra_tsv_to_table.wdl
+++ b/pipes/WDL/workflows/terra_tsv_to_table.wdl
@@ -13,7 +13,7 @@ workflow terra_tsv_to_table {
     }
 
     input {
-        Array[File]+ tsv_files
+        Array[File?]+ tsv_files
     }
 
     call terra.check_terra_env


### PR DESCRIPTION
Terra troubleshooting undefined values: allow the `tsv_files` input of `terra_tsv_to_table` to contain undefined File entries