### PR TITLE
add noAddress: true to runtime blocks for airgap-safe tasks

### DIFF
--- a/pipes/WDL/tasks/tasks_16S_amplicon.wdl
+++ b/pipes/WDL/tasks/tasks_16S_amplicon.wdl
@@ -65,6 +65,7 @@ task qiime_import_from_bam {
         cpu: cpu
         disk: "~{disk_size_gb} GB"
         disks: "local-disk ~{disk_size_gb} HDD"
+        noAddress: true
     }
 }
 
@@ -146,6 +147,7 @@ task trim_reads {
         cpu: cpu
         disk: "~{disk_size_gb} GB"
         disks: "local-disk ~{disk_size_gb} HDD"
+        noAddress: true
     }
 }
 
@@ -196,6 +198,7 @@ task join_paired_ends {
         cpu: cpu
         disk: "~{disk_size_gb} GB"
         disks: "local-disk ~{disk_size_gb} HDD"
+        noAddress: true
     }
 }
 
@@ -271,6 +274,7 @@ task deblur {
         cpu: cpu
         disk: "~{disk_size_gb} GB"
         disks: "local-disk ~{disk_size_gb} HDD"
+        noAddress: true
     }
 }
 task train_classifier {
@@ -359,6 +363,7 @@ task train_classifier {
         cpu: cpu
         disk: "~{disk_size_gb} GB"
         disks: "local-disk ~{disk_size_gb} HDD"
+        noAddress: true
     }
 }
 task tax_analysis {
@@ -422,5 +427,6 @@ task tax_analysis {
         cpu: cpu
         disk: "~{disk_size_gb} GB"
         disks: "local-disk ~{disk_size_gb} HDD"
+        noAddress: true
     }
 } 

--- a/pipes/WDL/tasks/tasks_assembly.wdl
+++ b/pipes/WDL/tasks/tasks_assembly.wdl
@@ -107,6 +107,7 @@ task assemble {
         disks: "local-disk ~{disk_size} SSD"
         disk: "~{disk_size} GB" # TES
         dx_instance_type: "mem1_ssd1_v2_x8"
+        noAddress: true
     }
 
 }
@@ -197,6 +198,7 @@ task select_references {
     disk: "~{disk_size} GB" # TESs
     dx_instance_type: "mem1_ssd1_v2_x2"
     preemptible: 2
+    noAddress: true
   }
 }
 
@@ -459,6 +461,7 @@ task scaffold {
         disks: "local-disk ~{disk_size} SSD"
         disk: "~{disk_size} GB" # TES
         dx_instance_type: "mem1_ssd1_v2_x8"
+        noAddress: true
     }
 }
 
@@ -544,6 +547,7 @@ task skani_triangle {
     disk: "~{disk_size} GB" # TES
     dx_instance_type: "mem1_ssd1_v2_x4"
     preemptible: 2
+    noAddress: true
   }
 }
 
@@ -626,6 +630,7 @@ task ivar_trim {
         disks: "local-disk ~{disk_size} HDD"
         disk: "~{disk_size} GB" # TES
         dx_instance_type: "mem1_ssd1_v2_x4"
+        noAddress: true
     }
 }
 
@@ -691,6 +696,7 @@ task ivar_trim_stats {
         disks: "local-disk ~{disk_size} HDD"
         disk: "~{disk_size} GB"
         dx_instance_type: "mem1_ssd1_v2_x2"
+        noAddress: true
     }
 }
 
@@ -859,6 +865,7 @@ task align_reads {
     disk: "~{disk_size} GB" # TES
     dx_instance_type: "mem1_ssd1_v2_x8"
     preemptible: 1
+    noAddress: true
   }
 }
 
@@ -999,6 +1006,7 @@ task refine_assembly_with_aligned_reads {
         disks: "local-disk ~{disk_size} SSD"
         disk: "~{disk_size} GB" # TES
         dx_instance_type: "mem1_ssd1_v2_x8"
+        noAddress: true
     }
 }
 
@@ -1120,6 +1128,7 @@ task run_discordance {
         disk: "~{disk_size} GB" # TES
         dx_instance_type: "mem1_ssd1_v2_x2"
         preemptible: 1
+        noAddress: true
     }
 }
 
@@ -1231,6 +1240,7 @@ task filter_bad_ntc_batches {
         disks: "local-disk ~{disk_size} HDD"
         disk: "~{disk_size} GB" # TES
         dx_instance_type: "mem1_ssd1_v2_x2"
+        noAddress: true
     }
     output {
         File           seqids_kept      = "seqids.filtered.txt"
@@ -1341,5 +1351,6 @@ task wgsim {
         disks: "local-disk ~{disk_size} HDD"
         disk: "~{disk_size} GB" # TES
         dx_instance_type: "mem1_ssd1_v2_x2"
+        noAddress: true
     }
 }

--- a/pipes/WDL/tasks/tasks_demux.wdl
+++ b/pipes/WDL/tasks/tasks_demux.wdl
@@ -38,6 +38,7 @@ task merge_tarballs {
     disk: "~{disk_size} GB" # TES
     dx_instance_type: "mem1_ssd2_v2_x16"
     preemptible: 0
+    noAddress: true
   }
 }
 
@@ -90,6 +91,7 @@ task samplesheet_rename_ids {
     disks: "local-disk ~{disk_size} HDD"
     disk: "~{disk_size} GB" # TES
     dx_instance_type: "mem1_ssd1_v2_x2"
+    noAddress: true
   }
 }
 
