### PR TITLE
bump viral-assemble to 2.4.2.0

### DIFF
--- a/pipes/WDL/tasks/tasks_assembly.wdl
+++ b/pipes/WDL/tasks/tasks_assembly.wdl
@@ -15,7 +15,7 @@ task assemble {
       String   sample_name = basename(basename(reads_unmapped_bam, ".bam"), ".taxfilt")
       
       Int?     machine_mem_gb
-      String   docker = "quay.io/broadinstitute/viral-assemble:2.4.1.0"
+      String   docker = "quay.io/broadinstitute/viral-assemble:2.4.2.0"
     }
     parameter_meta{
       reads_unmapped_bam: {
@@ -114,8 +114,9 @@ task select_references {
     Int?          skani_m
     Int?          skani_s
     Int?          skani_c
+    Int?          skani_n
 
-    String        docker = "quay.io/broadinstitute/viral-assemble:2.4.1.0"
+    String        docker = "quay.io/broadinstitute/viral-assemble:2.4.2.0"
     Int           machine_mem_gb = 4
     Int           cpu = 2
     Int           disk_size = 100
@@ -135,6 +136,7 @@ task select_references {
       ~{'-m ' + skani_m} \
       ~{'-s ' + skani_s} \
       ~{'-c ' + skani_c} \
+      ~{'-n ' + skani_n} \
       --loglevel=DEBUG
 
     # create basename-only version of ref_clusters output file
@@ -206,7 +208,7 @@ task scaffold {
       Float?       scaffold_min_pct_contig_aligned
 
       Int?         machine_mem_gb
-      String       docker="quay.io/broadinstitute/viral-assemble:2.4.1.0"
+      String       docker="quay.io/broadinstitute/viral-assemble:2.4.2.0"
 
       # do this in multiple steps in case the input doesn't actually have "assembly1-x" in the name
       String       sample_name = basename(basename(contigs_fasta, ".fasta"), ".assembly1-spades")
@@ -720,7 +722,7 @@ task refine_assembly_with_aligned_reads {
       Int      min_coverage = 3
 
       Int      machine_mem_gb = 15
-      String   docker = "quay.io/broadinstitute/viral-assemble:2.4.1.0"
+      String   docker = "quay.io/broadinstitute/viral-assemble:2.4.2.0"
     }
 
     Int disk_size = 375

--- a/pipes/WDL/tasks/tasks_megablast.wdl
+++ b/pipes/WDL/tasks/tasks_megablast.wdl
@@ -15,7 +15,7 @@ task trim_rmdup_subsamp {
         Int cpu            = 16
         Int disk_size_gb   = 100 
 
-        String docker      = "quay.io/broadinstitute/viral-assemble:2.4.1.0"
+        String docker      = "quay.io/broadinstitute/viral-assemble:2.4.2.0"
     }
 
     parameter_meta {
@@ -36,7 +36,7 @@ task trim_rmdup_subsamp {
     command <<<
         set -ex o pipefail
         assembly.py --version | tee VERSION
-        #BAM ->FASTQ-> OutBam? https://github.com/broadinstitute/viral-assemble:2.4.1.0
+        #BAM ->FASTQ-> OutBam? https://github.com/broadinstitute/viral-assemble:2.4.2.0
         assembly.py trim_rmdup_subsamp \
         "~{inBam}" \
         "~{clipDb}" \

--- a/pipes/WDL/tasks/tasks_reports.wdl
+++ b/pipes/WDL/tasks/tasks_reports.wdl
@@ -717,7 +717,7 @@ task compare_two_genomes {
     File   genome_two
     String out_basename
 
-    String docker = "quay.io/broadinstitute/viral-assemble:2.4.1.0"
+    String docker = "quay.io/broadinstitute/viral-assemble:2.4.2.0"
   }
 
   Int disk_size = 50

--- a/requirements-modules.txt
+++ b/requirements-modules.txt
@@ -1,6 +1,6 @@
 broadinstitute/viral-baseimage=0.2.4
 broadinstitute/viral-core=2.4.1
-broadinstitute/viral-assemble=2.4.1.0
+broadinstitute/viral-assemble=2.4.2.0
 broadinstitute/viral-classify=2.2.5
 broadinstitute/viral-phylo=2.4.1.0
 broadinstitute/py3-bio=0.1.2


### PR DESCRIPTION
This PR:
 - updates the viral-assemble docker image from 2.4.1.0 to 2.4.2.0 -- see https://github.com/broadinstitute/viral-assemble/pull/54 for details, a number of conda dependency versions were updated, including spades, skani, mafft, etc.
 - adds a newly exposed optional parameter `skani_n` for invocations of `skani_contigs_to_refs`, allowing the user to specify whether or how many output hits to limit to