### PR TITLE
fix tar_extract: switch LOCAL to HDD disk, bump cpu and preemptible

### DIFF
--- a/pipes/WDL/tasks/tasks_utils.wdl
+++ b/pipes/WDL/tasks/tasks_utils.wdl
@@ -352,11 +352,11 @@ task tar_extract {
     runtime {
         docker: "quay.io/broadinstitute/viral-ngs:3.0.10-baseimage"
         memory: "2 GB"
-        cpu:    1
-        disks: "local-disk ~{disk_size} LOCAL"
+        cpu:    2
+        disks: "local-disk ~{disk_size} HDD"
         disk: "~{disk_size} GB" # TES
         dx_instance_type: "mem1_ssd1_v2_x2"
-        preemptible: 1
+        preemptible: 2
     }
     output {
         Array[File] files = glob("unpack/*")


### PR DESCRIPTION
## Summary
- Switch `tar_extract` disk type from `LOCAL` (NVMe local SSD) to `HDD` (persistent disk)
- Bump `cpu` from 1 to 2 and `preemptible` from 1 to 2

## Problem
The `tar_extract` task was failing 100% on GCP Batch in `broad-viral-surveillance/measles-usa` with:
> "The job was stopped before the command finished. GCP Batch task exited with Success(0)."

Root cause: `local-disk 375 LOCAL` requires NVMe local SSDs, which are only available on certain machine families (n1-standard-4+, n2, c2, etc.). GCP Batch selects lightweight instance types for the task's 1 CPU / 2 GB memory request that don't support local SSDs, causing the VM to fail during provisioning — no stderr/stdout were ever produced.

This affected 142/178 workflows in the initial submission and 136/142 on resubmission (100% fail rate when all tar_extract tasks launched simultaneously due to upstream call cache hits).

## Test plan
- [ ] Resubmit failed workflows in `broad-viral-surveillance/measles-usa` with updated WDL
- [ ] Verify tar_extract tasks complete successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)