@@ -134,6 +136,7 @@ task revcomp_i5 {
     disks: "local-disk ~{disk_size} HDD"
     disk: "~{disk_size} GB"
     dx_instance_type: "mem1_ssd1_v2_x2"
+    noAddress: true
   }
 }
 
@@ -653,6 +656,7 @@ task illumina_demux {
     dx_instance_type: "mem3_ssd2_v2_x32"
     dx_timeout: "20H"
     preemptible: 0  # this is the very first operation before scatter, so let's get it done quickly & reliably
+    noAddress: true
   }
 }
 
@@ -685,6 +689,7 @@ task map_map_setdefault {
     disks: "local-disk ~{disk_size} HDD"
     disk: "~{disk_size} GB"
     dx_instance_type: "mem1_ssd1_v2_x2"
+    noAddress: true
   }
 }
 
@@ -716,6 +721,7 @@ task merge_maps {
     disks: "local-disk ~{disk_size} LOCAL"
     disk: "~{disk_size} GB" # TES
     dx_instance_type: "mem1_ssd1_v2_x2"
+    noAddress: true
   }
 }
 
@@ -804,6 +810,7 @@ task group_fastq_pairs {
     disks: "local-disk ~{disk_size} HDD"
     disk: "~{disk_size} GB" # TES
     dx_instance_type: "mem1_ssd1_v2_x2"
+    noAddress: true
   }
 }
 
@@ -862,6 +869,7 @@ task get_illumina_run_metadata {
     disks: "local-disk ~{disk_size} LOCAL"
     disk: "~{disk_size} GB" # TES
     dx_instance_type: "mem1_ssd1_v2_x2"
+    noAddress: true
   }
 }
 
@@ -900,6 +908,7 @@ task check_for_barcode3 {
     docker: docker
     memory: "1 GB"
     cpu: 1
+    noAddress: true
   }
 }
 
@@ -1036,6 +1045,7 @@ task demux_fastqs {
     disk: "~{disk_size} GB" # TES
     dx_instance_type: "mem1_ssd1_v2_x16"
     preemptible: 0  # this is the very first operation before scatter, so let's get it done quickly & reliably
+    noAddress: true
   }
 }
 
@@ -1083,6 +1093,7 @@ task merge_demux_metrics {
     disks: "local-disk 50 HDD"
     disk: "50 GB"
     dx_instance_type: "mem1_ssd1_v2_x2"
+    noAddress: true
   }
 }
 
@@ -1150,5 +1161,6 @@ task merge_sample_metadata {
     disks: "local-disk 50 HDD"
     disk: "50 GB"
     dx_instance_type: "mem1_ssd1_v2_x2"
+    noAddress: true
   }
 }

--- a/pipes/WDL/tasks/tasks_interhost.wdl
+++ b/pipes/WDL/tasks/tasks_interhost.wdl
@@ -133,6 +133,7 @@ task subsample_by_cases {
         disks:  "local-disk 200 HDD"
         disk:   "200 GB"
         dx_instance_type: "mem3_ssd1_v2_x4"
+        noAddress: true
     }
     output {
         File    genome_matrix_days              =   "genome_matrix_days.tsv"
@@ -194,6 +195,7 @@ task multi_align_mafft_ref {
     disks: "local-disk ~{disk_size} HDD"
     disk: "~{disk_size} GB" # TES
     dx_instance_type: "mem3_ssd1_v2_x8"
+    noAddress: true
   }
 }
 
@@ -239,6 +241,7 @@ task multi_align_mafft {
     disks: "local-disk ~{disk_size} HDD"
     disk: "~{disk_size} GB" # TES
     dx_instance_type: "mem2_ssd1_v2_x8"
+    noAddress: true
   }
 }
 
@@ -339,6 +342,7 @@ task beast {
     gpuType:             select_first([gpu_type, "nvidia-tesla-p4"])  # Terra
     gpuCount:            select_first([gpu_count, 1])  # Terra
     nvidiaDriverVersion: "410.79"
+    noAddress: true
   }
 }
 
@@ -376,6 +380,7 @@ task index_ref {
     disks: "local-disk ~{disk_size} HDD"
     disk: "~{disk_size} GB" # TES
 
+    noAddress: true
   }
 }
 
@@ -405,6 +410,7 @@ task trimal_clean_msa {
     disks: "local-disk ~{disk_size} HDD"
     disk: "~{disk_size} GB" # TES
     dx_instance_type: "mem1_ssd1_v2_x8"
+    noAddress: true
   }
 }
 
@@ -461,6 +467,7 @@ task merge_vcfs_bcftools {
     memory: "~{select_first([machine_mem_gb, 3])} GB"
     cpu: 2
     dx_instance_type: "mem1_ssd1_v2_x2"
+    noAddress: true
   }
 }
 
@@ -522,6 +529,7 @@ task merge_vcfs_gatk {
     memory: "~{select_first([machine_mem_gb, 3])} GB"
     cpu: 2
     dx_instance_type: "mem1_ssd1_v2_x2"
+    noAddress: true
   }
 }
 
@@ -591,5 +599,6 @@ task reconstructr {
     disk: "~{disk_size} GB" # TES
     bootDiskSizeGb: 50
     dx_instance_type: "mem1_ssd1_v2_x4"
+    noAddress: true
   }
 }

