### PR TITLE
bump vadr docker 1.6.3 to 1.6.4 model-free

### DIFF
--- a/pipes/WDL/tasks/tasks_ncbi.wdl
+++ b/pipes/WDL/tasks/tasks_ncbi.wdl
@@ -1521,7 +1521,7 @@ task vadr {
     String? vadr_model_tar_subdir
 
     String out_basename = basename(genome_fasta, '.fasta')
-    String docker = "quay.io/staphb/vadr:1.6.4"
+    String docker = "mirror.gcr.io/staphb/vadr:1.6.4"
     Int    mem_size = 16  # the RSV model in particular seems to consume 15GB RAM
     Int    cpus = 4
   }


### PR DESCRIPTION
Bump VADR docker image from 1.6.3 to 1.6.4

This update also represents a shift in the [StaPH-B docker build for VADR](https://github.com/StaPH-B/docker-builds/tree/master/build-files/vadr/1.6.4) from model-inclusive to model-free (keeping the image quite lightweight). This means all models must be downloaded at runtime before use.