### PR TITLE
run_discordance task: first index the ref fasta

### DIFF
--- a/pipes/WDL/tasks/tasks_assembly.wdl
+++ b/pipes/WDL/tasks/tasks_assembly.wdl
@@ -904,6 +904,12 @@ task run_discordance {
 
         if [ ! -f everything.vcf ]; then
           # bcftools call snps while treating each RG as a separate sample
+
+          # first index the ref fasta, iff it contains non-N sequence
+          if [ $(grep -v '^>' "~{reference_fasta}" | tr -d '\nNn' | wc -c) != "0" ]; then
+            samtools faidx "~{reference_fasta}"
+          fi
+
           bcftools mpileup \
             -G readgroups.txt -d 10000 -a "FORMAT/DP,FORMAT/AD" \
             -q 1 -m 2 -Ou \


### PR DESCRIPTION
This attempts to prevent voluminous error output (multiple MB) in the logs containing statements to the effect of "[E::faidx_adjust_position] The sequence "$SEQ_NAME" was not found" in the event a fasta index does not exist for the (large in size?) provided reference genome. Otherwise the error message seems to be emitted once for every single read mapped to the reference.