### PR TITLE
Optimizations for Genbank submission of coinfections

### DIFF
--- a/pipes/WDL/tasks/tasks_ncbi.wdl
+++ b/pipes/WDL/tasks/tasks_ncbi.wdl
@@ -745,6 +745,7 @@ task biosample_to_genbank {
     String? filter_to_accession
     Map[String,String] src_to_attr_map = {}
     String?  organism_name_override
+    String?  sequence_id_override
     String?  isolate_prefix_override
     File?    source_overrides_json # optional set of key-value pairs to override source metadata
 
@@ -930,6 +931,10 @@ task biosample_to_genbank {
 
             # load the purpose of sequencing (or if not, the purpose of sampling) in the note field
             outrow['note'] = row.get('purpose_of_sequencing', row.get('purpose_of_sampling', ''))
+
+            # overwrite sequence ID if requested
+            if "~{default='' sequence_id_override}":
+                outrow['Sequence_ID'] = "~{default='' sequence_id_override}"
 
             # sanitize sequence IDs to match fasta headers
             if "~{sanitize_seq_ids}".lower() == 'true':

--- a/pipes/WDL/workflows/assemble_denovo_metagenomic.wdl
+++ b/pipes/WDL/workflows/assemble_denovo_metagenomic.wdl
@@ -190,16 +190,6 @@ workflow assemble_denovo_metagenomic {
                 min_unambig = 0,
                 allow_incomplete_output = true
         }
-        if (scaffold.assembly_preimpute_length_unambiguous > min_scaffold_unambig) {
-            # polish de novo assembly with reads
-            call assemble_refbased.assemble_refbased as refine {
-                input:
-                    reads_unmapped_bams  = [deplete.bam_filtered_to_taxa],
-                    reference_fasta      = scaffold.scaffold_fasta,
-                    sample_name          = sample_id,
-                    sample_original_name = sample_original_name
-            }
-        }
 
         # get taxid and taxname from taxid_to_ref_accessions_tsv
         call utils.fetch_row_from_tsv as tax_lookup {
@@ -212,6 +202,16 @@ workflow assemble_denovo_metagenomic {
         String taxid = tax_lookup.map["taxid"]
         String tax_name = tax_lookup.map["taxname"]
         String isolate_prefix = tax_lookup.map["isolate_prefix"]
+
+        # polish de novo assembly with reads
+        if (scaffold.assembly_preimpute_length_unambiguous > min_scaffold_unambig) {
+            call assemble_refbased.assemble_refbased as refine {
+                input:
+                    reads_unmapped_bams  = [deplete.bam_filtered_to_taxa],
+                    reference_fasta      = scaffold.scaffold_fasta,
+                    sample_name          = sample_id + "-" + taxid
+            }
+        }
 
         # build output tsv row
         Int    assembly_length_unambiguous = select_first([refine.assembly_length_unambiguous, 0])

--- a/pipes/WDL/workflows/genbank_single.wdl
+++ b/pipes/WDL/workflows/genbank_single.wdl
@@ -104,6 +104,7 @@ workflow genbank_single {
             num_segments           = length(string_split.tokens),
             taxid                  = tax_id,
             organism_name_override = organism_name,
+            sequence_id_override   = assembly_id,
             filter_to_accession    = biosample_accession,
             out_basename           = assembly_id,
             source_overrides_json  = genbank_special_taxa.genbank_source_overrides_json


### PR DESCRIPTION
Update `assemble_denovo_metagenomic` and `scaffold_and_refine_multitaxa` to name their assemblies (in their fasta headers specifically) using a full length assembly ID that ends with the NCBI taxonomy ID. This is intended to prevent ID collisions when submitting multiple genomes (coinfections) from the same sample to Genbank (which only matters for the bankit/sqn submission path, because flu/dengue/noro/sc2 are isolated submission paths). This also entails an update to the task `biosample_to_genbank` to allow overriding the Sequence ID that gets used for writing the Genbank source table instead of taking it verbatim from the BioSample attributes table (which corresponds to samples, not assemblies, and is taxid agnostic).
