### PR TITLE
demux and nextclade updates

### DIFF
--- a/pipes/WDL/tasks/tasks_nextstrain.wdl
+++ b/pipes/WDL/tasks/tasks_nextstrain.wdl
@@ -44,7 +44,7 @@ task taxid_to_nextclade_dataset_name {
         maxRetries: 2
     }
     output {
-        String nextclade_dataset_name = read_string("DATASET_NAME")
+        String nextclade_dataset_name = read_string("nextclade_dataset_name.str")
     }    
 }
 

--- a/pipes/WDL/tasks/tasks_nextstrain.wdl
+++ b/pipes/WDL/tasks/tasks_nextstrain.wdl
@@ -14,6 +14,8 @@ task taxid_to_nextclade_dataset_name {
         mkdir -p taxdump
         read_utils.py extract_tarball "~{taxdump_tgz}" taxdump
 
+        touch nextclade_dataset_name.str
+
         python3 << CODE
         import csv
         import metagenomics

--- a/pipes/WDL/tasks/tasks_nextstrain.wdl
+++ b/pipes/WDL/tasks/tasks_nextstrain.wdl
@@ -2,37 +2,44 @@ version 1.0
 
 task taxid_to_nextclade_dataset_name {
     input {
-        String taxid
+        Int     taxid
+        File    taxdump_tgz
+        File    nextclade_by_taxid_tsv # "gs://pathogen-public-dbs/viral-references/typing/nextclade-by-taxid.tsv"
+        String  docker = "quay.io/broadinstitute/viral-classify:2.2.5"
     }
     command <<<
-        python3 <<CODE
-        taxid = int("~{taxid}")
-        taxid_to_dataset_map = {
-            2697049 : 'sars-cov-2',
-            641809  : 'flu_h1n1pdm_ha',
-            335341  : 'flu_h3n2_ha',
-            119210  : 'flu_h3n2_ha',
-            518987  : 'flu_vic_ha',
-            208893  : 'rsv_a',
-            208895  : 'rsv_b',
-            11234   : 'nextstrain/measles/N450/WHO-2012',
-            11053   : 'nextstrain/dengue/all',
-            11060   : 'nextstrain/dengue/all',
-            11069   : 'nextstrain/dengue/all',
-            11070   : 'nextstrain/dengue/all',
-            10244   : 'MPXV',
-            619591  : 'hMPXV'
-        }
-        with open('DATASET_NAME', 'wt') as outf:
-            outf.write(taxid_to_dataset_map.get(taxid, '') + '\n')
+        set -e
+
+        # extract taxdump
+        mkdir -p taxdump
+        read_utils.py extract_tarball "~{taxdump_tgz}" taxdump
+
+        python3 << CODE
+        import csv
+        import metagenomics
+        taxid = ~{taxid}
+
+        # load taxdb and retrieve full hierarchy leading to this taxid
+        taxdb = metagenomics.TaxonomyDb(tax_dir="taxdump", load_nodes=True, load_names=True, load_gis=False)
+        ancestors = taxdb.get_ordered_ancestors(taxid)
+        this_and_ancestors = [taxid] + ancestors
+
+        # read in lookup table
+        with open("~{nextclade_by_taxid_tsv}", 'rt') as inf:
+            for row in csv.DictReader(inf, delimiter='\t'):
+              if any(node == int(row['tax_id']) for node in this_and_ancestors):
+                # found a match
+                with open("nextclade_dataset_name.str", 'wt') as outf:
+                    outf.write(row['nextclade_dataset'])
+                break
         CODE
     >>>
     runtime {
-        docker: "python:slim"
-        memory: "1 GB"
+        docker: docker
+        memory: "2 GB"
         cpu:   1
-        disks: "local-disk 50 HDD"
-        disk:  "50 GB" # TES
+        disks: "local-disk 100 HDD"
+        disk:  "100 GB" # TES
         dx_instance_type: "mem1_ssd1_v2_x2"
         maxRetries: 2
     }
@@ -96,7 +103,8 @@ task nextclade_one_sample {
             ('short-clade', 'NEXTCLADE_SHORTCLADE'),
             ('subclade', 'NEXTCLADE_SUBCLADE'),
             ('aaSubstitutions', 'NEXTCLADE_AASUBS'),
-            ('aaDeletions', 'NEXTCLADE_AADELS')]
+            ('aaDeletions', 'NEXTCLADE_AADELS'),
+            ('Nextclade_pango', 'NEXTCLADE_PANGO')]
         out = {}
         with codecs.open('~{basename}.nextclade.tsv', 'r', encoding='utf-8') as inf:
             for line in csv.DictReader(inf, delimiter='\t'):
@@ -125,6 +133,7 @@ task nextclade_one_sample {
         String nextclade_clade   = read_string("NEXTCLADE_CLADE")
         String nextclade_shortclade = read_string("NEXTCLADE_SHORTCLADE")
         String nextclade_subclade = read_string("NEXTCLADE_SUBCLADE")
+        String nextclade_pango   = read_string("NEXTCLADE_PANGO")
         String aa_subs_csv       = read_string("NEXTCLADE_AASUBS")
         String aa_dels_csv       = read_string("NEXTCLADE_AADELS")
     }

--- a/pipes/WDL/workflows/demux_metadata_only.wdl
+++ b/pipes/WDL/workflows/demux_metadata_only.wdl
@@ -56,57 +56,61 @@ workflow demux_metadata_only {
         }
     }
 
