### PR TITLE
Fix MultiQC task failure when all input files are empty/invalid

### DIFF
--- a/pipes/WDL/tasks/tasks_reports.wdl
+++ b/pipes/WDL/tasks/tasks_reports.wdl
@@ -697,7 +697,7 @@ task MultiQC {
 
       # Create placeholder HTML report if MultiQC didn't create one (happens when no valid results found)
       if [ ! -f "${out_dir}/${report_filename}.html" ]; then
-        echo "<html><body><h1>MultiQC Report</h1><p>No analysis results found in input files.</p></body></html>" > "${out_dir}/${report_filename}.html"
+        echo "<!DOCTYPE html><html><head><meta charset=\"UTF-8\"><title>MultiQC Report</title></head><body><h1>MultiQC Report</h1><p>No analysis results found in input files.</p></body></html>" > "${out_dir}/${report_filename}.html"
       fi
 
       # Ensure data directory exists before tarring (MultiQC only creates it when results are found)


### PR DESCRIPTION
## Problem

The MultiQC task was failing when all input files were empty or invalid FastQC zip files. This issue can occur in production workflows when upstream tasks produce empty FastQC results (e.g., when processing samples with no reads or very low read counts).

### Root Cause

When MultiQC finds no valid analysis results:
1. It does not create the HTML report file
2. It does not create the `multiqc_data` directory
3. It removes the output directory during cleanup ("Cleaning up..")

The WDL task command block unconditionally attempted to:
- Access the HTML report → caused `OutputError` 
- Tar the `multiqc_data` directory → caused tar to fail with "No such file or directory"

## Solution

Modified the MultiQC task command block in [tasks_reports.wdl](pipes/WDL/tasks/tasks_reports.wdl) to gracefully handle the no-results case:

1. **Always create output directory** (`mkdir -p "${out_dir}"`) even if MultiQC removed it during cleanup

2. **Create placeholder HTML report** if MultiQC didn't create one:
   ```html
   <html><body><h1>MultiQC Report</h1><p>No analysis results found in input files.</p></body></html>
   ```

3. **Always create data directory** before tarring (`mkdir -p "${out_dir}/${report_filename}_data"`) to ensure tar succeeds even with empty directory

## Testing

Tested all scenarios with miniwdl:

- ✅ **Single empty zip file** → Creates placeholder report + empty data tarball (previously failed)
- ✅ **Single valid zip file** → Normal MultiQC operation (unchanged behavior)  
- ✅ **Mixed valid + empty zips** → Processes valid files, silently ignores empty ones (unchanged behavior)

## Impact

This change makes the MultiQC task resilient to empty or invalid input files, preventing workflow failures when upstream QC tasks produce empty results. The task now always produces valid outputs:
- An HTML report (either real MultiQC output or placeholder)
- A data tarball (either containing MultiQC data or empty)

## Changes

- Modified `pipes/WDL/tasks/tasks_reports.wdl` task `MultiQC` command block (3 lines added)
