### PR TITLE
assembly and genbank updates

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -135,6 +135,9 @@ workflows:
   - name: filter_sequences
     subclass: WDL
     primaryDescriptorPath: /pipes/WDL/workflows/filter_sequences.wdl
+  - name: genbank_gather
+    subclass: WDL
+    primaryDescriptorPath: /pipes/WDL/workflows/genbank_gather.wdl
   - name: genbank_single
     subclass: WDL
     primaryDescriptorPath: /pipes/WDL/workflows/genbank_single.wdl

--- a/pipes/WDL/tasks/tasks_assembly.wdl
+++ b/pipes/WDL/tasks/tasks_assembly.wdl
@@ -783,7 +783,6 @@ task refine_assembly_with_aligned_reads {
         # trim edges if they're too ambiguous or else table2asn will reject if first or last line of seq > 40% ambig
         # (we don't really know how long the last line will be so use both the --ten and --fifty rules
         # and basically disable the --maxfrac rule as we will handle that elsewhere)
-        export PERL5LIB=$PERL5LIB:/opt/miniconda/envs/viral-ngs-env/share/sequip-0.10/lib
         fasta-trim-terminal-ambigs.pl --3rules \
           --ten 4 \
           --fifty 15 \

--- a/pipes/WDL/tasks/tasks_assembly.wdl
+++ b/pipes/WDL/tasks/tasks_assembly.wdl
@@ -720,7 +720,7 @@ task refine_assembly_with_aligned_reads {
       Int      min_coverage = 3
 
       Int      machine_mem_gb = 15
-      String   docker = "quay.io/broadinstitute/viral-assemble:2.3.6.1"
+      String   docker = "quay.io/broadinstitute/viral-assemble:dp-trim" #skip-global-version-pin
     }
 
     Int disk_size = 375

--- a/pipes/WDL/tasks/tasks_assembly.wdl
+++ b/pipes/WDL/tasks/tasks_assembly.wdl
@@ -783,6 +783,7 @@ task refine_assembly_with_aligned_reads {
         # trim edges if they're too ambiguous or else table2asn will reject if first or last line of seq > 40% ambig
         # (we don't really know how long the last line will be so use both the --ten and --fifty rules
         # and basically disable the --maxfrac rule as we will handle that elsewhere)
+        export PERL5LIB=$PERL5LIB:/opt/miniconda/envs/viral-ngs-env/share/sequip-0.10/lib
         fasta-trim-terminal-ambigs.pl --3rules \
           --ten 4 \
           --fifty 15 \

--- a/pipes/WDL/tasks/tasks_assembly.wdl
+++ b/pipes/WDL/tasks/tasks_assembly.wdl
@@ -15,7 +15,7 @@ task assemble {
       String   sample_name = basename(basename(reads_unmapped_bam, ".bam"), ".taxfilt")
       
       Int?     machine_mem_gb
-      String   docker = "quay.io/broadinstitute/viral-assemble:2.3.6.1"
+      String   docker = "quay.io/broadinstitute/viral-assemble:2.4.1.0"
     }
     parameter_meta{
       reads_unmapped_bam: {
@@ -115,7 +115,7 @@ task select_references {
     Int?          skani_s
     Int?          skani_c
 
-    String        docker = "quay.io/broadinstitute/viral-assemble:2.3.6.1"
+    String        docker = "quay.io/broadinstitute/viral-assemble:2.4.1.0"
     Int           machine_mem_gb = 4
     Int           cpu = 2
     Int           disk_size = 100
@@ -206,7 +206,7 @@ task scaffold {
       Float?       scaffold_min_pct_contig_aligned
 
       Int?         machine_mem_gb
-      String       docker="quay.io/broadinstitute/viral-assemble:2.3.6.1"
+      String       docker="quay.io/broadinstitute/viral-assemble:2.4.1.0"
 
       # do this in multiple steps in case the input doesn't actually have "assembly1-x" in the name
       String       sample_name = basename(basename(contigs_fasta, ".fasta"), ".assembly1-spades")
@@ -720,7 +720,7 @@ task refine_assembly_with_aligned_reads {
       Int      min_coverage = 3
 
       Int      machine_mem_gb = 15
-      String   docker = "quay.io/broadinstitute/viral-assemble:dp-trim" #skip-global-version-pin
+      String   docker = "quay.io/broadinstitute/viral-assemble:2.4.1.0"
     }
 
     Int disk_size = 375

--- a/pipes/WDL/tasks/tasks_megablast.wdl
+++ b/pipes/WDL/tasks/tasks_megablast.wdl
@@ -15,7 +15,7 @@ task trim_rmdup_subsamp {
         Int cpu            = 16
         Int disk_size_gb   = 100 
 
-        String docker      = "quay.io/broadinstitute/viral-assemble:2.3.6.1"
+        String docker      = "quay.io/broadinstitute/viral-assemble:2.4.1.0"
     }
 
     parameter_meta {
@@ -36,7 +36,7 @@ task trim_rmdup_subsamp {
     command <<<
         set -ex o pipefail
         assembly.py --version | tee VERSION
-        #BAM ->FASTQ-> OutBam? https://github.com/broadinstitute/viral-assemble:2.3.6.1
+        #BAM ->FASTQ-> OutBam? https://github.com/broadinstitute/viral-assemble:2.4.1.0
         assembly.py trim_rmdup_subsamp \
         "~{inBam}" \
         "~{clipDb}" \

--- a/pipes/WDL/tasks/tasks_ncbi.wdl
+++ b/pipes/WDL/tasks/tasks_ncbi.wdl
@@ -843,7 +843,7 @@ task biosample_to_genbank {
                   print("overriding geo_loc_name with food_origin")
                   row['geo_loc_name'] = row['food_origin']
 
-    with open("~{out_basename}.genbank.src", 'wt') as outf_smt:
+    with open("~{out_basename}.src", 'wt') as outf_smt:
       out_headers = list(h for h in out_headers_total if header_key_map.get(h,h) in in_headers)
       if 'db_xref' not in out_headers:
           out_headers.append('db_xref')

--- a/pipes/WDL/tasks/tasks_ncbi.wdl
+++ b/pipes/WDL/tasks/tasks_ncbi.wdl
@@ -1510,7 +1510,7 @@ task package_genbank_submissions {
       files_by_type[group] = []
 
     # read manifest from genbank_single
-    for genome in json.loads("[~{sep=',' genbank_file_manifest}]"):
+    for genome in json.loads('[~{sep="," genbank_file_manifest}]'):
       group = genome['submission_type'] + '_' + ('clean' if genome['validation_passing'] else 'warnings')
       counts_by_type[group] += 1
       files_by_type[group].extend(genome['files'])

--- a/pipes/WDL/tasks/tasks_ncbi.wdl
+++ b/pipes/WDL/tasks/tasks_ncbi.wdl
@@ -1503,7 +1503,7 @@ task package_genbank_submissions {
 
     # initialize counters and file lists for each submission category
     counts_by_type = {}
-    files_by_type {}
+    files_by_type = {}
     groups_total = list(m+"_"+v for m in ('table2asn', 'Influenza', 'SARS-CoV-2', 'Norovirus', 'Dengue') for v in ('clean', 'warnings'))
     for group in groups_total:
       counts_by_type[group] = 0

--- a/pipes/WDL/tasks/tasks_ncbi.wdl
+++ b/pipes/WDL/tasks/tasks_ncbi.wdl
@@ -1297,7 +1297,7 @@ task genbank_special_taxa {
     with open("table2asn_allowed.boolean", "wt") as outf:
       outf.write("false" if prohibited else "true")
     with open("genbank_submission_mechanism.str", "wt") as outf:
-      if any(node in set(11320, 11520, 11552) for node in this_and_ancestors):
+      if any(node in set((11320, 11520, 11552)) for node in this_and_ancestors):
         outf.write("Influenza")
       elif any(node == 2697049 for node in this_and_ancestors):
         outf.write("SARS-CoV-2")

--- a/pipes/WDL/tasks/tasks_read_utils.wdl
+++ b/pipes/WDL/tasks/tasks_read_utils.wdl
@@ -368,8 +368,8 @@ task FastqToUBAM {
     String? additional_picard_options
 
     Int     cpus = 2
-    Int     mem_gb = 3
-    Int     disk_size = 375
+    Int     mem_gb = 4
+    Int     disk_size = 750
     String  docker = "quay.io/broadinstitute/viral-core:2.4.1"
   }
   parameter_meta {

--- a/pipes/WDL/tasks/tasks_read_utils.wdl
+++ b/pipes/WDL/tasks/tasks_read_utils.wdl
@@ -367,9 +367,11 @@ task FastqToUBAM {
     String? sequencing_center
     String? additional_picard_options
 
+    Int     cpus = 2
+    Int     mem_gb = 3
+    Int     disk_size = 375
     String  docker = "quay.io/broadinstitute/viral-core:2.4.1"
   }
-  Int disk_size = 375
   parameter_meta {
     fastq_1: { description: "Unaligned read1 file in fastq format", patterns: ["*.fastq", "*.fastq.gz", "*.fq", "*.fq.gz"] }
     fastq_2: { description: "Unaligned read2 file in fastq format. This should be empty for single-end read conversion and required for paired-end reads. If provided, it must match fastq_1 in length and order.", patterns: ["*.fastq", "*.fastq.gz", "*.fq", "*.fq.gz"] }
@@ -401,8 +403,8 @@ task FastqToUBAM {
   }
   runtime {
     docker: docker
-    cpu: 2
-    memory: "3 GB"
+    cpu: cpus
+    memory: mem_gb + " GB"
     disks:  "local-disk " + disk_size + " LOCAL"
     disk: disk_size + " GB" # TES
     dx_instance_type: "mem1_ssd1_v2_x2"

--- a/pipes/WDL/tasks/tasks_reports.wdl
+++ b/pipes/WDL/tasks/tasks_reports.wdl
@@ -485,6 +485,8 @@ task align_and_count {
     if [ $TOTAL_READS_IN_INPUT -eq 0 ]; then
       echo "no reads in input bam"
       PCT_OF_INPUT_READS_MAPPED=$(echo "0" | tee "~{reads_basename}.count.~{ref_basename}.pct_total_reads_mapped.txt")
+      echo "PCT_TOP_HIT_OF_TOTAL_READS cannot be calculated: there were no mapping hits, or no reads"
+      PCT_TOP_HIT_OF_TOTAL_READS=$( echo "null" | tee '~{reads_basename}.count.~{ref_basename}.pct_top_hit_of_total_reads.txt')
     else
       PCT_OF_INPUT_READS_MAPPED=$( echo "scale=3; 100 * ($TOTAL_COUNT_OF_LESSER_HITS + $TOTAL_COUNT_OF_TOP_HIT) / $TOTAL_READS_IN_INPUT" | \
       bc -l | awk '{printf "%.3f\n", $0}' | tee '~{reads_basename}.count.~{ref_basename}.pct_total_reads_mapped.txt' )

--- a/pipes/WDL/tasks/tasks_reports.wdl
+++ b/pipes/WDL/tasks/tasks_reports.wdl
@@ -300,7 +300,8 @@ task coverage_report {
     python3 << CODE
     import tools.samtools
     import reports
-    in_bams = list([bam for bam in ["~{sep='", "' mapped_bams}"] if bam and not tools.samtools.isEmpty(bam)])
+    samtools = tools.samtools.SamtoolsTool()
+    in_bams = list([bam for bam in ["~{sep='", "' mapped_bams}"] if bam and not samtools.isEmpty(bam)])
     if in_bams:
       reports.coverage_only(in_bams, "~{out_report_name}")
     else:

--- a/pipes/WDL/tasks/tasks_reports.wdl
+++ b/pipes/WDL/tasks/tasks_reports.wdl
@@ -707,7 +707,7 @@ task compare_two_genomes {
     File   genome_two
     String out_basename
 
-    String docker = "quay.io/broadinstitute/viral-assemble:2.3.6.1"
+    String docker = "quay.io/broadinstitute/viral-assemble:2.4.1.0"
   }
 
   Int disk_size = 50

--- a/pipes/WDL/tasks/tasks_utils.wdl
+++ b/pipes/WDL/tasks/tasks_utils.wdl
@@ -992,16 +992,16 @@ task rename_file {
     File   infile
     String out_filename
   }
-  Int disk_size = 100
+  Int disk_size = 375
   command {
-    ln -s "~{infile}" "~{out_filename}"
+    cp "~{infile}" "~{out_filename}"
   }
   output {
     File out = "~{out_filename}"
   }
   runtime {
-    memory: "1 GB"
-    cpu: 1
+    memory: "2 GB"
+    cpu: 2
     docker: "ubuntu"
     disks:  "local-disk " + disk_size + " HDD"
     disk: disk_size + " GB" # TES

--- a/pipes/WDL/workflows/genbank_gather.wdl
+++ b/pipes/WDL/workflows/genbank_gather.wdl
@@ -1,0 +1,47 @@
+version 1.0
+
+import "../tasks/tasks_ncbi.wdl" as ncbi
+import "../tasks/tasks_utils.wdl" as utils
+
+workflow genbank_gather {
+    meta {
+        description: "More here."
+        author: "Broad Viral Genomics"
+        email:  "viral-ngs@broadinstitute.org"
+        allowNestedInputs: true
+    }
+
+    input {
+        Array[String?]     genbank_file_manifest
+        Array[File?]       genbank_submit_files
+    }
+
+    call ncbi.package_genbank_submissions {
+        input:
+            genbank_file_manifest   = select_all(genbank_file_manifest),
+            genbank_submit_files    = select_all(genbank_submit_files)
+    }
+
+    output {
+        File? submit_sqns_clean_zip       = package_genbank_submissions.submit_sqns_clean_zip
+        File? submit_sqns_warnings_zip    = package_genbank_submissions.submit_sqns_warnings_zip
+        Int   num_sqns_clean              = package_genbank_submissions.num_sqns_clean
+        Int   num_sqns_warnings           = package_genbank_submissions.num_sqns_warnings
+        File? submit_flu_clean_zip        = package_genbank_submissions.submit_flu_clean_zip
+        File? submit_flu_warnings_zip     = package_genbank_submissions.submit_flu_warnings_zip
+        Int   num_flu_clean               = package_genbank_submissions.num_flu_clean
+        Int   num_flu_warnings            = package_genbank_submissions.num_flu_warnings
+        File? submit_sc2_clean_zip        = package_genbank_submissions.submit_sc2_clean_zip
+        File? submit_sc2_warnings_zip     = package_genbank_submissions.submit_sc2_warnings_zip
+        Int   num_sc2_clean               = package_genbank_submissions.num_sc2_clean
+        Int   num_sc2_warnings            = package_genbank_submissions.num_sc2_warnings
+        File? submit_noro_clean_zip       = package_genbank_submissions.submit_noro_clean_zip
+        File? submit_noro_warnings_zip    = package_genbank_submissions.submit_noro_warnings_zip
+        Int   num_noro_clean              = package_genbank_submissions.num_noro_clean
+        Int   num_noro_warnings           = package_genbank_submissions.num_noro_warnings
+        File? submit_dengue_clean_zip     = package_genbank_submissions.submit_dengue_clean_zip
+        File? submit_dengue_warnings_zip  = package_genbank_submissions.submit_dengue_warnings_zip
+        Int   num_dengue_clean            = package_genbank_submissions.num_dengue_clean
+        Int   num_dengue_warnings         = package_genbank_submissions.num_dengue_warnings
+    }
+}

--- a/pipes/WDL/workflows/genbank_single.wdl
+++ b/pipes/WDL/workflows/genbank_single.wdl
@@ -147,11 +147,12 @@ workflow genbank_single {
       Array[File] special_submit_files = [assembly_fsa.out,
         structured_comments_from_aligned_bam.structured_comment_file,
         biosample_to_genbank.genbank_source_modifier_table]
+      String special_basename_list = '["~{assembly_id}.fsa", "~{assembly_id}.cmt", "~{assembly_id}.src"]'
     }
+    String basename_list_json = select_first([special_basename_list, '["~{assembly_id}.sqn"]'])
 
     scatter(submit_file in select_all(flatten(select_all([[table2asn.genbank_submission_sqn], special_submit_files])))) {
       File   submit_files = submit_file
-      String submit_basenames = basename(submit_file)
     }
 
     output {
@@ -171,7 +172,7 @@ workflow genbank_single {
         Boolean?      table2asn_pass         = table2asn.table2asn_passing
 
         Array[File]   genbank_submit_files   = submit_files
-        String        genbank_file_manifest  = '{"submission_type": "~{genbank_special_taxa.genbank_submission_mechanism}", "validation_passing": ~{select_first([vadr.pass, true]) && select_first([table2asn.table2asn_passing, true])}, "files": ~{read_string(write_json(submit_basenames))}}'
+        String        genbank_file_manifest  = '{"submission_type": "~{genbank_special_taxa.genbank_submission_mechanism}", "validation_passing": ~{select_first([vadr.pass, true]) && select_first([table2asn.table2asn_passing, true])}, "files": ~{basename_list_json}}'
     }
 
 }

--- a/pipes/WDL/workflows/genbank_single.wdl
+++ b/pipes/WDL/workflows/genbank_single.wdl
@@ -149,6 +149,11 @@ workflow genbank_single {
         biosample_to_genbank.genbank_source_modifier_table]
     }
 
+    scatter(submit_file in select_all(flatten(select_all([[table2asn.genbank_submission_sqn], special_submit_files])))) {
+      File   submit_files = submit_file
+      String submit_basenames = basename(submit_file)
+    }
+
     output {
         String        genbank_mechanism      = genbank_special_taxa.genbank_submission_mechanism
         File          genbank_comment_file   = structured_comments_from_aligned_bam.structured_comment_file
@@ -163,8 +168,10 @@ workflow genbank_single {
         File?         genbank_preview_file   = table2asn.genbank_preview_file
         File?         table2asn_val_file     = table2asn.genbank_validation_file
         Array[String] table2asn_errors       = select_first([table2asn.table2asn_errors, []])
+        Boolean?      table2asn_pass         = table2asn.table2asn_passing
 
-        Array[File]   genbank_submit_files   = select_all(flatten(select_all([[table2asn.genbank_submission_sqn], special_submit_files])))
+        Array[File]   genbank_submit_files   = submit_files
+        String        genbank_file_manifest  = '{"submission_type": "~{genbank_special_taxa.genbank_submission_mechanism}", "validation_passing": ~{select_first([vadr.pass, true]) && select_first([table2asn.table2asn_passing, true])}, "files": ~{read_string(write_json(submit_basenames))}}'
     }
 
 }

--- a/pipes/WDL/workflows/genbank_single.wdl
+++ b/pipes/WDL/workflows/genbank_single.wdl
@@ -69,7 +69,7 @@ workflow genbank_single {
     }
 
     # Rename fasta
-    call util.rename_file as assembly_fsa {
+    call utils.rename_file as assembly_fsa {
         input:
             infile       = assembly_fasta,
             out_filename = assembly_id + ".fsa"
@@ -164,7 +164,7 @@ workflow genbank_single {
         File?         table2asn_val_file     = table2asn.genbank_validation_file
         Array[String] table2asn_errors       = select_first([table2asn.table2asn_errors, []])
 
-        Array[File]   genbank_submit_files   = flatten(select_all([[table2asn.genbank_submission_sqn], special_submit_files]))
+        Array[File]   genbank_submit_files   = select_all(flatten(select_all([[table2asn.genbank_submission_sqn], special_submit_files])))
     }
 
 }

--- a/pipes/WDL/workflows/sarscov2_genbank.wdl
+++ b/pipes/WDL/workflows/sarscov2_genbank.wdl
@@ -126,7 +126,7 @@ workflow sarscov2_genbank {
             defaults_yaml = author_sbt_defaults_yaml,
             j2_template   = author_sbt_j2_template
     }
-    call ncbi.package_sc2_genbank_ftp_submission as passing_package_genbank {
+    call ncbi.package_special_genbank_ftp_submission as passing_package_genbank {
       input:
         sequences_fasta          = passing_fasta.combined,
         source_modifier_table    = passing_source_modifiers.genbank_source_modifier_table,
@@ -162,7 +162,7 @@ workflow sarscov2_genbank {
         assembly_stats_tsv = assembly_stats_tsv,
         filter_to_ids      = weird_ids.ids_txt
     }
-    call ncbi.package_sc2_genbank_ftp_submission as weird_package_genbank {
+    call ncbi.package_special_genbank_ftp_submission as weird_package_genbank {
       input:
         sequences_fasta          = weird_fasta.combined,
         source_modifier_table    = weird_source_modifiers.genbank_source_modifier_table,

--- a/pipes/WDL/workflows/sarscov2_illumina_full.wdl
+++ b/pipes/WDL/workflows/sarscov2_illumina_full.wdl
@@ -345,7 +345,7 @@ workflow sarscov2_illumina_full {
         sequences = submittable_filter.filtered_fasta,
         keep_list = [biosample_to_genbank.sample_ids]
     }
-    call ncbi.package_sc2_genbank_ftp_submission as package_genbank_ftp_submission {
+    call ncbi.package_special_genbank_ftp_submission as package_genbank_ftp_submission {
       input:
         sequences_fasta          = submit_genomes.filtered_fasta,
         source_modifier_table    = biosample_to_genbank.genbank_source_modifier_table,

--- a/pipes/WDL/workflows/sarscov2_sra_to_genbank.wdl
+++ b/pipes/WDL/workflows/sarscov2_sra_to_genbank.wdl
@@ -202,7 +202,7 @@ workflow sarscov2_sra_to_genbank {
         assembly_stats_tsv = write_tsv(flatten([[['SeqID','Assembly Method','Coverage','Sequencing Technology']],select_all(assembly_cmt)])),
         filter_to_ids      = write_lines(select_all(submittable_id))
     }
-    call ncbi.package_sc2_genbank_ftp_submission as package_genbank_ftp_submission {
+    call ncbi.package_special_genbank_ftp_submission as package_genbank_ftp_submission {
       input:
         sequences_fasta          = submit_genomes.combined,
         source_modifier_table    = biosample_to_genbank.genbank_source_modifier_table,

--- a/pipes/WDL/workflows/scaffold_and_refine_multitaxa.wdl
+++ b/pipes/WDL/workflows/scaffold_and_refine_multitaxa.wdl
@@ -78,17 +78,6 @@ workflow scaffold_and_refine_multitaxa {
                     sample_name          = sample_id,
                     sample_original_name = sample_original_name
             }
-            call reports.coverage_report as coverage_self {
-                input:
-                    mapped_bams = [refine.align_to_self_merged_aligned_only_bam],
-                    mapped_bam_idx = [],
-                    out_report_name = "~{sample_id}.coverage_report.txt"
-            }
-            call utils.tsv_drop_cols as coverage_two_col {
-                input:
-                    in_tsv = coverage_self.coverage_report,
-                    drop_cols = ["aln2self_cov_median", "aln2self_cov_mean_non0", "aln2self_cov_1X", "aln2self_cov_5X", "aln2self_cov_20X", "aln2self_cov_100X"]
-            }
         }
 
         # get taxid and taxname from taxid_to_ref_accessions_tsv
@@ -185,7 +174,6 @@ workflow scaffold_and_refine_multitaxa {
         File   assembly_stats_by_taxon_tsv                 = select_first([assembly_stats_non_empty.combined, assembly_stats_empty.combined])
         String assembly_method                             = "viral-ngs/scaffold_and_refine_multitaxa"
 
-        #String assembly_top_taxon_id               = select_references.top_matches_per_cluster_basenames[0]
         Int    skani_num_ref_clusters              = length(select_references.matched_reference_clusters_fastas_tars)
         File   skani_contigs_to_refs_dist_tsv      = select_references.skani_dist_full_tsv
 

--- a/pipes/WDL/workflows/scaffold_and_refine_multitaxa.wdl
+++ b/pipes/WDL/workflows/scaffold_and_refine_multitaxa.wdl
@@ -51,7 +51,7 @@ workflow scaffold_and_refine_multitaxa {
     }
 
     # assemble and produce stats for every reference cluster
-    Array[String] assembly_header = ["entity:assembly_id", "assembly_name", "sample_id", "sample_name", "taxid", "tax_name", "tax_shortname", "assembly_fasta", "aligned_only_reads_bam", "coverage_plot", "assembly_length", "assembly_length_unambiguous", "reads_aligned", "mean_coverage", "percent_reference_covered", "scaffolding_num_segments_recovered", "reference_num_segments_required", "reference_length", "reference_accessions", "skani_num_ref_clusters", "skani_this_cluster_num_refs", "skani_dist_tsv", "scaffolding_ani", "scaffolding_pct_ref_cov", "intermediate_gapfill_fasta", "assembly_preimpute_length_unambiguous", "replicate_concordant_sites", "replicate_discordant_snps", "replicate_discordant_indels", "replicate_discordant_vcf", "isnvsFile", "aligned_bam", "coverage_tsv", "read_pairs_aligned", "bases_aligned", "coverage_genbank", "assembly_method", "assembly_method_version", "biosample_accession", "sample"]
+    Array[String] assembly_header = ["entity:assembly_id", "assembly_name", "sample_id", "sample_name", "taxid", "tax_name", "tax_shortname", "assembly_fasta", "aligned_only_reads_bam", "coverage_plot", "assembly_length", "assembly_length_unambiguous", "reads_aligned", "mean_coverage", "percent_reference_covered", "scaffolding_num_segments_recovered", "reference_num_segments_required", "reference_length", "reference_accessions", "skani_num_ref_clusters", "skani_this_cluster_num_refs", "skani_dist_tsv", "scaffolding_ani", "scaffolding_pct_ref_cov", "intermediate_gapfill_fasta", "assembly_preimpute_length_unambiguous", "replicate_concordant_sites", "replicate_discordant_snps", "replicate_discordant_indels", "replicate_discordant_vcf", "isnvsFile", "aligned_bam", "coverage_tsv", "read_pairs_aligned", "bases_aligned", "assembly_method", "assembly_method_version", "biosample_accession", "sample"]
     scatter(ref_cluster_tar in select_references.matched_reference_clusters_fastas_tars) {
 
         call utils.tar_extract {
@@ -148,7 +148,6 @@ workflow scaffold_and_refine_multitaxa {
             "coverage_tsv" :       select_first([refine.align_to_self_merged_coverage_tsv, ""]),
             "read_pairs_aligned" : select_first([refine.align_to_self_merged_read_pairs_aligned, "0"]),
             "bases_aligned" :      select_first([refine.align_to_self_merged_bases_aligned, "0"]),
-            "coverage_genbank" :   select_first([coverage_two_col.out_tsv, ""]),
 
             "assembly_method" :         "viral-ngs/assemble_denovo",
             "assembly_method_version" : scaffold.viralngs_version,

--- a/pipes/WDL/workflows/scaffold_and_refine_multitaxa.wdl
+++ b/pipes/WDL/workflows/scaffold_and_refine_multitaxa.wdl
@@ -2,7 +2,6 @@ version 1.0
 
 import "../tasks/tasks_assembly.wdl" as assembly
 import "../tasks/tasks_ncbi.wdl" as ncbi
-import "../tasks/tasks_reports.wdl" as reports
 import "../tasks/tasks_utils.wdl" as utils
 import "assemble_refbased.wdl" as assemble_refbased
 

--- a/pipes/WDL/workflows/scaffold_and_refine_multitaxa.wdl
+++ b/pipes/WDL/workflows/scaffold_and_refine_multitaxa.wdl
@@ -39,7 +39,7 @@ workflow scaffold_and_refine_multitaxa {
         call ncbi.download_annotations {
             input:
                 accessions = string_split.tokens,
-                combined_out_prefix = taxon[3]
+                combined_out_prefix = sub(taxon[3], ":", "-")  # singularity does not like colons in filenames
         }
     }
 

--- a/pipes/WDL/workflows/scaffold_and_refine_multitaxa.wdl
+++ b/pipes/WDL/workflows/scaffold_and_refine_multitaxa.wdl
@@ -81,7 +81,8 @@ workflow scaffold_and_refine_multitaxa {
             call reports.coverage_report as coverage_self {
                 input:
                     mapped_bams = [refine.align_to_self_merged_aligned_only_bam],
-                    mapped_bam_idx = []
+                    mapped_bam_idx = [],
+                    out_report_name = "~{sample_id}.coverage_report.txt"
             }
             call utils.tsv_drop_cols as coverage_two_col {
                 input:

--- a/pipes/WDL/workflows/scaffold_and_refine_multitaxa.wdl
+++ b/pipes/WDL/workflows/scaffold_and_refine_multitaxa.wdl
@@ -95,7 +95,7 @@ workflow scaffold_and_refine_multitaxa {
             input:
                 tsv = taxid_to_ref_accessions_tsv,
                 idx_col = "accessions",
-                idx_val = scaffold.scaffolding_chosen_ref_basename,
+                idx_val = sub(scaffold.scaffolding_chosen_ref_basename, "-", ":"),
                 add_header = ["taxid", "isolate_prefix", "taxname", "accessions"]
         }
         String taxid = tax_lookup.map["taxid"]

--- a/requirements-modules.txt
+++ b/requirements-modules.txt
@@ -1,5 +1,5 @@
 broadinstitute/viral-core=2.4.1
-broadinstitute/viral-assemble=2.3.6.1
+broadinstitute/viral-assemble=2.4.1.0
 broadinstitute/viral-classify=2.2.5
 broadinstitute/viral-phylo=2.4.1.0
 broadinstitute/py3-bio=0.1.2

--- a/test/input/WDL/test_inputs-genbank_single-local.json
+++ b/test/input/WDL/test_inputs-genbank_single-local.json
@@ -9,7 +9,7 @@
   "genbank_single.structured_comments_from_aligned_bam.assembly_method": "placeholder assembly software",
   "genbank_single.structured_comments_from_aligned_bam.assembly_method_version": "5.4.3.2.1",
   "genbank_single.table2asn.comment": "this is only a test -- DO NOT SUBMIT to NCBI",
-  "genbank_single.table2asn.authors_sbt": "test/input/genbank/authors-nga_lasv.sbt",
+  "genbank_single.authors_sbt": "test/input/genbank/authors-nga_lasv.sbt",
   "genbank_single.genbank_special_taxa.taxdump_tgz": "test/input/taxdump-20231214.tar.gz",
   "genbank_single.genbank_special_taxa.vadr_by_taxid_tsv": "test/input/vadr-by-taxid.tsv",
   "genbank_single.email_address": "viral-ngs@broadinstitute.org"


### PR DESCRIPTION
Updates:
- Add new workflow 'genbank_gather' that collects a set of `genbank_single` outputs and bundles them into various submission bundles/packages based on submission category.
- In `genbank_single`, update more output filenames to be consistently named so we can more easily group them together.
- All assembly processes (anything involving `assemble_refbased` or `refine_assembly_with_aligned_reads`) will now trim the edges of ambiguous bases according to a "3rules" criteria used in NCBI's VADR script "fasta-trim-terminal-ambigs.pl". This is to satisfy submission requirements enforced by table2asn which fail sequences with too much ambiguous content at the edges.
- When downloading reference genomes in `scaffold_and_refine_multitaxa`, save them in files that use dashes instead of colons as delimiters in the filenames, as the colons are incompatible with Singularity.
- Update task `utils.rename_file` to be more portable (was not working with miniwdl's implementation)
- Bugfix: in task `align_and_count`, bugfix for empty input bams.
- In task `FastqToUBAM`, add knobs for ram and disk size and increase defaults.