### PR TITLE
fix check_terra_env

### DIFF
--- a/pipes/WDL/tasks/tasks_terra.wdl
+++ b/pipes/WDL/tasks/tasks_terra.wdl
@@ -33,7 +33,7 @@ task gcs_copy {
 
 task check_terra_env {
   input {
-    String docker = "quay.io/broadinstitute/viral-baseimage:0.2.4"
+    String docker = "quay.io/broadinstitute/viral-core:2.4.1"
   }
   meta {
     description: "task for inspection of backend to determine whether the task is running on Terra and/or GCP"


### PR DESCRIPTION
`check_terra_env` requires `jq` which is not in `viral-baseimage`, so revert to `viral-core`