### PR TITLE
Bump docker image versions for ncbi-tools, nextclade, read-qc-tools, pangolin

### DIFF
--- a/pipes/WDL/tasks/tasks_ncbi_tools.wdl
+++ b/pipes/WDL/tasks/tasks_ncbi_tools.wdl
@@ -9,7 +9,7 @@ task Fetch_SRA_to_BAM {
         String? email_address
         String? ncbi_api_key
         Int?    machine_mem_gb
-        String  docker = "quay.io/broadinstitute/ncbi-tools:2.11.1"
+        String  docker = "quay.io/broadinstitute/ncbi-tools:2.12.0"
     }
     Int disk_size = 750
     meta {
@@ -158,7 +158,7 @@ task Fetch_SRA_to_BAM {
 task fetch_genbank_metadata {
     input {
         String  genbank_accession
-        String  docker = "quay.io/broadinstitute/ncbi-tools:2.11.1"
+        String  docker = "quay.io/broadinstitute/ncbi-tools:2.12.0"
     }
     Int disk_size = 50
     command <<<
@@ -189,7 +189,7 @@ task biosample_tsv_filter_preexisting {
         File           meta_submit_tsv
 
         String         out_basename = "biosample_attributes"
-        String         docker = "quay.io/broadinstitute/ncbi-tools:2.11.1"
+        String         docker = "quay.io/broadinstitute/ncbi-tools:2.12.0"
     }
     Int disk_size = 50
     meta {
@@ -251,7 +251,7 @@ task fetch_biosamples {
         Array[String]  biosample_ids
 
         String         out_basename = "biosample_attributes"
-        String         docker = "quay.io/broadinstitute/ncbi-tools:2.11.1"
+        String         docker = "quay.io/broadinstitute/ncbi-tools:2.12.0"
     }
     Int disk_size = 50
     meta {
@@ -287,7 +287,7 @@ task ncbi_sftp_upload {
 
         String         wait_for="1"  # all, disabled, some number
 
-        String         docker = "quay.io/broadinstitute/ncbi-tools:2.11.1"
+        String         docker = "quay.io/broadinstitute/ncbi-tools:2.12.0"
     }
     Int disk_size = 100
     command <<<
@@ -333,7 +333,7 @@ task sra_tsv_to_xml {
         String   bioproject
         String   data_bucket_uri
 
-        String   docker = "quay.io/broadinstitute/ncbi-tools:2.11.1"
+        String   docker = "quay.io/broadinstitute/ncbi-tools:2.12.0"
     }
     Int disk_size = 50
     command <<<
@@ -369,7 +369,7 @@ task biosample_submit_tsv_to_xml {
         File     meta_submit_tsv
         File     config_js
 
-        String   docker = "quay.io/broadinstitute/ncbi-tools:2.11.1"
+        String   docker = "quay.io/broadinstitute/ncbi-tools:2.12.0"
     }
     Int disk_size = 50
     meta {
@@ -406,7 +406,7 @@ task biosample_submit_tsv_ftp_upload {
         File     config_js
         String   target_path
 
-        String   docker = "quay.io/broadinstitute/ncbi-tools:2.11.1"
+        String   docker = "quay.io/broadinstitute/ncbi-tools:2.12.0"
     }
     String base=basename(meta_submit_tsv, '.tsv')
     Int disk_size = 100    
@@ -446,7 +446,7 @@ task biosample_xml_response_to_tsv {
         File     meta_submit_tsv
         File     ncbi_report_xml
 
-        String   docker = "quay.io/broadinstitute/ncbi-tools:2.11.1"
+        String   docker = "quay.io/broadinstitute/ncbi-tools:2.12.0"
     }
     String out_name = "~{basename(meta_submit_tsv, '.tsv')}-attributes.tsv"
     Int disk_size = 100

--- a/pipes/WDL/tasks/tasks_nextstrain.wdl
+++ b/pipes/WDL/tasks/tasks_nextstrain.wdl
@@ -61,7 +61,7 @@ task nextclade_one_sample {
         File? gene_annotations_json
         String? dataset_name
         Int    disk_size = 50
-        String docker = "nextstrain/nextclade:3.19.0"
+        String docker = "nextstrain/nextclade:3.21.0"
     }
     String basename = basename(genome_fasta, ".fasta")
     command <<<
@@ -153,7 +153,7 @@ task nextclade_many_samples {
         String       basename
         File?        genome_ids_setdefault_blank
         Int          disk_size = 150
-        String       docker = "nextstrain/nextclade:3.19.0"
+        String       docker = "nextstrain/nextclade:3.21.0"
     }
     command <<<
         set -e

--- a/pipes/WDL/tasks/tasks_reports.wdl
+++ b/pipes/WDL/tasks/tasks_reports.wdl
@@ -721,7 +721,7 @@ task multiqc_from_bams {
     File?          config
     String?        config_yaml
 
-    String         docker = "ghcr.io/broadinstitute/read-qc-tools:1.0.1"
+    String         docker = "ghcr.io/broadinstitute/read-qc-tools:1.1.0"
 
     Int?           cpu              # Override auto-scaled CPU (default: 2*num_bams, capped 4-32)
     Int?           machine_mem_gb   # Override auto-scaled memory (default: 2*cpu GB)

--- a/pipes/WDL/tasks/tasks_sarscov2.wdl
+++ b/pipes/WDL/tasks/tasks_sarscov2.wdl
@@ -10,7 +10,7 @@ task pangolin_one_sample {
         Float?  max_ambig
         String? analysis_mode
         Boolean update_dbs_now=false
-        String  docker = "quay.io/staphb/pangolin:4.3.3-pdata-1.36"
+        String  docker = "quay.io/staphb/pangolin:4.4-pdata-1.38"
     }
     String basename = basename(genome_fasta, ".fasta")
     Int disk_size = 50
@@ -93,7 +93,7 @@ task pangolin_many_samples {
         String?      analysis_mode
         Boolean      update_dbs_now=false
         String       basename
-        String       docker = "quay.io/staphb/pangolin:4.3.3-pdata-1.36"
+        String       docker = "quay.io/staphb/pangolin:4.4-pdata-1.38"
     }
     Int disk_size = 100
     command <<<

--- a/requirements-modules.txt
+++ b/requirements-modules.txt
@@ -1,9 +1,9 @@
 broadinstitute/viral-ngs=3.0.10
-broadinstitute/read-qc-tools=1.0.1
+broadinstitute/read-qc-tools=1.1.0
 broadinstitute/py3-bio=0.1.5
 broadinstitute/beast-beagle-cuda=1.10.5pre
-broadinstitute/ncbi-tools=2.11.1
+broadinstitute/ncbi-tools=2.12.0
 nextstrain/base=build-20240318T173028Z
 andersenlabapps/ivar=1.3.1
-quay.io/staphb/pangolin=4.3.3-pdata-1.36
-nextstrain/nextclade=3.19.0
+quay.io/staphb/pangolin=4.4-pdata-1.38
+nextstrain/nextclade=3.21.0


### PR DESCRIPTION
## Summary
- Bump `ncbi-tools` from 2.11.1 to 2.12.0 (9 tasks in `tasks_ncbi_tools.wdl`)
- Bump `nextclade` from 3.19.0 to 3.21.0 (2 tasks in `tasks_nextstrain.wdl`)
- Bump `read-qc-tools` from 1.0.1 to 1.1.0 (1 task in `tasks_reports.wdl`)
- Bump `pangolin` from 4.3.3-pdata-1.36 to 4.4-pdata-1.38 (2 tasks in `tasks_sarscov2.wdl`)
- Updated `requirements-modules.txt` to match

## Test plan
- [ ] CI WDL validation passes (miniwdl check + womtool)
- [ ] Integration tests pass for affected workflows

🤖 Generated with [Claude Code](https://claude.com/claude-code)