### PR TITLE
`scaffold_and_refine_multitaxa` usability improvements: try obtaining e-mail address via Terra env introspection; allow `taxid_to_ref_accessions_tsv` to originate from an http[s] URL

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -109,6 +109,9 @@ workflows:
   - name: diff_genome_sets
     subclass: WDL
     primaryDescriptorPath: /pipes/WDL/workflows/diff_genome_sets.wdl
+  - name: download_file
+    subclass: WDL
+    primaryDescriptorPath: /pipes/WDL/workflows/download_file.wdl
   - name: downsample
     subclass: WDL
     primaryDescriptorPath: /pipes/WDL/workflows/downsample.wdl

--- a/pipes/WDL/tasks/tasks_assembly.wdl
+++ b/pipes/WDL/tasks/tasks_assembly.wdl
@@ -583,7 +583,7 @@ task align_reads {
     Boolean  skip_mark_dupes = false
 
     Int?     machine_mem_gb
-    String   docker = "quay.io/broadinstitute/viral-core:2.4.1"
+    String   docker = "quay.io/broadinstitute/viral-core:2.4.2"
 
     String   sample_name = basename(basename(basename(reads_unmapped_bam, ".bam"), ".taxfilt"), ".clean")
   }
@@ -849,7 +849,7 @@ task run_discordance {
       String out_basename = "run"
       Int    min_coverage = 4
 
-      String docker = "quay.io/broadinstitute/viral-core:2.4.1"
+      String docker = "quay.io/broadinstitute/viral-core:2.4.2"
     }
     parameter_meta {
       reads_aligned_bam: {

--- a/pipes/WDL/tasks/tasks_demux.wdl
+++ b/pipes/WDL/tasks/tasks_demux.wdl
@@ -6,7 +6,7 @@ task merge_tarballs {
     String       out_filename
 
     Int?         machine_mem_gb
-    String       docker = "quay.io/broadinstitute/viral-core:2.4.1"
+    String       docker = "quay.io/broadinstitute/viral-core:2.4.2"
   }
 
   Int disk_size = 2625
@@ -163,7 +163,7 @@ task illumina_demux {
 
     Int?    machine_mem_gb
     Int     disk_size = 2625
-    String  docker = "quay.io/broadinstitute/viral-core:2.4.1"
+    String  docker = "quay.io/broadinstitute/viral-core:2.4.2"
   }
 
   parameter_meta {

--- a/pipes/WDL/tasks/tasks_interhost.wdl
+++ b/pipes/WDL/tasks/tasks_interhost.wdl
@@ -351,7 +351,7 @@ task index_ref {
     File?  novocraft_license
 
     Int?   machine_mem_gb
-    String docker = "quay.io/broadinstitute/viral-core:2.4.1"
+    String docker = "quay.io/broadinstitute/viral-core:2.4.2"
   }
 
   Int disk_size = 100

--- a/pipes/WDL/tasks/tasks_ncbi.wdl
+++ b/pipes/WDL/tasks/tasks_ncbi.wdl
@@ -79,7 +79,7 @@ task sequencing_platform_from_bam {
   input {
     File    bam
 
-    String  docker = "quay.io/broadinstitute/viral-core:2.4.1"
+    String  docker = "quay.io/broadinstitute/viral-core:2.4.2"
   }
 
   command <<<
@@ -188,7 +188,7 @@ task structured_comments {
 
     File?  filter_to_ids
 
-    String docker = "quay.io/broadinstitute/viral-core:2.4.1"
+    String docker = "quay.io/broadinstitute/viral-core:2.4.2"
   }
   String out_base = basename(assembly_stats_tsv, '.txt')
   command <<<
@@ -241,7 +241,7 @@ task structured_comments_from_aligned_bam {
     String  out_basename = basename(aligned_bam, '.bam')
     Boolean is_genome_assembly = true
     Boolean sanitize_ids = true
-    String  docker = "quay.io/broadinstitute/viral-core:2.4.1"
+    String  docker = "quay.io/broadinstitute/viral-core:2.4.2"
   }
   # see https://www.ncbi.nlm.nih.gov/genbank/structuredcomment/
   command <<<
@@ -360,7 +360,7 @@ task rename_fasta_header {
 
     String out_basename = basename(genome_fasta, ".fasta")
 
-    String docker = "quay.io/broadinstitute/viral-core:2.4.1"
+    String docker = "quay.io/broadinstitute/viral-core:2.4.2"
   }
   command {
     set -e
@@ -525,7 +525,7 @@ task sra_meta_prep {
     Boolean     paired
 
     String      out_name = "sra_metadata.tsv"
-    String      docker="quay.io/broadinstitute/viral-core:2.4.1"
+    String      docker="quay.io/broadinstitute/viral-core:2.4.2"
   }
   Int disk_size = 100
   parameter_meta {

--- a/pipes/WDL/tasks/tasks_nextstrain.wdl
+++ b/pipes/WDL/tasks/tasks_nextstrain.wdl
@@ -332,7 +332,7 @@ task derived_cols {
         String?       lab_highlight_loc
         Array[File]   table_map = []
 
-        String        docker = "quay.io/broadinstitute/viral-core:2.4.1"
+        String        docker = "quay.io/broadinstitute/viral-core:2.4.2"
         Int           disk_size = 50
     }
     parameter_meta {
@@ -900,7 +900,7 @@ task filter_sequences_to_list {
 
         String       out_fname = sub(sub(basename(sequences, ".zst"), ".vcf", ".filtered.vcf"), ".fasta$", ".filtered.fasta")
         # Prior docker image: "nextstrain/base:build-20240318T173028Z"
-        String       docker = "quay.io/broadinstitute/viral-core:2.4.1"
+        String       docker = "quay.io/broadinstitute/viral-core:2.4.2"
         Int          disk_size = 750
     }
     parameter_meta {

--- a/pipes/WDL/tasks/tasks_read_utils.wdl
+++ b/pipes/WDL/tasks/tasks_read_utils.wdl
@@ -84,7 +84,7 @@ task group_bams_by_sample {
 task get_bam_samplename {
   input {
     File    bam
-    String  docker = "quay.io/broadinstitute/viral-core:2.4.1"
+    String  docker = "quay.io/broadinstitute/viral-core:2.4.2"
   }
   Int   disk_size = round(size(bam, "GB")) + 50
   command <<<
@@ -111,7 +111,7 @@ task get_sample_meta {
   input {
     Array[File] samplesheets_extended
 
-    String      docker = "quay.io/broadinstitute/viral-core:2.4.1"
+    String      docker = "quay.io/broadinstitute/viral-core:2.4.2"
   }
   Int disk_size = 50
   command <<<
@@ -172,7 +172,7 @@ task merge_and_reheader_bams {
       File?        reheader_table
       String       out_basename = basename(in_bams[0], ".bam")
 
-      String       docker = "quay.io/broadinstitute/viral-core:2.4.1"
+      String       docker = "quay.io/broadinstitute/viral-core:2.4.2"
       Int          disk_size = 750
       Int          machine_mem_gb = 4
     }
@@ -244,7 +244,7 @@ task rmdup_ubam {
     String  method = "mvicuna"
 
     Int     machine_mem_gb = 7
-    String  docker = "quay.io/broadinstitute/viral-core:2.4.1"
+    String  docker = "quay.io/broadinstitute/viral-core:2.4.2"
   }
 
   Int disk_size = 375 + 2 * ceil(size(reads_unmapped_bam, "GB"))
@@ -303,7 +303,7 @@ task downsample_bams {
     Boolean      deduplicateAfter = false
 
     Int?         machine_mem_gb
-    String       docker = "quay.io/broadinstitute/viral-core:2.4.1"
+    String       docker = "quay.io/broadinstitute/viral-core:2.4.2"
   }
 
   Int disk_size = 750
@@ -370,7 +370,7 @@ task FastqToUBAM {
     Int     cpus = 2
     Int     mem_gb = 4
     Int     disk_size = 750
-    String  docker = "quay.io/broadinstitute/viral-core:2.4.1"
+    String  docker = "quay.io/broadinstitute/viral-core:2.4.2"
   }
   parameter_meta {
     fastq_1: { description: "Unaligned read1 file in fastq format", patterns: ["*.fastq", "*.fastq.gz", "*.fq", "*.fq.gz"] }
@@ -424,7 +424,7 @@ task read_depths {
     File      aligned_bam
 
     String    out_basename = basename(aligned_bam, '.bam')
-    String    docker = "quay.io/broadinstitute/viral-core:2.4.1"
+    String    docker = "quay.io/broadinstitute/viral-core:2.4.2"
   }
   Int disk_size = 200
   command <<<

--- a/pipes/WDL/tasks/tasks_reports.wdl
+++ b/pipes/WDL/tasks/tasks_reports.wdl
@@ -15,7 +15,7 @@ task alignment_metrics {
     Int    max_amplicons=500
 
     Int    machine_mem_gb=32
-    String docker = "quay.io/broadinstitute/viral-core:2.4.1"
+    String docker = "quay.io/broadinstitute/viral-core:2.4.2"
   }
 
   String out_basename = basename(aligned_bam, ".bam")
@@ -142,7 +142,7 @@ task plot_coverage {
     String? plotXLimits # of the form "min max" (ints, space between)
     String? plotYLimits # of the form "min max" (ints, space between)
 
-    String  docker = "quay.io/broadinstitute/viral-core:2.4.1"
+    String  docker = "quay.io/broadinstitute/viral-core:2.4.2"
   }
 
   Int disk_size = 375
@@ -289,7 +289,7 @@ task coverage_report {
     Array[File]  mapped_bam_idx = []  # optional.. speeds it up if you provide it, otherwise we auto-index
     String       out_report_name = "coverage_report.txt"
 
-    String       docker = "quay.io/broadinstitute/viral-core:2.4.1"
+    String       docker = "quay.io/broadinstitute/viral-core:2.4.2"
   }
 
   Int disk_size = 375
@@ -364,7 +364,7 @@ task fastqc {
   input {
     File   reads_bam
 
-    String docker = "quay.io/broadinstitute/viral-core:2.4.1"
+    String docker = "quay.io/broadinstitute/viral-core:2.4.2"
   }
   parameter_meta {
     reads_bam:{ 
@@ -412,7 +412,7 @@ task align_and_count {
     Boolean keep_duplicates_when_filtering                    = false
 
     Int?   machine_mem_gb
-    String docker = "quay.io/broadinstitute/viral-core:2.4.1"
+    String docker = "quay.io/broadinstitute/viral-core:2.4.2"
   }
 
   String  reads_basename=basename(reads_bam, ".bam")
@@ -535,7 +535,7 @@ task align_and_count_summary {
 
     String       output_prefix = "count_summary"
 
-    String       docker = "quay.io/broadinstitute/viral-core:2.4.1"
+    String       docker = "quay.io/broadinstitute/viral-core:2.4.2"
   }
 
   Int disk_size = 100

--- a/pipes/WDL/tasks/tasks_taxon_filter.wdl
+++ b/pipes/WDL/tasks/tasks_taxon_filter.wdl
@@ -211,7 +211,7 @@ task merge_one_per_sample {
     Boolean      rmdup = false
 
     Int          machine_mem_gb = 7
-    String       docker = "quay.io/broadinstitute/viral-core:2.4.1"
+    String       docker = "quay.io/broadinstitute/viral-core:2.4.2"
   }
 
   Int disk_size = 750

--- a/pipes/WDL/tasks/tasks_terra.wdl
+++ b/pipes/WDL/tasks/tasks_terra.wdl
@@ -33,7 +33,7 @@ task gcs_copy {
 
 task check_terra_env {
   input {
-    String docker = "quay.io/broadinstitute/viral-baseimage:0.2.4"
+    String docker = "quay.io/broadinstitute/viral-core:2.4.2"
   }
   meta {
     description: "task for inspection of backend to determine whether the task is running on Terra and/or GCP"
@@ -439,7 +439,7 @@ task create_or_update_sample_tables {
     String  sample_table_name  = "sample"
     String  library_table_name = "library"
 
-    String  docker = "quay.io/broadinstitute/viral-core:2.4.1"
+    String  docker = "quay.io/broadinstitute/viral-core:2.4.2"
   }
 
   meta {

--- a/pipes/WDL/tasks/tasks_utils.wdl
+++ b/pipes/WDL/tasks/tasks_utils.wdl
@@ -572,7 +572,7 @@ task download_from_url {
         #   select_first([download_from_url.downloaded_response_file, download_from_url.passthrough_url])
         #File?   downloaded_response_file_debug = read_string("FILE_LOCATION")
         #File?   downloaded_response_file = if (read_boolean("WAS_HTTP_DOWNLOAD")) then read_string("FILE_LOCATION") else nullStrPlaceholder
-        File?   downloaded_response_file = if (read_boolean("WAS_HTTP_DOWNLOAD")) select_first(flatten([glob(download_subdir_local+"/*"),[""]])) else nullStrPlaceholder
+        File?   downloaded_response_file = if (read_boolean("WAS_HTTP_DOWNLOAD")) then select_first(flatten([glob(download_subdir_local+"/*"),[""]])) else nullStrPlaceholder
         String? passthrough_url          = if (read_boolean("WAS_HTTP_DOWNLOAD")) then nullStrPlaceholder else url_to_download
 
         File?   downloaded_response_headers = if ( defined(downloaded_response_file) && save_response_header_to_file ) then basename(read_string("FILE_LOCATION")) + ".headers" else nullStrPlaceholder

--- a/pipes/WDL/tasks/tasks_utils.wdl
+++ b/pipes/WDL/tasks/tasks_utils.wdl
@@ -392,8 +392,8 @@ task download_from_url {
         Int     disk_size = 50
 
         # Do not use these inputs; they are placeholders to output null until WDL supports null literals
-        Int?    _nullIntPlaceholder 
-        String? _nullStrPlaceholder
+        Int?    nullIntPlaceholder 
+        String? nullStrPlaceholder
     }
 
     parameter_meta {
@@ -569,12 +569,12 @@ task download_from_url {
         # other urls (i.e. localizable paths like 'gs://*') will be available via passthrough_url
         # When consuming this task, select the relevant output via:
         #   select_first([download_from_url.downloaded_response_file, download_from_url.passthrough_url])
-        File?   downloaded_response_file = if (read_boolean("WAS_HTTP_DOWNLOAD")) then read_string("FILE_LOCATION") else _nullStrPlaceholder
-        String? passthrough_url          = if (read_boolean("WAS_HTTP_DOWNLOAD")) then _nullStrPlaceholder else url_to_download
+        File?   downloaded_response_file = if (read_boolean("WAS_HTTP_DOWNLOAD")) then read_string("FILE_LOCATION") else nullStrPlaceholder
+        String? passthrough_url          = if (read_boolean("WAS_HTTP_DOWNLOAD")) then nullStrPlaceholder else url_to_download
 
-        File?   downloaded_response_headers = if ( defined(downloaded_response_file) ) then basename(read_string("FILE_LOCATION")) + ".headers" else _nullStrPlaceholder
-        String? md5_sum_of_response_file    = if ( defined(downloaded_response_file) ) then read_string("MD5_SUM_OF_DOWNLOADED_FILE") else _nullStrPlaceholder
-        Int?    file_size_bytes             = if ( defined(downloaded_response_file) ) then floor(size(downloaded_response_file)) else _nullIntPlaceholder 
+        File?   downloaded_response_headers = if ( defined(downloaded_response_file) ) then basename(read_string("FILE_LOCATION")) + ".headers" else nullStrPlaceholder
+        String? md5_sum_of_response_file    = if ( defined(downloaded_response_file) ) then read_string("MD5_SUM_OF_DOWNLOADED_FILE") else nullStrPlaceholder
+        Int?    file_size_bytes             = if ( defined(downloaded_response_file) ) then floor(size(downloaded_response_file)) else nullIntPlaceholder 
         
         Boolean passed_through_input_url_instead_of_downloading = if ( defined(downloaded_response_file) ) then false else true
 

--- a/pipes/WDL/tasks/tasks_utils.wdl
+++ b/pipes/WDL/tasks/tasks_utils.wdl
@@ -394,6 +394,7 @@ task download_from_url {
         # Do not use these inputs; they are placeholders to output null until WDL supports null literals
         Int?    nullIntPlaceholder 
         String? nullStrPlaceholder
+        File?   nullFilePlaceholder
     }
 
     parameter_meta {
@@ -571,7 +572,7 @@ task download_from_url {
         #   select_first([download_from_url.downloaded_response_file, download_from_url.passthrough_url])
         #File?   downloaded_response_file_debug = read_string("FILE_LOCATION")
         #File?   downloaded_response_file = if (read_boolean("WAS_HTTP_DOWNLOAD")) then read_string("FILE_LOCATION") else nullStrPlaceholder
-        File?   downloaded_response_file = select_first(flatten([glob(download_subdir_local+"/*"),[""]])) #read_string("FILE_LOCATION")
+        File?   downloaded_response_file = if (read_boolean("WAS_HTTP_DOWNLOAD")) select_first(flatten([glob(download_subdir_local+"/*"),[""]])) else nullStrPlaceholder
         String? passthrough_url          = if (read_boolean("WAS_HTTP_DOWNLOAD")) then nullStrPlaceholder else url_to_download
 
         File?   downloaded_response_headers = if ( defined(downloaded_response_file) && save_response_header_to_file ) then basename(read_string("FILE_LOCATION")) + ".headers" else nullStrPlaceholder

--- a/pipes/WDL/tasks/tasks_utils.wdl
+++ b/pipes/WDL/tasks/tasks_utils.wdl
@@ -432,7 +432,8 @@ task download_from_url {
         # enforce that only one source of expected md5 hash can be provided
         ~{if defined(md5_hash_expected) && defined(md5_hash_expected_file_url) then 'echo "The inputs \'md5_hash_expected\' and \'md5_hash_expected_file_url\' cannot both be specified; please provide only one."; exit 1;' else ''}
 
-        #touch FILE_LOCATION SIZE_OF_DOWNLOADED_FILE_BYTES MD5_SUM_OF_DOWNLOADED_FILE
+        #touch SIZE_OF_DOWNLOADED_FILE_BYTES MD5_SUM_OF_DOWNLOADED_FILE
+        touch FILE_LOCATION
 
         # if this is an http[s] url, download the file
         # (otherwise just pass through the URL to the 'path_str' output)
@@ -540,7 +541,6 @@ task download_from_url {
 
             # report the file size, in bytes
             printf "Downloaded file size (bytes): " && stat --format=%s  "~{download_subdir_local}/${downloaded_file_name}" | tee SIZE_OF_DOWNLOADED_FILE_BYTES
-            touch FILE_LOCATION
             echo "true" > WAS_HTTP_DOWNLOAD
             downloaded_file_realpath=$(realpath "~{download_subdir_local}/${downloaded_file_name}")
             

--- a/pipes/WDL/tasks/tasks_utils.wdl
+++ b/pipes/WDL/tasks/tasks_utils.wdl
@@ -542,25 +542,12 @@ task download_from_url {
             # report the file size, in bytes
             printf "Downloaded file size (bytes): " && stat --format=%s  "~{download_subdir_local}/${downloaded_file_name}" | tee SIZE_OF_DOWNLOADED_FILE_BYTES
             echo "true" > WAS_HTTP_DOWNLOAD
-            downloaded_file_realpath=$(realpath "~{download_subdir_local}/${downloaded_file_name}")
-            
-            echo '~{download_subdir_local}/${downloaded_file_name}: '"~{download_subdir_local}/${downloaded_file_name}"
-            echo '${downloaded_file_realpath}: '"${downloaded_file_realpath}"
-            
-            #echo "${downloaded_file_realpath}" | tee FILE_LOCATION
             echo "~{download_subdir_local}/${downloaded_file_name}" | tee FILE_LOCATION
-
-            echo "ls -lah $(pwd)"
-            ls -lah
-
-            echo "ls -lah $(pwd)/~{download_subdir_local}"
-            ls -lah ~{download_subdir_local}
         else
             echo "Only URLs beginning with 'http://' or 'https://' can be downloaded; passing through input url to directly to output..."
-            #echo "~{url_to_download}" > FILE_LOCATION
-            echo "" > FILE_LOCATION
-            printf "0" > SIZE_OF_DOWNLOADED_FILE_BYTES
-            printf "" > MD5_SUM_OF_DOWNLOADED_FILE
+            echo ""      > FILE_LOCATION
+            printf "0"   > SIZE_OF_DOWNLOADED_FILE_BYTES
+            printf ""    > MD5_SUM_OF_DOWNLOADED_FILE
             echo "false" > WAS_HTTP_DOWNLOAD
         fi
     >>>

--- a/pipes/WDL/tasks/tasks_utils.wdl
+++ b/pipes/WDL/tasks/tasks_utils.wdl
@@ -586,7 +586,7 @@ task download_from_url {
         File?   downloaded_response_file = if (read_boolean("WAS_HTTP_DOWNLOAD")) then read_string("FILE_LOCATION") else nullStrPlaceholder
         String? passthrough_url          = if (read_boolean("WAS_HTTP_DOWNLOAD")) then nullStrPlaceholder else url_to_download
 
-        File?   downloaded_response_headers = if ( defined(downloaded_response_file) ) then read_string("FILE_LOCATION") + ".headers" else nullStrPlaceholder
+        File?   downloaded_response_headers = if ( defined(downloaded_response_file) ) then basename(read_string("FILE_LOCATION")) + ".headers" else nullStrPlaceholder
         String? md5_sum_of_response_file    = if ( defined(downloaded_response_file) ) then read_string("MD5_SUM_OF_DOWNLOADED_FILE") else nullStrPlaceholder
         Int?    file_size_bytes             = if ( defined(downloaded_response_file) ) then floor(size(downloaded_response_file)) else nullIntPlaceholder 
         

--- a/pipes/WDL/tasks/tasks_utils.wdl
+++ b/pipes/WDL/tasks/tasks_utils.wdl
@@ -584,7 +584,7 @@ task download_from_url {
         #   select_first([download_from_url.downloaded_response_file, download_from_url.passthrough_url])
         #File?   downloaded_response_file_debug = read_string("FILE_LOCATION")
         #File?   downloaded_response_file = if (read_boolean("WAS_HTTP_DOWNLOAD")) then read_string("FILE_LOCATION") else nullStrPlaceholder
-        File?   downloaded_response_file = select_first([glob(download_subdir_local+"/*")[0],""]) #read_string("FILE_LOCATION")
+        File?   downloaded_response_file = select_first(flatten([glob(download_subdir_local+"/*"),[""]])) #read_string("FILE_LOCATION")
         String? passthrough_url          = if (read_boolean("WAS_HTTP_DOWNLOAD")) then nullStrPlaceholder else url_to_download
 
         File?   downloaded_response_headers = if ( defined(downloaded_response_file) && save_response_header_to_file ) then basename(read_string("FILE_LOCATION")) + ".headers" else nullStrPlaceholder

--- a/pipes/WDL/tasks/tasks_utils.wdl
+++ b/pipes/WDL/tasks/tasks_utils.wdl
@@ -521,6 +521,9 @@ task download_from_url {
             echo "ls -lah $(pwd)"
             ls -lah
 
+            echo "ls -lah $(pwd)/~{download_subdir_local}"
+            ls -lah ~{download_subdir_local}
+
             check_md5_sum() {
                 # $1 =  md5sum expected
                 # $2 =  md5sum of downloaded file

--- a/pipes/WDL/tasks/tasks_utils.wdl
+++ b/pipes/WDL/tasks/tasks_utils.wdl
@@ -518,6 +518,9 @@ task download_from_url {
 
             popd # return to job working directory
 
+            echo "ls -lah $(pwd)"
+            ls -lah
+
             check_md5_sum() {
                 # $1 =  md5sum expected
                 # $2 =  md5sum of downloaded file
@@ -542,10 +545,16 @@ task download_from_url {
             printf "Downloaded file size (bytes): " && stat --format=%s  "~{download_subdir_local}/${downloaded_file_name}" | tee SIZE_OF_DOWNLOADED_FILE_BYTES
             touch FILE_LOCATION
             echo "true" > WAS_HTTP_DOWNLOAD
-            echo $(realpath "~{download_subdir_local}/${downloaded_file_name}") > FILE_LOCATION
+            downloaded_file_realpath=$(realpath "~{download_subdir_local}/${downloaded_file_name}")
+            
+            echo '~{download_subdir_local}/${downloaded_file_name}: '"~{download_subdir_local}/${downloaded_file_name}"
+            echo '${downloaded_file_realpath}: '"${downloaded_file_realpath}"
+            
+            echo "${downloaded_file_realpath}" | tee FILE_LOCATION
         else
             echo "Only URLs beginning with 'http://' or 'https://' can be downloaded; passing through input url to directly to output..."
-            echo "~{url_to_download}" > FILE_LOCATION
+            #echo "~{url_to_download}" > FILE_LOCATION
+            echo "" > FILE_LOCATION
             printf "0" > SIZE_OF_DOWNLOADED_FILE_BYTES
             printf "" > MD5_SUM_OF_DOWNLOADED_FILE
             echo "false" > WAS_HTTP_DOWNLOAD
@@ -569,6 +578,7 @@ task download_from_url {
         # other urls (i.e. localizable paths like 'gs://*') will be available via passthrough_url
         # When consuming this task, select the relevant output via:
         #   select_first([download_from_url.downloaded_response_file, download_from_url.passthrough_url])
+        File?   downloaded_response_file_debug = read_string("FILE_LOCATION")
         File?   downloaded_response_file = if (read_boolean("WAS_HTTP_DOWNLOAD")) then read_string("FILE_LOCATION") else nullStrPlaceholder
         String? passthrough_url          = if (read_boolean("WAS_HTTP_DOWNLOAD")) then nullStrPlaceholder else url_to_download
 

--- a/pipes/WDL/tasks/tasks_utils.wdl
+++ b/pipes/WDL/tasks/tasks_utils.wdl
@@ -586,7 +586,7 @@ task download_from_url {
         File?   downloaded_response_file = if (read_boolean("WAS_HTTP_DOWNLOAD")) then read_string("FILE_LOCATION") else nullStrPlaceholder
         String? passthrough_url          = if (read_boolean("WAS_HTTP_DOWNLOAD")) then nullStrPlaceholder else url_to_download
 
-        File?   downloaded_response_headers = if ( defined(downloaded_response_file) ) then basename(read_string("FILE_LOCATION")) + ".headers" else nullStrPlaceholder
+        File?   downloaded_response_headers = if ( defined(downloaded_response_file) ) then read_string("FILE_LOCATION") + ".headers" else nullStrPlaceholder
         String? md5_sum_of_response_file    = if ( defined(downloaded_response_file) ) then read_string("MD5_SUM_OF_DOWNLOADED_FILE") else nullStrPlaceholder
         Int?    file_size_bytes             = if ( defined(downloaded_response_file) ) then floor(size(downloaded_response_file)) else nullIntPlaceholder 
         

--- a/pipes/WDL/tasks/tasks_utils.wdl
+++ b/pipes/WDL/tasks/tasks_utils.wdl
@@ -589,7 +589,7 @@ task download_from_url {
 
         File?   downloaded_response_headers = if ( defined(downloaded_response_file) && save_response_header_to_file ) then basename(read_string("FILE_LOCATION")) + ".headers" else nullStrPlaceholder
         String? md5_sum_of_response_file    = if ( defined(downloaded_response_file) ) then read_string("MD5_SUM_OF_DOWNLOADED_FILE") else nullStrPlaceholder
-        Int?    file_size_bytes             = if ( defined(downloaded_response_file) ) then floor(size(read_string("FILE_LOCATION"))) else nullIntPlaceholder 
+        Int?    file_size_bytes             = if ( defined(downloaded_response_file) ) then floor(size(downloaded_response_file)) else nullIntPlaceholder 
         
         Boolean passed_through_input_url_instead_of_downloading = if ( defined(downloaded_response_file) ) then false else true
 

--- a/pipes/WDL/tasks/tasks_utils.wdl
+++ b/pipes/WDL/tasks/tasks_utils.wdl
@@ -584,7 +584,7 @@ task download_from_url {
         #   select_first([download_from_url.downloaded_response_file, download_from_url.passthrough_url])
         #File?   downloaded_response_file_debug = read_string("FILE_LOCATION")
         #File?   downloaded_response_file = if (read_boolean("WAS_HTTP_DOWNLOAD")) then read_string("FILE_LOCATION") else nullStrPlaceholder
-        File?   downloaded_response_file = read_string("FILE_LOCATION")
+        File?   downloaded_response_file = select_first([glob(download_subdir_local+"/*")[0],""]) #read_string("FILE_LOCATION")
         String? passthrough_url          = if (read_boolean("WAS_HTTP_DOWNLOAD")) then nullStrPlaceholder else url_to_download
 
         File?   downloaded_response_headers = if ( defined(downloaded_response_file) && save_response_header_to_file ) then basename(read_string("FILE_LOCATION")) + ".headers" else nullStrPlaceholder

--- a/pipes/WDL/tasks/tasks_utils.wdl
+++ b/pipes/WDL/tasks/tasks_utils.wdl
@@ -587,7 +587,7 @@ task download_from_url {
         File?   downloaded_response_file = read_string("FILE_LOCATION")
         String? passthrough_url          = if (read_boolean("WAS_HTTP_DOWNLOAD")) then nullStrPlaceholder else url_to_download
 
-        File?   downloaded_response_headers = if ( defined(downloaded_response_file) and save_response_header_to_file ) then basename(read_string("FILE_LOCATION")) + ".headers" else nullStrPlaceholder
+        File?   downloaded_response_headers = if ( defined(downloaded_response_file) && save_response_header_to_file ) then basename(read_string("FILE_LOCATION")) + ".headers" else nullStrPlaceholder
         String? md5_sum_of_response_file    = if ( defined(downloaded_response_file) ) then read_string("MD5_SUM_OF_DOWNLOADED_FILE") else nullStrPlaceholder
         Int?    file_size_bytes             = if ( defined(downloaded_response_file) ) then floor(size(read_string("FILE_LOCATION"))) else nullIntPlaceholder 
         

--- a/pipes/WDL/tasks/tasks_utils.wdl
+++ b/pipes/WDL/tasks/tasks_utils.wdl
@@ -553,7 +553,8 @@ task download_from_url {
             echo '~{download_subdir_local}/${downloaded_file_name}: '"~{download_subdir_local}/${downloaded_file_name}"
             echo '${downloaded_file_realpath}: '"${downloaded_file_realpath}"
             
-            echo "${downloaded_file_realpath}" | tee FILE_LOCATION
+            #echo "${downloaded_file_realpath}" | tee FILE_LOCATION
+            echo "~{download_subdir_local}/${downloaded_file_name}" | tee FILE_LOCATION
         else
             echo "Only URLs beginning with 'http://' or 'https://' can be downloaded; passing through input url to directly to output..."
             #echo "~{url_to_download}" > FILE_LOCATION

--- a/pipes/WDL/tasks/tasks_utils.wdl
+++ b/pipes/WDL/tasks/tasks_utils.wdl
@@ -52,7 +52,7 @@ task unpack_archive_to_bucket_path {
         # execution and resource requirements
         Int    disk_size      = 500
         Int    machine_mem_gb = 128
-        String docker         = "quay.io/broadinstitute/viral-core:2.4.1"
+        String docker         = "quay.io/broadinstitute/viral-core:2.4.2"
     }
 
     parameter_meta {
@@ -293,7 +293,7 @@ task zcat {
         { if [ -f /sys/fs/cgroup/memory.peak ]; then cat /sys/fs/cgroup/memory.peak; elif [ -f /sys/fs/cgroup/memory/memory.peak ]; then cat /sys/fs/cgroup/memory/memory.peak; elif [ -f /sys/fs/cgroup/memory/memory.max_usage_in_bytes ]; then cat /sys/fs/cgroup/memory/memory.max_usage_in_bytes; else echo "0"; fi } > MEM_BYTES
     >>>
     runtime {
-        docker: "quay.io/broadinstitute/viral-core:2.4.1"
+        docker: "quay.io/broadinstitute/viral-core:2.4.2"
         memory: "1 GB"
         cpu:    cpus
         disks:  "local-disk " + disk_size + " LOCAL"
@@ -901,7 +901,7 @@ task tsv_join {
   runtime {
     memory: "~{machine_mem_gb} GB"
     cpu: 4
-    docker: "quay.io/broadinstitute/viral-core:2.4.1"
+    docker: "quay.io/broadinstitute/viral-core:2.4.2"
     disks:  "local-disk " + disk_size + " HDD"
     disk: disk_size + " GB" # TES
     dx_instance_type: "mem1_ssd1_v2_x4"
@@ -988,7 +988,7 @@ task tsv_stack {
   input {
     Array[File]+ input_tsvs
     String       out_basename
-    String       docker = "quay.io/broadinstitute/viral-core:2.4.1"
+    String       docker = "quay.io/broadinstitute/viral-core:2.4.2"
   }
 
   Int disk_size = 50
@@ -1259,7 +1259,7 @@ task filter_sequences_by_length {
         File   sequences_fasta
         Int    min_non_N = 1
 
-        String docker = "quay.io/broadinstitute/viral-core:2.4.1"
+        String docker = "quay.io/broadinstitute/viral-core:2.4.2"
         Int    disk_size = 750
     }
     parameter_meta {

--- a/pipes/WDL/tasks/tasks_utils.wdl
+++ b/pipes/WDL/tasks/tasks_utils.wdl
@@ -390,6 +390,10 @@ task download_from_url {
         Boolean save_response_header_to_file = false
 
         Int     disk_size = 50
+
+        # Do not use these inputs; they are placeholders to output null until WDL supports null literals
+        Int?    _nullIntPlaceholder 
+        String? _nullStrPlaceholder
     }
 
     parameter_meta {
@@ -558,10 +562,6 @@ task download_from_url {
         preemptible: 1
     }
 
-    # placeholders to output null until WDL supports null literals
-    Int?    nullIntPlaceholder 
-    String? nullStrPlaceholder
-
     # output files
     output {
         # one or the other will be returned, depending on the download method
@@ -569,12 +569,12 @@ task download_from_url {
         # other urls (i.e. localizable paths like 'gs://*') will be available via passthrough_url
         # When consuming this task, select the relevant output via:
         #   select_first([download_from_url.downloaded_response_file, download_from_url.passthrough_url])
-        File?   downloaded_response_file = if (read_boolean("WAS_HTTP_DOWNLOAD")) then read_string("FILE_LOCATION") else nullStrPlaceholder
-        String? passthrough_url          = if (read_boolean("WAS_HTTP_DOWNLOAD")) then nullStrPlaceholder else url_to_download
+        File?   downloaded_response_file = if (read_boolean("WAS_HTTP_DOWNLOAD")) then read_string("FILE_LOCATION") else _nullStrPlaceholder
+        String? passthrough_url          = if (read_boolean("WAS_HTTP_DOWNLOAD")) then _nullStrPlaceholder else url_to_download
 
-        File?   downloaded_response_headers = if ( defined(downloaded_response_file) ) then basename(read_string("FILE_LOCATION")) + ".headers" else nullStrPlaceholder
-        String? md5_sum_of_response_file    = if ( defined(downloaded_response_file) ) then read_string("MD5_SUM_OF_DOWNLOADED_FILE") else nullStrPlaceholder
-        Int?    file_size_bytes             = if ( defined(downloaded_response_file) ) then floor(size(downloaded_response_file)) else nullIntPlaceholder 
+        File?   downloaded_response_headers = if ( defined(downloaded_response_file) ) then basename(read_string("FILE_LOCATION")) + ".headers" else _nullStrPlaceholder
+        String? md5_sum_of_response_file    = if ( defined(downloaded_response_file) ) then read_string("MD5_SUM_OF_DOWNLOADED_FILE") else _nullStrPlaceholder
+        Int?    file_size_bytes             = if ( defined(downloaded_response_file) ) then floor(size(downloaded_response_file)) else _nullIntPlaceholder 
         
         Boolean passed_through_input_url_instead_of_downloading = if ( defined(downloaded_response_file) ) then false else true
 

--- a/pipes/WDL/tasks/tasks_utils.wdl
+++ b/pipes/WDL/tasks/tasks_utils.wdl
@@ -518,12 +518,6 @@ task download_from_url {
 
             popd # return to job working directory
 
-            echo "ls -lah $(pwd)"
-            ls -lah
-
-            echo "ls -lah $(pwd)/~{download_subdir_local}"
-            ls -lah ~{download_subdir_local}
-
             check_md5_sum() {
                 # $1 =  md5sum expected
                 # $2 =  md5sum of downloaded file
@@ -555,6 +549,12 @@ task download_from_url {
             
             #echo "${downloaded_file_realpath}" | tee FILE_LOCATION
             echo "~{download_subdir_local}/${downloaded_file_name}" | tee FILE_LOCATION
+
+            echo "ls -lah $(pwd)"
+            ls -lah
+
+            echo "ls -lah $(pwd)/~{download_subdir_local}"
+            ls -lah ~{download_subdir_local}
         else
             echo "Only URLs beginning with 'http://' or 'https://' can be downloaded; passing through input url to directly to output..."
             #echo "~{url_to_download}" > FILE_LOCATION
@@ -582,13 +582,14 @@ task download_from_url {
         # other urls (i.e. localizable paths like 'gs://*') will be available via passthrough_url
         # When consuming this task, select the relevant output via:
         #   select_first([download_from_url.downloaded_response_file, download_from_url.passthrough_url])
-        File?   downloaded_response_file_debug = read_string("FILE_LOCATION")
-        File?   downloaded_response_file = if (read_boolean("WAS_HTTP_DOWNLOAD")) then read_string("FILE_LOCATION") else nullStrPlaceholder
+        #File?   downloaded_response_file_debug = read_string("FILE_LOCATION")
+        #File?   downloaded_response_file = if (read_boolean("WAS_HTTP_DOWNLOAD")) then read_string("FILE_LOCATION") else nullStrPlaceholder
+        File?   downloaded_response_file = read_string("FILE_LOCATION")
         String? passthrough_url          = if (read_boolean("WAS_HTTP_DOWNLOAD")) then nullStrPlaceholder else url_to_download
 
-        File?   downloaded_response_headers = if ( defined(downloaded_response_file) ) then basename(read_string("FILE_LOCATION")) + ".headers" else nullStrPlaceholder
+        File?   downloaded_response_headers = if ( defined(downloaded_response_file) and save_response_header_to_file ) then basename(read_string("FILE_LOCATION")) + ".headers" else nullStrPlaceholder
         String? md5_sum_of_response_file    = if ( defined(downloaded_response_file) ) then read_string("MD5_SUM_OF_DOWNLOADED_FILE") else nullStrPlaceholder
-        Int?    file_size_bytes             = if ( defined(downloaded_response_file) ) then floor(size(downloaded_response_file)) else nullIntPlaceholder 
+        Int?    file_size_bytes             = if ( defined(downloaded_response_file) ) then floor(size(read_string("FILE_LOCATION"))) else nullIntPlaceholder 
         
         Boolean passed_through_input_url_instead_of_downloading = if ( defined(downloaded_response_file) ) then false else true
 

--- a/pipes/WDL/workflows/download_file.wdl
+++ b/pipes/WDL/workflows/download_file.wdl
@@ -1,0 +1,33 @@
+version 1.0
+
+#DX_SKIP_WORKFLOW
+
+import "../tasks/tasks_utils.wdl" as terra
+
+workflow download_file {
+    meta {
+        description: "Downloads an http[s] file. Helpful if this is not natively supported by the WDL execution backend for File inputs."
+        author: "Broad Viral Genomics"
+        email:  "viral-ngs@broadinstitute.org"
+    }
+
+    call terra.download_from_url
+
+    output {
+        File output_file                      = select_first([download_from_url.downloaded_response_file, download_from_url.passthrough_url])
+
+        # one or the other will be returned, depending on the download method
+        # an http[s] url will be downloaded to a file and available via downloaded_response_file
+        # other urls (i.e. localizable paths like 'gs://*', 'drs://') will be available via passthrough_url
+        File?   downloaded_response_file      = download_from_url.downloaded_response_file
+        String? passthrough_url               = download_from_url.passthrough_url
+        
+        # optional fields only returned in the case of a downloaded file
+        File?   downloaded_response_headers   = download_from_url.downloaded_response_headers
+        String? md5_sum_of_response_file      = download_from_url.md5_sum_of_response_file
+        Int?    file_size_bytes               = download_from_url.file_size_bytes
+
+        # boolean flag to indicate if the download task passed through the input url instead of downloading the file
+        Boolean passed_through_input_url_instead_of_downloading  = download_from_url.passed_through_input_url_instead_of_downloading
+    }
+}

--- a/pipes/WDL/workflows/download_file.wdl
+++ b/pipes/WDL/workflows/download_file.wdl
@@ -12,12 +12,12 @@ workflow download_file {
     }
 
     input {
-        String path_utl
+        String path_url
     }
 
     call terra.download_from_url {
         input:
-            url_to_download = path_utl
+            url_to_download = path_url
     }
 
     output {

--- a/pipes/WDL/workflows/download_file.wdl
+++ b/pipes/WDL/workflows/download_file.wdl
@@ -11,10 +11,17 @@ workflow download_file {
         email:  "viral-ngs@broadinstitute.org"
     }
 
-    call terra.download_from_url
+    input {
+        String path_utl
+    }
+
+    call terra.download_from_url {
+        input:
+            url_to_download = path_utl
+    }
 
     output {
-        File output_file                      = select_first([download_from_url.downloaded_response_file, download_from_url.passthrough_url])
+        File    file_path                     = select_first([download_from_url.downloaded_response_file, download_from_url.passthrough_url])
 
         # one or the other will be returned, depending on the download method
         # an http[s] url will be downloaded to a file and available via downloaded_response_file

--- a/pipes/WDL/workflows/scaffold_and_refine_multitaxa.wdl
+++ b/pipes/WDL/workflows/scaffold_and_refine_multitaxa.wdl
@@ -40,7 +40,7 @@ workflow scaffold_and_refine_multitaxa {
 
     call download_file.download_file as dl_taxid_to_ref_tsv {
         input:
-            url = taxid_to_ref_accessions_tsv
+            path_url = taxid_to_ref_accessions_tsv
     }
 
     # download (multi-segment) genomes for each reference, fasta filename = colon-concatenated accession list

--- a/pipes/WDL/workflows/scaffold_and_refine_multitaxa.wdl
+++ b/pipes/WDL/workflows/scaffold_and_refine_multitaxa.wdl
@@ -3,6 +3,7 @@ version 1.0
 import "../tasks/tasks_assembly.wdl" as assembly
 import "../tasks/tasks_ncbi.wdl" as ncbi
 import "../tasks/tasks_utils.wdl" as utils
+import "../tasks/tasks_terra.wdl" as terra
 import "assemble_refbased.wdl" as assemble_refbased
 import "download_file.wdl" as download_file
 
@@ -29,11 +30,12 @@ workflow scaffold_and_refine_multitaxa {
     Int    min_scaffold_unambig = 300 # in base-pairs; any scaffolded assembly < this length will not be refined/polished
     String sample_original_name = select_first([sample_name, sample_id])
 
+    call terra.check_terra_env
+
     # get user email address, with the following precedence:
     # 1. email_address provided via WDL input
     # 2. user_email determined by introspection via check_terra_env task
     # 3. (empty string fallback)
-    call terra.check_terra_env
     String user_email_address = select_first([email_address,check_terra_env.user_email, ""])
 
     call download_file.download_file as dl_taxid_to_ref_tsv {

--- a/pipes/WDL/workflows/scaffold_and_refine_multitaxa.wdl
+++ b/pipes/WDL/workflows/scaffold_and_refine_multitaxa.wdl
@@ -33,7 +33,8 @@ workflow scaffold_and_refine_multitaxa {
     # 1. email_address provided via WDL input
     # 2. user_email determined by introspection via check_terra_env task
     # 3. (empty string fallback)
-    String? user_email_address = select_first([email_address,check_terra_env.user_email, ""])
+    call terra.check_terra_env
+    String user_email_address = select_first([email_address,check_terra_env.user_email, ""])
 
     call download_file.download_file as dl_taxid_to_ref_tsv {
         input:

--- a/requirements-modules.txt
+++ b/requirements-modules.txt
@@ -1,5 +1,5 @@
 broadinstitute/viral-baseimage=0.2.4
-broadinstitute/viral-core=2.4.1
+broadinstitute/viral-core=2.4.2
 broadinstitute/viral-assemble=2.4.1.0
 broadinstitute/viral-classify=2.2.5
 broadinstitute/viral-phylo=2.4.1.0


### PR DESCRIPTION
This makes a couple small usability-related changes to the `scaffold_and_refine_multitaxa` workflow in response to observed friction points:
* the workflow will attempt to obtain the e-mail address of the active user by introspection of the execution environment iff running on Terra, while also allowing for an overriding input. This e-mail address is sent [when making requests](https://www.ncbi.nlm.nih.gov/books/NBK25497/) to download reference genomes from NCBI. The `tasks_ncbi.wdl::download_annotations` task should ideally also be updated at some point to accept an NCBI API key as an alternative to providing an e-mail address.
* the workflow will accept an input URL for `taxid_to_ref_accessions_tsv` that is from an http[s] source; the (newly-added) `download_file` task will allow a path specified using `gs://` *or* `http[s]`, and download the latter or pass-through the former. This was added with public http[s]-accessible databases in mind, such as the reference genome list maintained in the repo [`broadinstitute/viral-references`](https://github.com/broadinstitute/viral-references/blob/main/assembly/reference_genomes.tsv).

Added:
*  `download_from_url` task: only download https[s] URLs, and pass non-http[s] input urls through directly to the output for consumption downstream in tasks that can localize Files addressable via the "non-http protocols" (i.e. gs://, drs://, etc.). The task does this simply by checking the URL prefix/protocol, but we would ideally decide to download or not based on introspection of the execution engine and its localization capabilities or configuration. After calling `download_from_url`, downstream tasks can consume http[s] (or gs:// etc. paths) by selecting which output of `download_from_url` is defined:

```WDL
select_first([download_from_url.downloaded_response_file, download_from_url.passthrough_url])
```

 * a new workflow, `download_file`: calls the `download_from_url` task. This may be useful in isolation, but it primarily allows for the functionality described above to be abstracted into a sub-workflow, with the result accessed via a single output, `download_file.file_path`