### PR TITLE
Expose --timetree parameter in refine_augur_tree

### DIFF
--- a/pipes/WDL/tasks/tasks_nextstrain.wdl
+++ b/pipes/WDL/tasks/tasks_nextstrain.wdl
@@ -1409,7 +1409,6 @@ task refine_augur_tree {
             --metadata "~{metadata}" \
             --output-tree "~{out_basename}_timetree.nwk" \
             --output-node-data "~{out_basename}_branch_lengths.json" \
-            --timetree \
             ~{"--clock-rate " + clock_rate} \
             ~{"--clock-std-dev " + clock_std_dev} \
             ~{"--coalescent " + coalescent} \

--- a/pipes/WDL/tasks/tasks_nextstrain.wdl
+++ b/pipes/WDL/tasks/tasks_nextstrain.wdl
@@ -1373,7 +1373,7 @@ task refine_augur_tree {
         File     msa_or_vcf
         File     metadata
 
-        Boolean? generate_timetree = true
+        Boolean  generate_timetree = true
         Int?     gen_per_year
         Float?   clock_rate
         Float?   clock_std_dev

--- a/pipes/WDL/tasks/tasks_nextstrain.wdl
+++ b/pipes/WDL/tasks/tasks_nextstrain.wdl
@@ -1373,6 +1373,7 @@ task refine_augur_tree {
         File     msa_or_vcf
         File     metadata
 
+        Boolean? generate_timetree = true
         Int?     gen_per_year
         Float?   clock_rate
         Float?   clock_std_dev
@@ -1409,6 +1410,7 @@ task refine_augur_tree {
             --metadata "~{metadata}" \
             --output-tree "~{out_basename}_timetree.nwk" \
             --output-node-data "~{out_basename}_branch_lengths.json" \
+            ~{true="--timetree" false="" generate_timetree} \
             ~{"--clock-rate " + clock_rate} \
             ~{"--clock-std-dev " + clock_std_dev} \
             ~{"--coalescent " + coalescent} \

--- a/pipes/WDL/workflows/augur_from_mltree.wdl
+++ b/pipes/WDL/workflows/augur_from_mltree.wdl
@@ -54,35 +54,29 @@ workflow augur_from_mltree {
         }
     }
 
-    call nextstrain.refine_augur_tree {
-        input:
-            raw_tree   = raw_tree,
-            msa_or_vcf = msa_or_vcf,
-            metadata   = sample_metadata
-    }
     if(defined(ancestral_traits_to_infer) && length(select_first([ancestral_traits_to_infer,[]]))>0) {
         call nextstrain.ancestral_traits {
             input:
-                tree     = refine_augur_tree.tree_refined,
+                tree     = raw_tree,
                 metadata = sample_metadata,
                 columns  = select_first([ancestral_traits_to_infer,[]])
         }
     }
     call nextstrain.ancestral_tree {
         input:
-            tree       = refine_augur_tree.tree_refined,
+            tree       = raw_tree,
             msa_or_vcf = msa_or_vcf
     }
     call nextstrain.translate_augur_tree {
         input:
-            tree       = refine_augur_tree.tree_refined,
+            tree       = raw_tree,
             nt_muts    = ancestral_tree.nt_muts_json,
             genbank_gb = genbank_gb
     }
     if(defined(clades_tsv)) {
         call nextstrain.assign_clades_to_nodes {
             input:
-                tree_nwk     = refine_augur_tree.tree_refined,
+                tree_nwk     = raw_tree,
                 nt_muts_json = ancestral_tree.nt_muts_json,
                 aa_muts_json = translate_augur_tree.aa_muts_json,
                 ref_fasta    = ref_fasta,
@@ -91,10 +85,9 @@ workflow augur_from_mltree {
     }
     call nextstrain.export_auspice_json {
         input:
-            tree            = refine_augur_tree.tree_refined,
+            tree            = raw_tree,
             sample_metadata = sample_metadata,
             node_data_jsons = select_all([
-                                refine_augur_tree.branch_lengths,
                                 ancestral_traits.node_data_json,
                                 ancestral_tree.nt_muts_json,
                                 translate_augur_tree.aa_muts_json,
@@ -103,7 +96,7 @@ workflow augur_from_mltree {
     }
 
     output {
-        File time_tree          = refine_augur_tree.tree_refined
+        File time_tree          = raw_tree
         File auspice_input_json = export_auspice_json.virus_json
     }
 }

--- a/pipes/WDL/workflows/augur_from_mltree.wdl
+++ b/pipes/WDL/workflows/augur_from_mltree.wdl
@@ -67,18 +67,11 @@ workflow augur_from_mltree {
             tree       = raw_tree,
             msa_or_vcf = msa_or_vcf
     }
-    call nextstrain.translate_augur_tree {
-        input:
-            tree       = raw_tree,
-            nt_muts    = ancestral_tree.nt_muts_json,
-            genbank_gb = genbank_gb
-    }
     if(defined(clades_tsv)) {
         call nextstrain.assign_clades_to_nodes {
             input:
                 tree_nwk     = raw_tree,
                 nt_muts_json = ancestral_tree.nt_muts_json,
-                aa_muts_json = translate_augur_tree.aa_muts_json,
                 ref_fasta    = ref_fasta,
                 clades_tsv   = select_first([clades_tsv])
         }
@@ -90,7 +83,6 @@ workflow augur_from_mltree {
             node_data_jsons = select_all([
                                 ancestral_traits.node_data_json,
                                 ancestral_tree.nt_muts_json,
-                                translate_augur_tree.aa_muts_json,
                                 assign_clades_to_nodes.node_clade_data_json]),
             auspice_config  = auspice_config
     }

--- a/pipes/WDL/workflows/augur_from_mltree.wdl
+++ b/pipes/WDL/workflows/augur_from_mltree.wdl
@@ -54,41 +54,56 @@ workflow augur_from_mltree {
         }
     }
 
+    call nextstrain.refine_augur_tree {
+        input:
+            raw_tree   = raw_tree,
+            msa_or_vcf = msa_or_vcf,
+            metadata   = sample_metadata
+    }
     if(defined(ancestral_traits_to_infer) && length(select_first([ancestral_traits_to_infer,[]]))>0) {
         call nextstrain.ancestral_traits {
             input:
-                tree     = raw_tree,
+                tree     = refine_augur_tree.tree_refined,
                 metadata = sample_metadata,
                 columns  = select_first([ancestral_traits_to_infer,[]])
         }
     }
     call nextstrain.ancestral_tree {
         input:
-            tree       = raw_tree,
+            tree       = refine_augur_tree.tree_refined,
             msa_or_vcf = msa_or_vcf
+    }
+    call nextstrain.translate_augur_tree {
+        input:
+            tree       = refine_augur_tree.tree_refined,
+            nt_muts    = ancestral_tree.nt_muts_json,
+            genbank_gb = genbank_gb
     }
     if(defined(clades_tsv)) {
         call nextstrain.assign_clades_to_nodes {
             input:
-                tree_nwk     = raw_tree,
+                tree_nwk     = refine_augur_tree.tree_refined,
                 nt_muts_json = ancestral_tree.nt_muts_json,
+                aa_muts_json = translate_augur_tree.aa_muts_json,
                 ref_fasta    = ref_fasta,
                 clades_tsv   = select_first([clades_tsv])
         }
     }
     call nextstrain.export_auspice_json {
         input:
-            tree            = raw_tree,
+            tree            = refine_augur_tree.tree_refined,
             sample_metadata = sample_metadata,
             node_data_jsons = select_all([
+                                refine_augur_tree.branch_lengths,
                                 ancestral_traits.node_data_json,
                                 ancestral_tree.nt_muts_json,
+                                translate_augur_tree.aa_muts_json,
                                 assign_clades_to_nodes.node_clade_data_json]),
             auspice_config  = auspice_config
     }
 
     output {
-        File time_tree          = raw_tree
+        File time_tree          = refine_augur_tree.tree_refined
         File auspice_input_json = export_auspice_json.virus_json
     }
 }


### PR DESCRIPTION
Adds a new parameter generate_timetree to refine_augur_tree task to expose --timetree parameter of augur refine. When generate_timetree is true or blank, time is used to adjust branch lengths. When generate_timetree is false, time is not used to adjust branch lengths.