--- a/pipes/WDL/tasks/tasks_intrahost.wdl
+++ b/pipes/WDL/tasks/tasks_intrahost.wdl
@@ -126,6 +126,7 @@ task polyphonia_detect_cross_contamination {
     disks: "local-disk ~{disk_size} HDD"
     disk: "~{disk_size} GB" # TES
     dx_instance_type: "mem1_ssd1_v2_x4"
+    noAddress: true
   }
 }
 
@@ -201,6 +202,7 @@ task lofreq {
     disks: "local-disk ~{disk_size} SSD"
     disk: "~{disk_size} GB" # TES
     dx_instance_type: "mem1_ssd1_v2_x4"
+    noAddress: true
   }
 }
 
@@ -241,6 +243,7 @@ task isnvs_per_sample {
     docker: docker
     memory: "~{select_first([machine_mem_gb, 7])} GB"
     dx_instance_type: "mem1_ssd1_v2_x8"
+    noAddress: true
   }
 }
 

--- a/pipes/WDL/tasks/tasks_megablast.wdl
+++ b/pipes/WDL/tasks/tasks_megablast.wdl
@@ -56,6 +56,7 @@ task trim_rmdup_subsamp {
         cpu:    cpu
         disks: "local-disk ~{disk_size_gb} LOCAL"
         dx_instance_type: "n2-highmem-4"
+        noAddress: true
     }
 }
 
@@ -154,6 +155,7 @@ task lca_megablast {
         disks: "local-disk ~{disk_size_gb} HDD"
 
         dx_instance_type: "n2-highmem-16"
+        noAddress: true
     }
 }
 
@@ -233,6 +235,7 @@ task ChunkBlastHits {
         disks: "local-disk ~{disk_size_gb} LOCAL"
 
         dx_instance_type: "n2-standard-16"
+        noAddress: true
     }
 }
 
@@ -406,5 +409,6 @@ task blastoff {
         disks: "local-disk ~{disk_size_gb} HDD"
 
         dx_instance_type: "n2-highmem-8"
+        noAddress: true
     }
 }

--- a/pipes/WDL/tasks/tasks_metagenomics.wdl
+++ b/pipes/WDL/tasks/tasks_metagenomics.wdl
@@ -131,6 +131,7 @@ task krakenuniq {
     disk: "~{disk_size} GB" # TES
     dx_instance_type: "mem3_ssd1_v2_x48"
     preemptible: 0
+    noAddress: true
   }
 }
 
@@ -200,6 +201,7 @@ task build_krakenuniq_db {
     cpu: 32
     dx_instance_type: "mem3_ssd1_v2_x32"
     preemptible: 0
+    noAddress: true
   }
 }
 
@@ -337,6 +339,7 @@ task kraken2 {
     disk: "~{disk_size} GB" # TESs
     dx_instance_type: "mem3_ssd1_v2_x8"
     preemptible: 2
+    noAddress: true
   }
 }
 
@@ -385,6 +388,7 @@ task report_primary_kraken_taxa {
     disk: "~{disk_size} GB" # TESs
     dx_instance_type: "mem1_ssd1_v2_x2"
     preemptible: 2
+    noAddress: true
   }
 }
 
@@ -423,6 +427,7 @@ task filter_refs_to_found_taxa {
     disk: "~{disk_size} GB" # TESs
     dx_instance_type: "mem1_ssd1_v2_x2"
     preemptible: 2
+    noAddress: true
   }
 }
 
@@ -662,6 +667,7 @@ task blastx {
     disk: "~{disk_size} GB" # TES
     dx_instance_type: "mem1_ssd1_v2_x36"
     preemptible: 1
+    noAddress: true
   }
 }
 
@@ -735,6 +741,7 @@ task krona {
     disks: "local-disk ~{disk_size} HDD"
     disk: "~{disk_size} GB" # TES
     dx_instance_type: "mem1_ssd2_v2_x2"
+    noAddress: true
   }
 }
 
@@ -767,6 +774,7 @@ task krona_merge {
     disks: "local-disk ~{disk_size} HDD"
     disk: "~{disk_size} GB" # TES
     dx_instance_type: "mem1_ssd2_v2_x2"
+    noAddress: true
   }
 }
 
@@ -864,6 +872,7 @@ task filter_bam_to_taxa {
     cpu: 8
     dx_instance_type: "mem1_ssd1_v2_x8"
     preemptible: 1
+    noAddress: true
   }
 }
 
@@ -939,5 +948,6 @@ task kaiju {
     disks: "local-disk ~{disk_size} LOCAL"
     disk: "~{disk_size} GB" # TES
     dx_instance_type: "mem3_ssd1_v2_x16"
+    noAddress: true
   }
 }

--- a/pipes/WDL/tasks/tasks_ncbi.wdl
+++ b/pipes/WDL/tasks/tasks_ncbi.wdl
@@ -218,6 +218,7 @@ task sequencing_platform_from_bam {
     memory: "3 GB"
     cpu: 2
     dx_instance_type: "mem1_ssd1_v2_x2"
+    noAddress: true
   }
 }
 
@@ -278,6 +279,7 @@ task align_and_annot_transfer_single {
     cpu: 8
     dx_instance_type: "mem2_ssd1_v2_x4"
     preemptible: 1
+    noAddress: true
   }
 }
 
