### PR TITLE
Fix unpack_archive_to_bucket_path to fail fast and optimize resources

### DIFF
--- a/pipes/WDL/tasks/tasks_utils.wdl
+++ b/pipes/WDL/tasks/tasks_utils.wdl
@@ -50,8 +50,8 @@ task unpack_archive_to_bucket_path {
         String  gcloud_storage_cp_opts = ""
 
         # execution and resource requirements
-        Int    disk_size      = 500
-        Int    machine_mem_gb = 128
+        Int    disk_size      = ceil(3.0 * size(input_archive_files[0], "GB")) + 50
+        Int    machine_mem_gb = 8
         String docker         = "quay.io/broadinstitute/viral-core:2.5.10"
     }
 
@@ -104,6 +104,8 @@ task unpack_archive_to_bucket_path {
     }
 
     command <<<
+        set -e
+
         # verify gcloud is installed (it should be, if the default docker image is used)
         if ! command -v gcloud &> /dev/null; then
             echo "ERROR: gcloud is not installed; it is required to authenticate to Google Cloud Storage" >&2
@@ -208,7 +210,7 @@ task unpack_archive_to_bucket_path {
         cpu:    16
         disks:  "local-disk " + disk_size + " LOCAL"
         disk: disk_size + " GB" # TES
-        dx_instance_type: "mem3_ssd1_v2_x16"
+        dx_instance_type: "mem1_ssd1_v2_x16"
         preemptible: 0
         maxRetries: 1
     }


### PR DESCRIPTION
## Summary
- Add set -e to fail immediately on tar errors (disk space, corruption, etc.)
- Set disk_size dynamically to 3x first input file size + 50GB buffer (was hardcoded 500GB)
- Reduce memory from 128GB to 8GB (task only does streaming I/O, doesn't need high memory)
- Update dx_instance_type from mem3 to mem1 to match reduced memory requirement

## Context
Previously, when tar failed due to insufficient disk space, the task would continue and attempt to upload partially extracted files without raising an error.

## Resource Optimization
- The task performs only streaming operations (tar extraction, gcloud storage uploads), which don't require high memory
- CPU count of 16 is optimal for saturating GCE network bandwidth (32 Gbps max at 2 Gbps/vCPU)
- Dynamic disk sizing prevents both waste (when input is small) and failures (when input is large)

## Test plan
- WDL syntax validation with miniwdl check passes
- Test with large archive file that previously failed
- Verify task fails appropriately when disk space is insufficient