-    #### merge biosample attribute tsvs (iff provided with more than one)
-    if (length(biosample_map_tsvs) > 1) {
-        call utils.tsv_join as biosample_map_tsv_join {
-            input:
-                input_tsvs   = biosample_map_tsvs,
-                id_col       = 'accession',
-                out_suffix   = ".tsv",
-                out_basename = "biosample-attributes-merged"
+    if(length(biosample_map_tsvs) > 0) {
+        # NCBI biosample metadata is available
+
+        #### merge biosample attribute tsvs (iff provided with more than one)
+        if (length(biosample_map_tsvs) > 1) {
+            call utils.tsv_join as biosample_map_tsv_join {
+                input:
+                    input_tsvs   = biosample_map_tsvs,
+                    id_col       = 'accession',
+                    out_suffix   = ".tsv",
+                    out_basename = "biosample-attributes-merged"
+            }
         }
-    }
-    File biosample_map_tsv = select_first(flatten([[biosample_map_tsv_join.out_tsv], biosample_map_tsvs]))
+        File biosample_map_tsv = select_first(flatten([[biosample_map_tsv_join.out_tsv], biosample_map_tsvs]))
 
-    #### biosample metadata mapping
-    call ncbi.biosample_to_table {
-        input:
-            biosample_attributes_tsv = biosample_map_tsv,
-            raw_bam_filepaths        = raw_reads_unaligned_bams,
-            demux_meta_json          = meta_by_filename_json
-    }
-
-    #### SRA submission prep
-    call ncbi.sra_meta_prep {
-        input:
-            cleaned_bam_filepaths = cleaned_reads_unaligned_bams,
-            biosample_map         = biosample_map_tsv,
-            library_metadata      = samplesheet_rename_ids.new_sheet,
-            platform              = "ILLUMINA",
-            paired                = (run_info['indexes'] == '2'),
-
-            out_name              = "sra_metadata-~{run_info['run_id']}.tsv",
-            instrument_model      = select_first(flatten([[instrument_model_user_specified],[run_info['sequencer_model']]])),
-            title                 = sra_title
-    }
-
-    if(insert_demux_outputs_into_terra_tables && select_first([check_terra_env.is_running_on_terra])) {
-        call terra.upload_entities_tsv as terra_load_biosample_data {
+        #### biosample metadata mapping
+        call ncbi.biosample_to_table {
             input:
-                workspace_name   = select_first([check_terra_env.workspace_name]),
-                terra_project    = select_first([check_terra_env.workspace_namespace]),
-                tsv_file         = biosample_to_table.sample_meta_tsv
+                biosample_attributes_tsv = biosample_map_tsv,
+                raw_bam_filepaths        = raw_reads_unaligned_bams,
+                demux_meta_json          = meta_by_filename_json
+        }
+
+        #### SRA submission prep
+        call ncbi.sra_meta_prep {
+            input:
+                cleaned_bam_filepaths = cleaned_reads_unaligned_bams,
+                biosample_map         = biosample_map_tsv,
+                library_metadata      = samplesheet_rename_ids.new_sheet,
+                platform              = "ILLUMINA",
+                paired                = (run_info['indexes'] == '2'),
+
+                out_name              = "sra_metadata-~{run_info['run_id']}.tsv",
+                instrument_model      = select_first(flatten([[instrument_model_user_specified],[run_info['sequencer_model']]])),
+                title                 = sra_title
+        }
+
+        if(insert_demux_outputs_into_terra_tables && select_first([check_terra_env.is_running_on_terra])) {
+            call terra.upload_entities_tsv as terra_load_biosample_data {
+                input:
+                    workspace_name   = select_first([check_terra_env.workspace_name]),
+                    terra_project    = select_first([check_terra_env.workspace_namespace]),
+                    tsv_file         = biosample_to_table.sample_meta_tsv
+            }
         }
     }
 
 
     output {
-        File        sra_metadata                             = sra_meta_prep.sra_metadata
+        File?       sra_metadata                             = sra_meta_prep.sra_metadata
         
         String      instrument_model_inferred                = select_first(flatten([[instrument_model_user_specified],[run_info['sequencer_model']]]))
 
         File?       terra_library_table                      = create_or_update_sample_tables.library_metadata_tsv
         File?       terra_sample_library_map                 = create_or_update_sample_tables.sample_membership_tsv
-        File        terra_sample_metadata                    = biosample_to_table.sample_meta_tsv
+        File?       terra_sample_metadata                    = biosample_to_table.sample_meta_tsv
     }
 }

--- a/pipes/WDL/workflows/nextclade_single.wdl
+++ b/pipes/WDL/workflows/nextclade_single.wdl
@@ -9,20 +9,27 @@ workflow nextclade_single {
 
     call nextstrain.taxid_to_nextclade_dataset_name
 
-    call nextstrain.nextclade_one_sample {
-        input:
-            dataset_name = taxid_to_nextclade_dataset_name.nextclade_dataset_name
+    if (defined(taxid_to_nextclade_dataset_name.nextclade_dataset_name) 
+        && taxid_to_nextclade_dataset_name.nextclade_dataset_name != "") {
+
+        String dataset = taxid_to_nextclade_dataset_name.nextclade_dataset_name
+
+        call nextstrain.nextclade_one_sample {
+            input:
+                dataset_name = dataset
+        }
     }
 
     output {
-        String nextclade_clade    = nextclade_one_sample.nextclade_clade
-        File   nextclade_tsv      = nextclade_one_sample.nextclade_tsv
-        File   nextclade_json     = nextclade_one_sample.nextclade_json
-        String nextclade_aa_subs  = nextclade_one_sample.aa_subs_csv
-        String nextclade_aa_dels  = nextclade_one_sample.aa_dels_csv
-        String nextclade_shortclade = nextclade_one_sample.nextclade_shortclade
-        String nextclade_subclade = nextclade_one_sample.nextclade_subclade
-        String nextclade_pango    = nextclade_one_sample.nextclade_pango
-        String nextclade_version  = nextclade_one_sample.nextclade_version
+        String? nextclade_dataset  = dataset
+        String? nextclade_clade    = nextclade_one_sample.nextclade_clade
+        File?   nextclade_tsv      = nextclade_one_sample.nextclade_tsv
+        File?   nextclade_json     = nextclade_one_sample.nextclade_json
+        String? nextclade_aa_subs  = nextclade_one_sample.aa_subs_csv
+        String? nextclade_aa_dels  = nextclade_one_sample.aa_dels_csv
+        String? nextclade_shortclade = nextclade_one_sample.nextclade_shortclade
+        String? nextclade_subclade = nextclade_one_sample.nextclade_subclade
+        String? nextclade_pango    = nextclade_one_sample.nextclade_pango
+        String? nextclade_version  = nextclade_one_sample.nextclade_version
     }
 }

--- a/pipes/WDL/workflows/nextclade_single.wdl
+++ b/pipes/WDL/workflows/nextclade_single.wdl
@@ -7,7 +7,12 @@ workflow nextclade_single {
         description: "Run Nextclade on a single genome"
     }
 
-    call nextstrain.nextclade_one_sample
+    call nextstrain.taxid_to_nextclade_dataset_name
+
+    call nextstrain.nextclade_one_sample {
+        input:
+            dataset_name = taxid_to_nextclade_dataset_name.nextclade_dataset_name
+    }
 
     output {
         String nextclade_clade    = nextclade_one_sample.nextclade_clade
@@ -17,6 +22,7 @@ workflow nextclade_single {
         String nextclade_aa_dels  = nextclade_one_sample.aa_dels_csv
         String nextclade_shortclade = nextclade_one_sample.nextclade_shortclade
         String nextclade_subclade = nextclade_one_sample.nextclade_subclade
+        String nextclade_pango    = nextclade_one_sample.nextclade_pango
         String nextclade_version  = nextclade_one_sample.nextclade_version
     }
 }


### PR DESCRIPTION
A few simple updates:
1. `demux_deplete` now accepts a boolean input (default false) called `revcomp_i5_indexes` which will automatically reverse complement the i5 index sequences if the provided samplesheet is in the wrong orientation.
2. `demux_metadata_only` now functions properly if no biosample metadata is provided (input is set to empty array)
3. `nextclade_single` workflow now incorporates the `taxid_to_nextclade` task to automatically select the dataset based on numeric taxid. The task now also reads the mapping from an input tsv table instead of hard coded values in the code.