@@ -327,6 +329,7 @@ task structured_comments {
     memory: "1 GB"
     cpu: 1
     dx_instance_type: "mem1_ssd1_v2_x2"
+    noAddress: true
   }
 }
 
@@ -418,6 +421,7 @@ task structured_comments_from_aligned_bam {
     memory: "2 GB"
     cpu: 2
     dx_instance_type: "mem1_ssd1_v2_x2"
+    noAddress: true
   }
 }
 
@@ -446,6 +450,7 @@ task prefix_fasta_header {
     memory: "1 GB"
     cpu: 1
     dx_instance_type: "mem1_ssd1_v2_x2"
+    noAddress: true
   }
 }
 
@@ -471,6 +476,7 @@ task rename_fasta_header {
     memory: "1 GB"
     cpu: 1
     dx_instance_type: "mem1_ssd1_v2_x2"
+    noAddress: true
   }
 }
 
@@ -578,6 +584,7 @@ task gisaid_meta_prep {
     memory: "1 GB"
     cpu: 1
     dx_instance_type: "mem1_ssd1_v2_x2"
+    noAddress: true
   }
 }
 
@@ -601,6 +608,7 @@ task lookup_table_by_filename {
     memory: "1 GB"
     cpu: 1
     dx_instance_type: "mem1_ssd1_v2_x2"
+    noAddress: true
   }
 }
 
@@ -734,6 +742,7 @@ task sra_meta_prep {
     disks: "local-disk ~{disk_size} HDD"
     disk: "~{disk_size} GB" # TES
     dx_instance_type: "mem1_ssd1_v2_x2"
+    noAddress: true
   }
 }
 
@@ -819,6 +828,7 @@ task biosample_to_table {
     memory: "1 GB"
     cpu: 1
     dx_instance_type: "mem1_ssd1_v2_x2"
+    noAddress: true
   }
 }
 
@@ -1065,6 +1075,7 @@ task biosample_to_genbank {
     memory: "1 GB"
     cpu: 1
     dx_instance_type: "mem1_ssd1_v2_x2"
+    noAddress: true
   }
 }
 
@@ -1209,6 +1220,7 @@ task generate_author_sbt_file {
     memory: "1 GB"
     cpu: 1
     dx_instance_type: "mem1_ssd1_v2_x2"
+    noAddress: true
   }
 }
 
@@ -1303,6 +1315,7 @@ task table2asn {
     dx_instance_type: "mem1_ssd1_v2_x2"
     disks: "local-disk ~{disk_size} HDD"
     disk: "~{disk_size} GB" # TES
+    noAddress: true
   }
 }
 
@@ -1373,6 +1386,7 @@ task package_special_genbank_ftp_submission {
     memory: "1 GB"
     cpu: 1
     dx_instance_type: "mem1_ssd1_v2_x2"
+    noAddress: true
   }
 }
 
@@ -1629,6 +1643,7 @@ task vadr {
     memory: "~{mem_size} GB"
     cpu: cpus
     dx_instance_type: "mem2_ssd1_v2_x4"
+    noAddress: true
   }
 }
 
@@ -1811,5 +1826,6 @@ task package_genbank_submissions {
     memory: "~{mem_size} GB"
     cpu: cpus
     dx_instance_type: "mem1_ssd1_v2_x2"
+    noAddress: true
   }
 }

--- a/pipes/WDL/tasks/tasks_ncbi_tools.wdl
+++ b/pipes/WDL/tasks/tasks_ncbi_tools.wdl
@@ -361,6 +361,7 @@ task sra_tsv_to_xml {
         disk: "~{disk_size} GB" # TES
         dx_instance_type: "mem2_ssd1_v2_x2"
         docker:  docker
+        noAddress: true
     }
 }
 
@@ -397,6 +398,7 @@ task biosample_submit_tsv_to_xml {
         disk: "~{disk_size} GB" # TES
         dx_instance_type: "mem2_ssd1_v2_x2"
         docker:  docker
+        noAddress: true
     }
 }
 
@@ -475,6 +477,7 @@ task biosample_xml_response_to_tsv {
         disk: "~{disk_size} GB" # TES
         dx_instance_type: "mem2_ssd1_v2_x2"
         docker:  docker
+        noAddress: true
     }
 }
 
@@ -565,6 +568,7 @@ task group_sra_bams_by_biosample {
     disks: "local-disk ~{disk_size} HDD"
     disk: "~{disk_size} GB" # TES
     dx_instance_type: "mem1_ssd1_v2_x2"
+    noAddress: true
   }
 }
 

--- a/pipes/WDL/tasks/tasks_nextstrain.wdl
+++ b/pipes/WDL/tasks/tasks_nextstrain.wdl
@@ -43,6 +43,7 @@ task taxid_to_nextclade_dataset_name {
         disks: "local-disk 100 HDD"
         disk:  "100 GB" # TES
         dx_instance_type: "mem1_ssd1_v2_x2"
+        noAddress: true
     }
     output {
         String nextclade_dataset_name = read_string("nextclade_dataset_name.str")
@@ -316,6 +317,7 @@ task nextmeta_prep {
     memory: "1 GB"
     cpu: 1
     dx_instance_type: "mem1_ssd1_v2_x2"
+    noAddress: true
   }
 }
 
