### PR TITLE
Adjust preemptible settings for assembly/metagenomics tasks

### DIFF
--- a/pipes/WDL/tasks/tasks_assembly.wdl
+++ b/pipes/WDL/tasks/tasks_assembly.wdl
@@ -196,7 +196,7 @@ task select_references {
     disks: "local-disk ~{disk_size} SSD"
     disk: "~{disk_size} GB" # TESs
     dx_instance_type: "mem1_ssd1_v2_x2"
-    preemptible: 2
+    preemptible: 3
   }
 }
 
@@ -858,7 +858,7 @@ task align_reads {
     disks: "local-disk ~{disk_size} LOCAL"
     disk: "~{disk_size} GB" # TES
     dx_instance_type: "mem1_ssd1_v2_x8"
-    preemptible: 1
+    preemptible: 3
   }
 }
 
@@ -1119,7 +1119,6 @@ task run_discordance {
         disks: "local-disk ~{disk_size} HDD"
         disk: "~{disk_size} GB" # TES
         dx_instance_type: "mem1_ssd1_v2_x2"
-        preemptible: 1
     }
 }
 

--- a/pipes/WDL/tasks/tasks_metagenomics.wdl
+++ b/pipes/WDL/tasks/tasks_metagenomics.wdl
@@ -336,7 +336,7 @@ task kraken2 {
     disks: "local-disk ~{disk_size} LOCAL"
     disk: "~{disk_size} GB" # TESs
     dx_instance_type: "mem3_ssd1_v2_x8"
-    preemptible: 2
+    preemptible: 3
   }
 }
 
@@ -384,7 +384,6 @@ task report_primary_kraken_taxa {
     disks: "local-disk ~{disk_size} HDD"
     disk: "~{disk_size} GB" # TESs
     dx_instance_type: "mem1_ssd1_v2_x2"
-    preemptible: 2
   }
 }
 
@@ -863,7 +862,7 @@ task filter_bam_to_taxa {
     disk: "~{disk_size} GB" # TES
     cpu: 8
     dx_instance_type: "mem1_ssd1_v2_x8"
-    preemptible: 1
+    preemptible: 3
   }
 }
 

--- a/pipes/WDL/tasks/tasks_reports.wdl
+++ b/pipes/WDL/tasks/tasks_reports.wdl
@@ -216,7 +216,6 @@ task plot_coverage {
     disks: "local-disk ~{disk_size} HDD"
     disk: "~{disk_size} GB" # TES
     dx_instance_type: "mem1_ssd1_v2_x4"
-    preemptible: 1
   }
 }
 

--- a/pipes/WDL/tasks/tasks_utils.wdl
+++ b/pipes/WDL/tasks/tasks_utils.wdl
@@ -356,7 +356,6 @@ task tar_extract {
         disks: "local-disk ~{disk_size} HDD"
         disk: "~{disk_size} GB" # TES
         dx_instance_type: "mem1_ssd1_v2_x2"
-        preemptible: 2
     }
     output {
         Array[File] files = glob("unpack/*")


### PR DESCRIPTION
## Summary

- Bump preemptible from 1-2 to 3 on expensive tasks: align_reads, kraken2, filter_bam_to_taxa, select_references
- Remove preemptible entirely from cheap/fast tasks: run_discordance, report_primary_kraken_taxa, plot_coverage, tar_extract

## Motivation

Preemptible VMs on Terra/Cromwell no longer automatically fall back to non-preemptible VMs after exhausting attempts -- they just fail. With values of 1-2, we were seeing hard failures on preemption. We cannot use maxRetries as a fallback mechanism either, since it disables Cromwell call caching entirely (see #641).

For expensive tasks, bumping to 3 gives more chances to land a preemptible VM while keeping cost savings. For trivial tasks, the cost savings from preemptible are negligible so we remove it to avoid unnecessary failure risk.

Demux tasks were already set to preemptible: 0 and are unchanged.

## Test plan

- [x] miniwdl check passes on assemble_refbased and assemble_denovo_metagenomic workflows
- [ ] Monitor next Terra submissions for reduced preemption failures

Generated with [Claude Code](https://claude.ai/code)