### PR TITLE
Add simulate_illumina_reads workflow for synthetic test data generation

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -244,6 +244,11 @@ workflows:
   - name: scaffold_and_refine_multitaxa
     subclass: WDL
     primaryDescriptorPath: /pipes/WDL/workflows/scaffold_and_refine_multitaxa.wdl
+  - name: simulate_illumina_reads
+    subclass: WDL
+    primaryDescriptorPath: /pipes/WDL/workflows/simulate_illumina_reads.wdl
+    testParameterFiles:
+    - /test/input/WDL/miniwdl-local/test_inputs-simulate_illumina_reads-local.json
   - name: submit_biosample
     subclass: WDL
     primaryDescriptorPath: /pipes/WDL/workflows/submit_biosample.wdl

--- a/pipes/WDL/tasks/tasks_assembly.wdl
+++ b/pipes/WDL/tasks/tasks_assembly.wdl
@@ -1080,3 +1080,106 @@ task filter_bad_ntc_batches {
         File           fail_meta_json   = "genome_status.json"
     }
 }
+
+task simulate_illumina_reads {
+    meta {
+        description: "Generate synthetic Illumina paired-end reads from reference sequences using wgsim via assembly.py simulate_illumina_reads."
+    }
+
+    input {
+        String coverage_string
+        File   reference_fasta
+        File?  coverage_bed
+        String out_basename = "simulated_reads"
+
+        Int?   read_length
+        Int?   outer_distance
+        Float? mutation_rate
+        Float? indel_fraction
+        Float? indel_extend_probability
+        Int?   random_seed
+
+        Int    machine_mem_gb = 7
+        String docker = "quay.io/broadinstitute/viral-assemble:2.4.3.1"
+    }
+
+    parameter_meta {
+        coverage_string: {
+            description: "Either a simple coverage value (e.g., '10X') or a space-separated string of colon-separated pairs where each pair consists of a GenBank accession and a coverage value (e.g., 'KJ660346.2:12.5x NC_004296.1:0.9X'). Ignored if coverage_bed is provided.",
+            category: "required"
+        }
+        reference_fasta: {
+            description: "Reference genome sequences in FASTA format from which to generate reads.",
+            patterns: ["*.fasta"],
+            category: "required"
+        }
+        coverage_bed: {
+            description: "Optional BED file specifying coverage per region. If provided, this overrides coverage_string.",
+            patterns: ["*.bed"],
+            category: "advanced"
+        }
+        read_length: {
+            description: "Length of simulated reads (default: 150bp).",
+            category: "advanced"
+        }
+        outer_distance: {
+            description: "Outer distance between paired reads (default: 500bp).",
+            category: "advanced"
+        }
+        mutation_rate: {
+            description: "Base mutation rate (default: 0.001).",
+            category: "advanced"
+        }
+        indel_fraction: {
+            description: "Fraction of mutations that are indels (default: 0.15).",
+            category: "advanced"
+        }
+        indel_extend_probability: {
+            description: "Probability an indel is extended (default: 0.3).",
+            category: "advanced"
+        }
+        random_seed: {
+            description: "Random seed for reproducibility.",
+            category: "advanced"
+        }
+    }
+
+    Int disk_size = 100
+
+    command <<<
+        set -e
+        assembly.py --version | tee VERSION
+
+        # Run simulate_illumina_reads
+        assembly.py simulate_illumina_reads \
+            ~{if defined(coverage_bed) then '--coverage_bed "' + coverage_bed + '"' else '"' + coverage_string + '"'} \
+            "~{reference_fasta}" \
+            "~{out_basename}.bam" \
+            ~{'--read_length ' + read_length} \
+            ~{'--outer_distance ' + outer_distance} \
+            ~{'--mutation_rate ' + mutation_rate} \
+            ~{'--indel_fraction ' + indel_fraction} \
+            ~{'--indel_extend_probability ' + indel_extend_probability} \
+            ~{'--random_seed ' + random_seed} \
+            --loglevel=DEBUG
+
+        # Count reads in output BAM
+        samtools view -c "~{out_basename}.bam" | tee READ_COUNT
+    >>>
+
+    output {
+        File   simulated_reads_bam = "~{out_basename}.bam"
+        Int    read_count          = read_int("READ_COUNT")
+        String viralngs_version    = read_string("VERSION")
+    }
+
+    runtime {
+        docker: docker
+        memory: machine_mem_gb + " GB"
+        cpu: 2
+        disks:  "local-disk " + disk_size + " HDD"
+        disk: disk_size + " GB" # TES
+        dx_instance_type: "mem1_ssd1_v2_x2"
+        maxRetries: 2
+    }
+}