@@ -429,6 +431,7 @@ task derived_cols {
         disks: "local-disk ~{disk_size} HDD"
         disk: "~{disk_size} GB" # TES
         dx_instance_type: "mem1_ssd1_v2_x2"
+        noAddress: true
     }
     output {
         File derived_metadata = "~{basename}.derived_cols.txt"
@@ -476,6 +479,7 @@ task filter_segments {
         disks: "local-disk ~{disk_size} LOCAL"
         disk: "~{disk_size} GB" # TES
         dx_instance_type: "mem1_ssd1_v2_x2"
+        noAddress: true
     }
     output {
         File assembly_of_segment = stdout()
@@ -867,6 +871,7 @@ task filter_subsample_sequences {
         disk: "~{disk_size} GB" # TES
         dx_instance_type: "mem1_ssd1_v2_x4"
         preemptible: 1
+        noAddress: true
     }
     output {
         File   filtered_fasta    = out_fname
@@ -964,6 +969,7 @@ task filter_sequences_to_list {
         disk: "~{disk_size} GB" # TES
         dx_instance_type: "mem1_ssd1_v2_x4"
         preemptible: 1
+        noAddress: true
     }
     output {
         File   filtered_fasta    = out_fname
@@ -1056,6 +1062,7 @@ task mafft_one_chr {
         disk: "~{disk_size} GB" # TES
         preemptible: 0
         dx_instance_type: "mem3_ssd1_v2_x36"
+        noAddress: true
     }
     output {
         File   aligned_sequences = "~{basename}_aligned.fasta"
@@ -1163,6 +1170,7 @@ task mafft_one_chr_chunked {
         disk: "~{disk_size} GB" # TES
         preemptible: 0
         dx_instance_type: "mem3_ssd1_v2_x36"
+        noAddress: true
     }
     output {
         File   aligned_sequences = "~{basename}_aligned.fasta"
@@ -1213,6 +1221,7 @@ task augur_mafft_align {
         disk: "~{disk_size} GB" # TES
         preemptible: 0
         dx_instance_type: "mem3_ssd2_v2_x32"
+        noAddress: true
     }
     output {
         File   aligned_sequences = "~{basename}_aligned.fasta"
@@ -1243,6 +1252,7 @@ task snp_sites {
         disk: "~{disk_size} GB" # TES
         preemptible: 0
         dx_instance_type: "mem3_ssd1_v2_x4"
+        noAddress: true
     }
     output {
         File   snps_vcf          = "~{out_basename}.vcf"
@@ -1291,6 +1301,7 @@ task augur_mask_sites {
         disk: "~{disk_size} GB" # TES
         preemptible: 1
         dx_instance_type: "mem1_ssd1_v2_x4"
+        noAddress: true
     }
     output {
         File   masked_sequences = out_fname
@@ -1349,6 +1360,7 @@ task draft_augur_tree {
         disk: "~{disk_size} GB" # TES
         dx_instance_type: "mem1_ssd1_v2_x36"
         preemptible: 0
+        noAddress: true
     }
     output {
         File   aligned_tree  = "~{out_basename}_~{method}.nwk"
@@ -1433,6 +1445,7 @@ task refine_augur_tree {
         disk: "~{disk_size} GB" # TES
         dx_instance_type: "mem3_ssd1_v2_x8"
         preemptible: 0
+        noAddress: true
     }
     output {
         File   tree_refined   = "~{out_basename}_timetree.nwk"
@@ -1485,6 +1498,7 @@ task ancestral_traits {
         disk: "~{disk_size} GB" # TES
         dx_instance_type: "mem3_ssd1_v2_x4"
         preemptible: 1
+        noAddress: true
     }
     output {
         File   node_data_json = "~{out_basename}_ancestral_traits.json"
@@ -1548,6 +1562,7 @@ task ancestral_tree {
         disk: "~{disk_size} GB" # TES
         dx_instance_type: "mem3_ssd1_v2_x8"
         preemptible: 0
+        noAddress: true
     }
     output {
         File   nt_muts_json  = "~{out_basename}_nt_muts.json"
@@ -1596,6 +1611,7 @@ task translate_augur_tree {
         disk: "~{disk_size} GB" # TES
         dx_instance_type: "mem1_ssd1_v2_x2"
         preemptible: 1
+        noAddress: true
     }
     output {
         File   aa_muts_json = "~{out_basename}_aa_muts.json"
@@ -1666,6 +1682,7 @@ task tip_frequencies {
         disk: "~{disk_size} GB" # TES
         dx_instance_type: "mem3_ssd2_x4"
         preemptible: 1
+        noAddress: true
     }
     output {
         File   node_data_json = "~{out_basename}_tip-frequencies.json"
@@ -1710,6 +1727,7 @@ task assign_clades_to_nodes {
         disk: "~{disk_size} GB" # TES
         dx_instance_type: "mem1_ssd1_v2_x2"
         preemptible: 1
+        noAddress: true
     }
     output {
         File   node_clade_data_json = "~{out_basename}_clades.json"
@@ -1758,6 +1776,7 @@ task augur_import_beast {
         disk: "~{disk_size} GB" # TES
         dx_instance_type: "mem1_ssd1_v2_x2"
         preemptible: 1
+        noAddress: true
     }
     output {
         File   tree_newick    = "~{tree_basename}.nwk"
@@ -1860,6 +1879,7 @@ task export_auspice_json {
         disk: "~{disk_size} GB" # TES
         dx_instance_type: "mem3_ssd1_v2_x8"
         preemptible: 0
+        noAddress: true
     }
     output {
         File   virus_json         = "~{out_basename}_auspice.json"

--- a/pipes/WDL/tasks/tasks_read_utils.wdl
+++ b/pipes/WDL/tasks/tasks_read_utils.wdl
@@ -22,6 +22,7 @@ task max {
     disks: "local-disk ~{disk_size} HDD"
     disk: "~{disk_size} GB" # TES
     dx_instance_type: "mem1_ssd1_v2_x2"
+    noAddress: true
   }
 }
 
@@ -76,6 +77,7 @@ task group_bams_by_sample {
     disks: "local-disk ~{disk_size} HDD"
     disk: "~{disk_size} GB" # TES
     dx_instance_type: "mem1_ssd1_v2_x2"
+    noAddress: true
   }
 }
 
@@ -98,6 +100,7 @@ task get_bam_samplename {
     disks: "local-disk ~{disk_size} HDD"
     disk: "~{disk_size} GB" # TES
     dx_instance_type: "mem1_ssd1_v2_x2"
+    noAddress: true
   }
   output {
     String sample_name = read_string("SAMPLE_NAME")
@@ -153,6 +156,7 @@ task get_sample_meta {
     disks: "local-disk ~{disk_size} HDD"
     disk: "~{disk_size} GB" # TES
     dx_instance_type: "mem1_ssd1_v2_x2"
+    noAddress: true
   }
 }
 
@@ -225,6 +229,7 @@ task merge_and_reheader_bams {
         disk: "~{disk_size} GB" # TES
         dx_instance_type: "mem1_ssd2_v2_x4"
         preemptible: 0
+        noAddress: true
     }
 }
 
@@ -306,6 +311,7 @@ task rmdup_ubam {
     disks: "local-disk ~{disk_size} LOCAL"
     disk: "~{disk_size} GB" # TES
     dx_instance_type: "mem2_ssd1_v2_x2"
+    noAddress: true
   }
 }
 
@@ -410,6 +416,7 @@ task bbnorm_bam {
     disks: "local-disk ~{disk_size} LOCAL"
     disk: "~{disk_size} GB" # TES
     dx_instance_type: "mem2_ssd1_v2_x8"
+    noAddress: true
   }
 }
 
@@ -471,6 +478,7 @@ task downsample_bams {
     disk: "~{disk_size} GB" # TES
     dx_instance_type: "mem1_ssd1_v2_x4"
     maxRetries: 2
+    noAddress: true
   }
 }
 
@@ -535,6 +543,7 @@ task FastqToUBAM {
     disks: "local-disk ~{disk_size} LOCAL"
     disk: "~{disk_size} GB" # TES
     dx_instance_type: "mem1_ssd1_v2_x2"
+    noAddress: true
   }
   output {
     File unmapped_bam = "~{sample_name}.bam"
@@ -565,5 +574,6 @@ task read_depths {
     disks: "local-disk ~{disk_size} HDD"
     disk: "~{disk_size} GB" # TES
     dx_instance_type: "mem1_ssd1_v2_x2"
+    noAddress: true
   }
 }

--- a/pipes/WDL/tasks/tasks_reports.wdl
+++ b/pipes/WDL/tasks/tasks_reports.wdl
@@ -118,6 +118,7 @@ task alignment_metrics {
     disks: "local-disk ~{disk_size} HDD"
     disk: "~{disk_size} GB" # TES
     dx_instance_type: "mem3_ssd1_v2_x4"
+    noAddress: true
   }
 }
 
@@ -217,6 +218,7 @@ task plot_coverage {
     disk: "~{disk_size} GB" # TES
     dx_instance_type: "mem1_ssd1_v2_x4"
     preemptible: 1
+    noAddress: true
   }
 }
 
@@ -278,6 +280,7 @@ task merge_coverage_per_position {
     disks: "local-disk ~{disk_size} HDD"
     disk: "~{disk_size} GB" # TES
     dx_instance_type: "mem1_ssd2_v2_x4"
+    noAddress: true
   }
 }
 
@@ -320,6 +323,7 @@ task coverage_report {
     disks: "local-disk ~{disk_size} HDD"
     disk: "~{disk_size} GB" # TES
     dx_instance_type: "mem1_ssd2_v2_x4"
+    noAddress: true
   }
 }
 
@@ -353,6 +357,7 @@ task assembly_bases {
         disks: "local-disk ~{disk_size} HDD"
         disk: "~{disk_size} GB" # TES
         dx_instance_type: "mem1_ssd1_v2_x2"
+        noAddress: true
     }
 }
 
@@ -392,6 +397,7 @@ task fastqc {
     disks: "local-disk ~{disk_size} SSD"
     disk: "~{disk_size} GB" # TES
     dx_instance_type: "mem1_ssd1_v2_x2"
+    noAddress: true
   }
 }
 
@@ -509,6 +515,7 @@ task align_and_count {
     disks: "local-disk ~{disk_size} HDD"
     disk: "~{disk_size} GB" # TES
     dx_instance_type: "mem1_ssd1_v2_x4"
+    noAddress: true
   }
 }
 
@@ -542,6 +549,7 @@ task align_and_count_summary {
     disks: "local-disk ~{disk_size} HDD"
     disk: "~{disk_size} GB" # TES
     dx_instance_type: "mem1_ssd1_v2_x2"
+    noAddress: true
   }
 }
 
@@ -591,6 +599,7 @@ task aggregate_metagenomics_reports {
     disk: "~{disk_size} GB" # TES
     dx_instance_type: "mem1_ssd2_v2_x2"
     preemptible: 0
+    noAddress: true
   }
 }
 
@@ -702,6 +711,7 @@ task MultiQC {
     disks: "local-disk ~{disk_size} HDD"
     disk: "~{disk_size} GB" # TES
     dx_instance_type: "mem2_ssd1_v2_x2"
+    noAddress: true
   }
 }
 
@@ -893,6 +903,7 @@ task multiqc_from_bams {
     disks: "local-disk ~{disk_size} HDD"
     disk: "~{disk_size} GB" # TES
     dx_instance_type: "mem1_ssd1_v2_x8"
+    noAddress: true
   }
 }
 
@@ -933,6 +944,7 @@ task compare_two_genomes {
     disk: "~{disk_size} GB" # TES
     dx_instance_type: "mem1_ssd1_v2_x2"
     preemptible: 1
+    noAddress: true
   }
 }
 

