### PR TITLE
Exposed --root-sequence parameter of augur ancestral

### DIFF
--- a/pipes/WDL/tasks/tasks_nextstrain.wdl
+++ b/pipes/WDL/tasks/tasks_nextstrain.wdl
@@ -1526,6 +1526,7 @@ task ancestral_tree {
         Boolean  infer_ambiguous = false
         Boolean  keep_overhangs = false
         File?    vcf_reference
+        File?    root_sequence
         File?    output_vcf
 
         String   docker = "docker.io/nextstrain/base:build-20240318T173028Z"
@@ -1546,6 +1547,7 @@ task ancestral_tree {
             --alignment "~{msa_or_vcf}" \
             --output-node-data "~{out_basename}_nt_muts.json" \
             ~{"--vcf-reference " + vcf_reference} \
+            ~{"--root-sequence " + root_sequence} \
             ~{"--output-vcf " + output_vcf} \
             --output-sequences "~{out_basename}_ancestral_sequences.fasta" \
             ~{true="--keep-overhangs" false="" keep_overhangs} \


### PR DESCRIPTION
Exposed --root-sequence optional parameter of augur ancestral. This allows the user to specify a reference sequence to be used as "root", with mutations from the reference to the inferred root described upstream of the inferred root in the resulting tree json file. This is needed for Nextclade datasets, where the root must be identical to the reference. See notes below:

On Nextclade datasets:
The tree must be rooted at the sample that matches the [reference sequence](https://docs.nextstrain.org/projects/nextclade/en/latest/user/terminology.html#reference-sequence). A workaround in case one does not want to root the tree to be rooted on the reference is to attach the mutational differences between the tree root and the reference on the branch leading to the root node. This can be accomplished by passing the reference sequence to augur ancestral’s --root-sequence argument (see the [augur ancestral docs](https://docs.nextstrain.org/projects/augur/en/stable/usage/cli/ancestral.html#inputs)).

On augur ancestral:
--root-sequence
[FASTA alignment only] file of the sequence that is used as root for mutation calling. Differences between this sequence and the inferred root will be reported as mutations on the root branch.