--- a/pipes/WDL/tasks/tasks_assembly.wdl
+++ b/pipes/WDL/tasks/tasks_assembly.wdl
@@ -1152,9 +1152,9 @@ task simulate_illumina_reads {
 
         # Run simulate_illumina_reads
         assembly.py simulate_illumina_reads \
-            ~{if defined(coverage_bed) then '--coverage_bed "' + coverage_bed + '"' else '"' + coverage_string + '"'} \
             "~{reference_fasta}" \
             "~{out_basename}.bam" \
+            ~{if defined(coverage_bed) then '--coverage_bed "' + coverage_bed + '"' else '"' + coverage_string + '"'} \
             ~{'--read_length ' + read_length} \
             ~{'--outer_distance ' + outer_distance} \
             ~{'--mutation_rate ' + mutation_rate} \

--- a/pipes/WDL/tasks/tasks_assembly.wdl
+++ b/pipes/WDL/tasks/tasks_assembly.wdl
@@ -1081,7 +1081,7 @@ task filter_bad_ntc_batches {
     }
 }
 
-task simulate_illumina_reads {
+task wgsim {
     meta {
         description: "Generate synthetic Illumina paired-end reads from reference sequences using wgsim via assembly.py simulate_illumina_reads."
     }

--- a/pipes/WDL/tasks/tasks_ncbi.wdl
+++ b/pipes/WDL/tasks/tasks_ncbi.wdl
@@ -32,6 +32,62 @@ task download_fasta {
   }
 }
 
+task download_fasta_from_accession_string {
+  meta {
+    description: "Download GenBank sequences from a space-separated string of accessions (optionally with coverage specifications like 'accession:12.5x') and combine into a single fasta file."
+  }
+
+  input {
+    String accession_string
+    String out_prefix
+    String emailAddress
+
+    String docker = "quay.io/broadinstitute/viral-phylo:2.4.1.0"
+  }
+
+  command <<<
+    set -e
+    ncbi.py --version | tee VERSION
+
+    # Parse accession string to extract just the accession IDs (strip coverage values if present)
+    python3 <<CODE
+    import re
+    accession_string = "~{accession_string}"
+    # Split by whitespace and extract accession (before colon if present)
+    accessions = []
+    for pair in accession_string.split():
+        if ':' in pair:
+            accessions.append(pair.split(':')[0])
+        else:
+            accessions.append(pair)
+
+    with open('accessions.txt', 'w') as f:
+        for acc in accessions:
+            f.write(acc + '\n')
+    CODE
+
+    # Download sequences using extracted accessions
+    ncbi.py fetch_fastas \
+        ~{emailAddress} \
+        . \
+        $(cat accessions.txt | tr '\n' ' ') \
+        --combinedFilePrefix ~{out_prefix}
+  >>>
+
+  output {
+    File   sequences_fasta  = "~{out_prefix}.fasta"
+    String viralngs_version = read_string("VERSION")
+  }
+
+  runtime {
+    docker: docker
+    memory: "7 GB"
+    cpu: 2
+    dx_instance_type: "mem2_ssd1_v2_x2"
+    maxRetries: 2
+  }
+}
+
 task download_annotations {
   input {
     Array[String]+ accessions

--- a/pipes/WDL/workflows/simulate_illumina_reads.wdl
+++ b/pipes/WDL/workflows/simulate_illumina_reads.wdl
@@ -34,7 +34,7 @@ workflow simulate_illumina_reads {
             out_prefix       = out_basename
     }
 
-    call assembly.simulate_illumina_reads as simulate_reads {
+    call assembly.wgsim as simulate_reads {
         input:
             coverage_string = accession_coverage_string,
             reference_fasta = download_fasta_from_accession_string.sequences_fasta,

--- a/pipes/WDL/workflows/simulate_illumina_reads.wdl
+++ b/pipes/WDL/workflows/simulate_illumina_reads.wdl
@@ -1,0 +1,50 @@
+version 1.0
+
+import "../tasks/tasks_ncbi.wdl" as ncbi
+import "../tasks/tasks_assembly.wdl" as assembly
+
+workflow simulate_illumina_reads {
+
+    meta {
+        description: "Generate synthetic Illumina read sets for testing using wgsim. Takes a space-separated string of colon-separated pairs where each pair consists of a GenBank accession and a coverage value (e.g., 'KJ660346.2:12.5x NC_004296.1:0.9X'), downloads the sequences, and simulates Illumina reads."
+        author: "Broad Viral Genomics"
+        email:  "viral-ngs@broadinstitute.org"
+        allowNestedInputs: true
+    }
+
+    parameter_meta {
+        accession_coverage_string: {
+            description: "Space-separated string of colon-separated pairs where each pair consists of a GenBank accession and a coverage value (e.g., 'KJ660346.2:12.5x NC_004296.1:0.9X').",
+            category: "required"
+        }
+        out_basename: {
+            description: "Base name for output files.",
+            category: "common"
+        }
+    }
+
+    input {
+        String accession_coverage_string
+        String out_basename = "simulated_reads"
+    }
+
+    call ncbi.download_fasta_from_accession_string {
+        input:
+            accession_string = accession_coverage_string,
+            out_prefix       = out_basename
+    }
+
+    call assembly.simulate_illumina_reads as simulate_reads {
+        input:
+            coverage_string = accession_coverage_string,
+            reference_fasta = download_fasta_from_accession_string.sequences_fasta,
+            out_basename    = out_basename
+    }
+
+    output {
+        File   simulated_reads_bam = simulate_reads.simulated_reads_bam
+        Int    read_count          = simulate_reads.read_count
+        File   reference_sequences = download_fasta_from_accession_string.sequences_fasta
+        String viralngs_version    = simulate_reads.viralngs_version
+    }
+}

--- a/test/input/WDL/miniwdl-local/test_inputs-simulate_illumina_reads-local.json
+++ b/test/input/WDL/miniwdl-local/test_inputs-simulate_illumina_reads-local.json
@@ -1,0 +1,5 @@
+{
+  "simulate_illumina_reads.accession_coverage_string": "KJ660346.2:12.5x NC_004296.1:0.9X",
+  "simulate_illumina_reads.download_fasta_from_accession_string.emailAddress": "viral-ngs@broadinstitute.org",
+  "simulate_illumina_reads.out_basename": "test_simulated"
+}


### PR DESCRIPTION
## Summary
Implements a new WDL workflow `simulate_illumina_reads` that generates synthetic Illumina read sets for testing using wgsim via `assembly.py simulate_illumina_reads`.

Closes #603

## Changes
- **New task in `tasks_ncbi.wdl`**: `download_fasta_from_accession_string`
  - Downloads GenBank sequences from space-separated accession:coverage string
  - Parses and extracts accession IDs, stripping coverage values

- **New task in `tasks_assembly.wdl`**: `simulate_illumina_reads`
  - Generates synthetic Illumina reads using wgsim
  - Supports both coverage string mode and optional BED file mode for flexibility
  - Exposes all optional parameters (read_length, outer_distance, mutation_rate, indel_fraction, indel_extend_probability, random_seed)
  - Outputs unaligned BAM file and read count

- **New workflow**: `simulate_illumina_reads.wdl`
  - Orchestrates sequence download and read simulation
  - Uses `allowNestedInputs: true` for flexible parameterization
  - Workflow-level inputs limited to those used by multiple tasks

- **Dockstore integration**: Updated `.dockstore.yml` to register new workflow

- **Integration test**: Added test input JSON with example accession:coverage pairs

## Testing
- ✅ WDL syntax validated with `miniwdl check`
- ✅ Workflow structure confirmed correct
- ✅ Test input JSON created for CI/CD validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)