--- a/pipes/WDL/tasks/tasks_sarscov2.wdl
+++ b/pipes/WDL/tasks/tasks_sarscov2.wdl
@@ -222,6 +222,7 @@ task sequencing_report {
         disk: "~{disk_size} GB" # TES
         dx_instance_type: "mem1_ssd1_v2_x2"
         maxRetries: 2
+        noAddress: true
     }
     output {
         Array[File] reports = glob("*.pdf")
@@ -380,6 +381,7 @@ task sc2_meta_final {
         disk: "~{disk_size} GB" # TES
         dx_instance_type: "mem1_ssd1_v2_x2"
         maxRetries: 2
+        noAddress: true
     }
     output {
         File meta_tsv = "~{out_basename}.final.tsv"
@@ -551,6 +553,7 @@ task crsp_meta_etl {
         disk: "~{disk_size} GB" # TES
         dx_instance_type: "mem1_ssd1_v2_x2"
         maxRetries: 2
+        noAddress: true
     }
     output {
         File          biosample_submit_tsv = "biosample_meta_submit-~{out_basename}.tsv"

--- a/pipes/WDL/tasks/tasks_taxon_filter.wdl
+++ b/pipes/WDL/tasks/tasks_taxon_filter.wdl
@@ -128,6 +128,7 @@ task deplete_taxa {
     disk: "~{disk_size} GB" # TES
     dx_instance_type: "mem1_ssd1_v2_x8"
     preemptible: preemptible_tries
+    noAddress: true
   }
 }
 
@@ -188,6 +189,7 @@ task filter_to_taxon {
     disks: "local-disk ~{disk_size} LOCAL"
     disk: "~{disk_size} GB" # TES
     dx_instance_type: "mem1_ssd1_v2_x8"
+    noAddress: true
   }
 }
 
@@ -224,6 +226,7 @@ task build_lastal_db {
     disks: "local-disk ~{disk_size} LOCAL"
     disk: "~{disk_size} GB" # TES
     dx_instance_type: "mem1_ssd1_v2_x4"
+    noAddress: true
   }
 }
 
