### PR TITLE
update viral-core 2.3.6 -> 2.4.0

### DIFF
--- a/pipes/WDL/tasks/tasks_assembly.wdl
+++ b/pipes/WDL/tasks/tasks_assembly.wdl
@@ -583,7 +583,7 @@ task align_reads {
     Boolean  skip_mark_dupes = false
 
     Int?     machine_mem_gb
-    String   docker = "quay.io/broadinstitute/viral-core:2.3.6"
+    String   docker = "quay.io/broadinstitute/viral-core:2.4.0"
 
     String   sample_name = basename(basename(basename(reads_unmapped_bam, ".bam"), ".taxfilt"), ".clean")
   }
@@ -981,7 +981,7 @@ task run_discordance {
       String out_basename = "run"
       Int    min_coverage = 4
 
-      String docker = "quay.io/broadinstitute/viral-core:2.3.6"
+      String docker = "quay.io/broadinstitute/viral-core:2.4.0"
     }
     parameter_meta {
       reads_aligned_bam: {

--- a/pipes/WDL/tasks/tasks_demux.wdl
+++ b/pipes/WDL/tasks/tasks_demux.wdl
@@ -6,7 +6,7 @@ task merge_tarballs {
     String       out_filename
 
     Int?         machine_mem_gb
-    String       docker = "quay.io/broadinstitute/viral-core:2.3.6"
+    String       docker = "quay.io/broadinstitute/viral-core:2.4.0"
   }
 
   Int disk_size = 2625
@@ -163,7 +163,7 @@ task illumina_demux {
 
     Int?    machine_mem_gb
     Int     disk_size = 2625
-    String  docker = "quay.io/broadinstitute/viral-core:2.3.6"
+    String  docker = "quay.io/broadinstitute/viral-core:2.4.0"
   }
 
   parameter_meta {

--- a/pipes/WDL/tasks/tasks_interhost.wdl
+++ b/pipes/WDL/tasks/tasks_interhost.wdl
@@ -351,7 +351,7 @@ task index_ref {
     File?  novocraft_license
 
     Int?   machine_mem_gb
-    String docker = "quay.io/broadinstitute/viral-core:2.3.6"
+    String docker = "quay.io/broadinstitute/viral-core:2.4.0"
   }
 
   Int disk_size = 100

--- a/pipes/WDL/tasks/tasks_megablast.wdl
+++ b/pipes/WDL/tasks/tasks_megablast.wdl
@@ -36,7 +36,7 @@ task trim_rmdup_subsamp {
     command <<<
         set -ex o pipefail
         assembly.py --version | tee VERSION
-        #BAM ->FASTQ-> OutBam? https://github.com/broadinstitute/viral-assemble/blob/80bcc1da5c6a0174362ca9fd8bc0b49ee0b4103b/assembly.py#L91
+        #BAM ->FASTQ-> OutBam? https://github.com/broadinstitute/viral-assemble:2.3.6.1
         assembly.py trim_rmdup_subsamp \
         "~{inBam}" \
         "~{clipDb}" \

--- a/pipes/WDL/tasks/tasks_ncbi.wdl
+++ b/pipes/WDL/tasks/tasks_ncbi.wdl
@@ -192,7 +192,7 @@ task structured_comments {
 
     File?  filter_to_ids
 
-    String docker = "quay.io/broadinstitute/viral-core:2.3.6"
+    String docker = "quay.io/broadinstitute/viral-core:2.4.0"
   }
   String out_base = basename(assembly_stats_tsv, '.txt')
   command <<<
@@ -272,7 +272,7 @@ task rename_fasta_header {
 
     String out_basename = basename(genome_fasta, ".fasta")
 
-    String docker = "quay.io/broadinstitute/viral-core:2.3.6"
+    String docker = "quay.io/broadinstitute/viral-core:2.4.0"
   }
   command {
     set -e
@@ -437,7 +437,7 @@ task sra_meta_prep {
     Boolean     paired
 
     String      out_name = "sra_metadata.tsv"
-    String      docker="quay.io/broadinstitute/viral-core:2.3.6"
+    String      docker="quay.io/broadinstitute/viral-core:2.4.0"
   }
   Int disk_size = 100
   parameter_meta {

--- a/pipes/WDL/tasks/tasks_nextstrain.wdl
+++ b/pipes/WDL/tasks/tasks_nextstrain.wdl
@@ -321,7 +321,7 @@ task derived_cols {
         String?       lab_highlight_loc
         Array[File]   table_map = []
 
-        String        docker = "quay.io/broadinstitute/viral-core:2.3.6"
+        String        docker = "quay.io/broadinstitute/viral-core:2.4.0"
         Int           disk_size = 50
     }
     parameter_meta {
@@ -889,7 +889,7 @@ task filter_sequences_to_list {
 
         String       out_fname = sub(sub(basename(sequences, ".zst"), ".vcf", ".filtered.vcf"), ".fasta$", ".filtered.fasta")
         # Prior docker image: "nextstrain/base:build-20240318T173028Z"
-        String       docker = "quay.io/broadinstitute/viral-core:2.3.6"
+        String       docker = "quay.io/broadinstitute/viral-core:2.4.0"
         Int          disk_size = 750
     }
     parameter_meta {

--- a/pipes/WDL/tasks/tasks_read_utils.wdl
+++ b/pipes/WDL/tasks/tasks_read_utils.wdl
@@ -84,7 +84,7 @@ task group_bams_by_sample {
 task get_bam_samplename {
   input {
     File    bam
-    String  docker = "quay.io/broadinstitute/viral-core:2.3.6"
+    String  docker = "quay.io/broadinstitute/viral-core:2.4.0"
   }
   Int   disk_size = round(size(bam, "GB")) + 50
   command <<<
@@ -111,7 +111,7 @@ task get_sample_meta {
   input {
     Array[File] samplesheets_extended
 
-    String      docker = "quay.io/broadinstitute/viral-core:2.3.6"
+    String      docker = "quay.io/broadinstitute/viral-core:2.4.0"
   }
   Int disk_size = 50
   command <<<
@@ -172,7 +172,7 @@ task merge_and_reheader_bams {
       File?        reheader_table
       String       out_basename = basename(in_bams[0], ".bam")
 
-      String       docker = "quay.io/broadinstitute/viral-core:2.3.6"
+      String       docker = "quay.io/broadinstitute/viral-core:2.4.0"
       Int          disk_size = 750
       Int          machine_mem_gb = 4
     }
@@ -244,7 +244,7 @@ task rmdup_ubam {
     String  method = "mvicuna"
 
     Int     machine_mem_gb = 7
-    String  docker = "quay.io/broadinstitute/viral-core:2.3.6"
+    String  docker = "quay.io/broadinstitute/viral-core:2.4.0"
   }
 
   Int disk_size = 375
@@ -303,7 +303,7 @@ task downsample_bams {
     Boolean      deduplicateAfter = false
 
     Int?         machine_mem_gb
-    String       docker = "quay.io/broadinstitute/viral-core:2.3.6"
+    String       docker = "quay.io/broadinstitute/viral-core:2.4.0"
   }
 
   Int disk_size = 750
@@ -367,7 +367,7 @@ task FastqToUBAM {
     String? sequencing_center
     String? additional_picard_options
 
-    String  docker = "quay.io/broadinstitute/viral-core:2.3.6"
+    String  docker = "quay.io/broadinstitute/viral-core:2.4.0"
   }
   Int disk_size = 375
   parameter_meta {
@@ -418,7 +418,7 @@ task read_depths {
     File      aligned_bam
 
     String    out_basename = basename(aligned_bam, '.bam')
-    String    docker = "quay.io/broadinstitute/viral-core:2.3.6"
+    String    docker = "quay.io/broadinstitute/viral-core:2.4.0"
   }
   Int disk_size = 200
   command <<<

--- a/pipes/WDL/tasks/tasks_reports.wdl
+++ b/pipes/WDL/tasks/tasks_reports.wdl
@@ -15,7 +15,7 @@ task alignment_metrics {
     Int    max_amplicons=500
 
     Int    machine_mem_gb=32
-    String docker = "quay.io/broadinstitute/viral-core:2.3.6"
+    String docker = "quay.io/broadinstitute/viral-core:2.4.0"
   }
 
   String out_basename = basename(aligned_bam, ".bam")
@@ -142,7 +142,7 @@ task plot_coverage {
     String? plotXLimits # of the form "min max" (ints, space between)
     String? plotYLimits # of the form "min max" (ints, space between)
 
-    String  docker = "quay.io/broadinstitute/viral-core:2.3.6"
+    String  docker = "quay.io/broadinstitute/viral-core:2.4.0"
   }
 
   Int disk_size = 375
@@ -289,7 +289,7 @@ task coverage_report {
     Array[File]  mapped_bam_idx # optional.. speeds it up if you provide it, otherwise we auto-index
     String       out_report_name = "coverage_report.txt"
 
-    String       docker = "quay.io/broadinstitute/viral-core:2.3.6"
+    String       docker = "quay.io/broadinstitute/viral-core:2.4.0"
   }
 
   Int disk_size = 375
@@ -356,7 +356,7 @@ task fastqc {
   input {
     File   reads_bam
 
-    String docker = "quay.io/broadinstitute/viral-core:2.3.6"
+    String docker = "quay.io/broadinstitute/viral-core:2.4.0"
   }
   parameter_meta {
     reads_bam:{ 
@@ -404,7 +404,7 @@ task align_and_count {
     Boolean keep_duplicates_when_filtering                    = false
 
     Int?   machine_mem_gb
-    String docker = "quay.io/broadinstitute/viral-core:2.3.6"
+    String docker = "quay.io/broadinstitute/viral-core:2.4.0"
   }
 
   String  reads_basename=basename(reads_bam, ".bam")
@@ -516,7 +516,7 @@ task align_and_count_summary {
 
     String       output_prefix = "count_summary"
 
-    String       docker = "quay.io/broadinstitute/viral-core:2.3.6"
+    String       docker = "quay.io/broadinstitute/viral-core:2.4.0"
   }
 
   Int disk_size = 100

--- a/pipes/WDL/tasks/tasks_taxon_filter.wdl
+++ b/pipes/WDL/tasks/tasks_taxon_filter.wdl
@@ -211,7 +211,7 @@ task merge_one_per_sample {
     Boolean      rmdup = false
 
     Int          machine_mem_gb = 7
-    String       docker = "quay.io/broadinstitute/viral-core:2.3.6"
+    String       docker = "quay.io/broadinstitute/viral-core:2.4.0"
   }
 
   Int disk_size = 750

--- a/pipes/WDL/tasks/tasks_terra.wdl
+++ b/pipes/WDL/tasks/tasks_terra.wdl
@@ -391,7 +391,7 @@ task create_or_update_sample_tables {
     String  sample_table_name  = "sample"
     String  library_table_name = "library"
 
-    String  docker = "quay.io/broadinstitute/viral-core:2.3.6"
+    String  docker = "quay.io/broadinstitute/viral-core:2.4.0"
   }
 
   meta {

--- a/pipes/WDL/tasks/tasks_utils.wdl
+++ b/pipes/WDL/tasks/tasks_utils.wdl
@@ -103,7 +103,7 @@ task zcat {
         { if [ -f /sys/fs/cgroup/memory.peak ]; then cat /sys/fs/cgroup/memory.peak; elif [ -f /sys/fs/cgroup/memory/memory.peak ]; then cat /sys/fs/cgroup/memory/memory.peak; elif [ -f /sys/fs/cgroup/memory/memory.max_usage_in_bytes ]; then cat /sys/fs/cgroup/memory/memory.max_usage_in_bytes; else echo "0"; fi } > MEM_BYTES
     >>>
     runtime {
-        docker: "quay.io/broadinstitute/viral-core:2.3.6"
+        docker: "quay.io/broadinstitute/viral-core:2.4.0"
         memory: "1 GB"
         cpu:    cpus
         disks:  "local-disk " + disk_size + " LOCAL"
@@ -430,7 +430,7 @@ task tsv_join {
   runtime {
     memory: "~{machine_mem_gb} GB"
     cpu: 4
-    docker: "quay.io/broadinstitute/viral-core:2.3.6"
+    docker: "quay.io/broadinstitute/viral-core:2.4.0"
     disks:  "local-disk " + disk_size + " HDD"
     disk: disk_size + " GB" # TES
     dx_instance_type: "mem1_ssd1_v2_x4"
@@ -517,7 +517,7 @@ task tsv_stack {
   input {
     Array[File]+ input_tsvs
     String       out_basename
-    String       docker = "quay.io/broadinstitute/viral-core:2.3.6"
+    String       docker = "quay.io/broadinstitute/viral-core:2.4.0"
   }
 
   Int disk_size = 50
@@ -780,7 +780,7 @@ task filter_sequences_by_length {
         File   sequences_fasta
         Int    min_non_N = 1
 
-        String docker = "quay.io/broadinstitute/viral-core:2.3.6"
+        String docker = "quay.io/broadinstitute/viral-core:2.4.0"
         Int    disk_size = 750
     }
     parameter_meta {

--- a/requirements-modules.txt
+++ b/requirements-modules.txt
@@ -1,4 +1,4 @@
-broadinstitute/viral-core=2.3.6
+broadinstitute/viral-core=2.4.0
 broadinstitute/viral-assemble=2.3.6.1
 broadinstitute/viral-classify=2.2.4.2
 broadinstitute/viral-phylo=2.3.6.0


### PR DESCRIPTION
update viral-core 2.3.6 -> 2.4.0 so the NCBI datasets CLI tools are available