@@ -274,5 +277,6 @@ task merge_one_per_sample {
     disks: "local-disk ~{disk_size} LOCAL"
     disk: "~{disk_size} GB" # TES
     dx_instance_type: "mem1_ssd2_v2_x4"
+    noAddress: true
   }
 }

--- a/pipes/WDL/tasks/tasks_utils.wdl
+++ b/pipes/WDL/tasks/tasks_utils.wdl
@@ -20,6 +20,7 @@ task concatenate {
         disks: "local-disk ~{disk_size} HDD"
         disk: "~{disk_size} GB" # TES
         dx_instance_type: "mem1_ssd1_v2_x2"
+        noAddress: true
     }
     output {
         File combined = "~{output_name}"
@@ -299,6 +300,7 @@ task zcat {
         disks: "local-disk ~{disk_size} LOCAL"
         disk: "~{disk_size} GB" # TES
         dx_instance_type: "mem1_ssd1_v2_x2"
+        noAddress: true
     }
     output {
         File    combined     = "${output_name}"
@@ -329,6 +331,7 @@ task sed {
         disks: "local-disk ~{disk_size} LOCAL"
         disk: "~{disk_size} GB" # TES
         dx_instance_type: "mem1_ssd1_v2_x2"
+        noAddress: true
     }
     output {
         File outfile = "~{outfilename}"
@@ -357,6 +360,7 @@ task tar_extract {
         disk: "~{disk_size} GB" # TES
         dx_instance_type: "mem1_ssd1_v2_x2"
         preemptible: 2
+        noAddress: true
     }
     output {
         Array[File] files = glob("unpack/*")
@@ -566,6 +570,7 @@ task sanitize_fasta_headers {
     disks: "local-disk ~{disk_size} LOCAL"
     disk: "~{disk_size} GB" # TES
     dx_instance_type: "mem1_ssd1_v2_x2"
+    noAddress: true
   }
 }
 
@@ -588,6 +593,7 @@ task fasta_to_ids {
         disks: "local-disk ~{disk_size} LOCAL"
         disk: "~{disk_size} GB" # TES
         dx_instance_type: "mem1_ssd1_v2_x2"
+        noAddress: true
     }
     output {
         File ids_txt = "~{basename}.txt"
@@ -612,6 +618,7 @@ task md5sum {
     disks: "local-disk ~{disk_size} HDD"
     disk: "~{disk_size} GB" # TES
     dx_instance_type: "mem1_ssd2_v2_x2"
+    noAddress: true
   }
 }
 
@@ -641,6 +648,7 @@ task json_dict_to_tsv {
     memory: "1 GB"
     cpu: 1
     dx_instance_type: "mem1_ssd1_v2_x2"
+    noAddress: true
   }
 }
 
@@ -684,6 +692,7 @@ task fetch_row_from_tsv {
     disk: "~{disk_size} GB" # TES
     disks: "local-disk 50 HDD"
     dx_instance_type: "mem1_ssd1_v2_x2"
+    noAddress: true
   }
 }
 
@@ -723,6 +732,7 @@ task fetch_col_from_tsv {
     disks: "local-disk ~{disk_size} HDD"
     disk: "~{disk_size} GB" # TES
     dx_instance_type: "mem1_ssd1_v2_x2"
+    noAddress: true
   }
 }
 
@@ -852,6 +862,7 @@ task tsv_join {
     disks: "local-disk ~{disk_size} HDD"
     disk: "~{disk_size} GB" # TES
     dx_instance_type: "mem1_ssd1_v2_x4"
+    noAddress: true
   }
 }
 
@@ -887,6 +898,7 @@ task tsv_to_csv {
     disks: "local-disk ~{disk_size} HDD"
     disk: "~{disk_size} GB" # TES
     dx_instance_type: "mem1_ssd1_v2_x2"
+    noAddress: true
   }
 }
 
@@ -921,6 +933,7 @@ task tsv_drop_cols {
         disks: "local-disk ~{disk_size} HDD"
         disk: "~{disk_size} GB" # TES
         dx_instance_type: "mem1_ssd1_v2_x2"
+        noAddress: true
     }
     output {
         File out_tsv = "~{out_filename}"
@@ -955,6 +968,7 @@ task tsv_stack {
     disks: "local-disk ~{disk_size} HDD"
     disk: "~{disk_size} GB" # TES
     dx_instance_type: "mem1_ssd1_v2_x2"
+    noAddress: true
   }
 }
 
@@ -983,6 +997,7 @@ task cat_except_headers {
     disks: "local-disk ~{disk_size} HDD"
     disk: "~{disk_size} GB" # TES
     dx_instance_type: "mem1_ssd1_v2_x2"
+    noAddress: true
   }
 }
 task make_empty_file {
@@ -1003,6 +1018,7 @@ task make_empty_file {
     disks: "local-disk ~{disk_size} HDD"
     disk: "~{disk_size} GB" # TES
     dx_instance_type: "mem1_ssd1_v2_x2"
+    noAddress: true
   }
 }
 
@@ -1025,6 +1041,7 @@ task rename_file {
     disks: "local-disk ~{disk_size} HDD"
     disk: "~{disk_size} GB" # TES
     dx_instance_type: "mem1_ssd1_v2_x2"
+    noAddress: true
   }
 }
 
@@ -1044,6 +1061,7 @@ task raise {
     disks:  "local-disk 30 HDD"
     disk: "30 GB" # TES
     dx_instance_type: "mem1_ssd1_v2_x2"
+    noAddress: true
   }
 }
 
@@ -1073,6 +1091,7 @@ task unique_strings {
     disks: "local-disk ~{disk_size} HDD"
     disk: "~{disk_size} GB" # TES
     dx_instance_type: "mem1_ssd1_v2_x2"
+    noAddress: true
   }
 }
 
@@ -1094,6 +1113,7 @@ task unique_arrays {
     disks: "local-disk ~{disk_size} HDD"
     disk: "~{disk_size} GB" # TES
     dx_instance_type: "mem1_ssd1_v2_x2"
+    noAddress: true
   }
 }
 
@@ -1120,6 +1140,7 @@ task today {
     disk: "~{disk_size} GB" # TES
     dx_instance_type: "mem1_ssd1_v2_x2"
     maxRetries: 2
+    noAddress: true
   }
 }
 
@@ -1183,6 +1204,7 @@ task string_split {
     cpu: 1
     disks: "local-disk 50 SSD"
     disk: "50 GB" # TES
+    noAddress: true
   }
 }
 
@@ -1238,6 +1260,7 @@ task filter_sequences_by_length {
         disks: "local-disk ~{disk_size} HDD"
         disk: "~{disk_size} GB" # TES
         dx_instance_type: "mem1_ssd1_v2_x2"
+        noAddress: true
     }
     output {
         File filtered_fasta    = out_fname
@@ -1270,5 +1293,6 @@ task pair_files_by_basename {
     disks:  "local-disk ~{disk_gb} HDD"
     disk: "~{disk_gb} GB" # TES
     dx_instance_type: "mem1_ssd1_v2_x2"
+    noAddress: true
   }
 }


### PR DESCRIPTION
## Summary
- Adds `noAddress: true` to the `runtime` block of all WDL tasks that do not require internet access
- This Cromwell/Terra runtime attribute indicates the task VM does not need a public IP address, improving security and reducing costs
- Tasks that require network access (NCBI downloads/uploads, Terra API calls, Nextstrain dataset fetches, GISAID uploads, etc.) are left unchanged

## Test plan
- [ ] Verify `miniwdl check` passes on all edited files
- [ ] Verify tasks that need network do NOT have `noAddress: true`
- [ ] Run CI validation (womtool + miniwdl check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)