### PR TITLE
bump docker images

### DIFF
--- a/pipes/WDL/tasks/tasks_assembly.wdl
+++ b/pipes/WDL/tasks/tasks_assembly.wdl
@@ -16,7 +16,7 @@ task assemble {
       
       Int?     machine_mem_gb
       Int?     cpu
-      String   docker = "quay.io/broadinstitute/viral-ngs:3.0.11-assemble"
+      String   docker = "quay.io/broadinstitute/viral-ngs:3.0.13-assemble"
     }
     parameter_meta{
       reads_unmapped_bam: {
@@ -124,7 +124,7 @@ task select_references {
     Int?          skani_c
     Int?          skani_n
 
-    String        docker = "quay.io/broadinstitute/viral-ngs:3.0.11-assemble"
+    String        docker = "quay.io/broadinstitute/viral-ngs:3.0.13-assemble"
     Int           machine_mem_gb = 4
     Int           cpu = 2
     Int           disk_size = 100
@@ -223,7 +223,7 @@ task scaffold {
       Float?       scaffold_min_pct_contig_aligned
 
       Int?         machine_mem_gb
-      String       docker="quay.io/broadinstitute/viral-ngs:3.0.11-assemble"
+      String       docker="quay.io/broadinstitute/viral-ngs:3.0.13-assemble"
 
       # do this in multiple steps in case the input doesn't actually have "assembly1-x" in the name
       String       sample_name = basename(basename(contigs_fasta, ".fasta"), ".assembly1-spades")
@@ -475,7 +475,7 @@ task skani_triangle {
     Int     compression_factor = 10
     Int     min_aligned_frac = 15
 
-    String  docker = "quay.io/broadinstitute/viral-ngs:3.0.11-assemble"
+    String  docker = "quay.io/broadinstitute/viral-ngs:3.0.13-assemble"
     Int     machine_mem_gb = 8
     Int     cpu = 4
     Int     disk_size = 100
@@ -636,7 +636,7 @@ task ivar_trim_stats {
       String out_basename = "ivar_trim_stats"
       String flowcell = ""
 
-      String docker = "quay.io/broadinstitute/py3-bio:0.1.5"
+      String docker = "quay.io/broadinstitute/py3-bio:0.1.7"
     }
     parameter_meta {
       ivar_trim_stats_tsv: {
@@ -715,7 +715,7 @@ task align_reads {
 
     Int?     cpu
     Int?     machine_mem_gb
-    String   docker = "quay.io/broadinstitute/viral-ngs:3.0.11-core"
+    String   docker = "quay.io/broadinstitute/viral-ngs:3.0.13-core"
 
     String   sample_name = basename(basename(basename(reads_unmapped_bam, ".bam"), ".taxfilt"), ".clean")
   }
@@ -879,7 +879,7 @@ task refine_assembly_with_aligned_reads {
       Int?     max_coverage = 4000
 
       Int      machine_mem_gb = 8
-      String   docker = "quay.io/broadinstitute/viral-ngs:3.0.11-assemble"
+      String   docker = "quay.io/broadinstitute/viral-ngs:3.0.13-assemble"
     }
 
     Int disk_size = 375
@@ -1021,7 +1021,7 @@ task run_discordance {
       Int    min_coverage = 4
 
       Int    machine_mem_gb = 4
-      String docker = "quay.io/broadinstitute/viral-ngs:3.0.11-core"
+      String docker = "quay.io/broadinstitute/viral-ngs:3.0.13-core"
     }
     parameter_meta {
       reads_aligned_bam: {
@@ -1267,7 +1267,7 @@ task wgsim {
         Int?   random_seed
 
         Int    machine_mem_gb = 7
-        String docker = "quay.io/broadinstitute/viral-ngs:3.0.11-assemble"
+        String docker = "quay.io/broadinstitute/viral-ngs:3.0.13-assemble"
     }
 
     parameter_meta {

--- a/pipes/WDL/tasks/tasks_demux.wdl
+++ b/pipes/WDL/tasks/tasks_demux.wdl
@@ -6,7 +6,7 @@ task merge_tarballs {
     String       out_filename
 
     Int?         machine_mem_gb
-    String       docker = "quay.io/broadinstitute/viral-ngs:3.0.11-core"
+    String       docker = "quay.io/broadinstitute/viral-ngs:3.0.13-core"
   }
 
   Int disk_size = 2625
@@ -97,7 +97,7 @@ task revcomp_i5 {
   input {
     File    old_sheet
     Boolean revcomp=true
-    String  docker = "quay.io/broadinstitute/py3-bio:0.1.5"
+    String  docker = "quay.io/broadinstitute/py3-bio:0.1.7"
   }
   String new_base = basename(basename(old_sheet, '.txt'), '.tsv')
   Int disk_size = 50
@@ -179,7 +179,7 @@ task illumina_demux {
     Int?    machine_mem_gb
     # Note: GCP local SSDs must be allocated in pairs (2, 4, 8, 16, 24 × 375GB), so use 3000 (8 SSDs) instead of 2625 (7 SSDs)
     Int     disk_size = 3000
-    String  docker    = "quay.io/broadinstitute/viral-ngs:3.0.11-core"
+    String  docker    = "quay.io/broadinstitute/viral-ngs:3.0.13-core"
   }
 
   parameter_meta {
@@ -817,7 +817,7 @@ task get_illumina_run_metadata {
     String? sequencing_center
 
     Int?   machine_mem_gb
-    String docker = "quay.io/broadinstitute/viral-ngs:3.0.11-core"
+    String docker = "quay.io/broadinstitute/viral-ngs:3.0.13-core"
   }
 
   parameter_meta {
@@ -920,7 +920,7 @@ task demux_fastqs {
     Int?    machine_mem_gb
     Int     max_cpu = 32       # Maximum CPU cap for autoscaling (use 16 for 2-barcode, 64 for 3-barcode)
     Int     disk_size = 750
-    String  docker = "quay.io/broadinstitute/viral-ngs:3.0.11-core"
+    String  docker = "quay.io/broadinstitute/viral-ngs:3.0.13-core"
   }
 
   # Calculate total input size for autoscaling
@@ -1048,7 +1048,7 @@ task merge_demux_metrics {
   input {
     Array[File]+ metrics_files
     String       output_filename = "merged_demux_metrics.txt"
-    String       docker = "quay.io/broadinstitute/viral-ngs:3.0.11-core"
+    String       docker = "quay.io/broadinstitute/viral-ngs:3.0.13-core"
   }
 
   parameter_meta {

--- a/pipes/WDL/tasks/tasks_interhost.wdl
+++ b/pipes/WDL/tasks/tasks_interhost.wdl
@@ -160,7 +160,7 @@ task multi_align_mafft_ref {
     Float?       mafft_gapOpeningPenalty
 
     Int?         machine_mem_gb
-    String       docker = "quay.io/broadinstitute/viral-ngs:3.0.11-phylo"
+    String       docker = "quay.io/broadinstitute/viral-ngs:3.0.13-phylo"
   }
 
   String         fasta_basename = basename(reference_fasta, '.fasta')
@@ -206,7 +206,7 @@ task multi_align_mafft {
     Float?       mafft_gapOpeningPenalty
 
     Int?         machine_mem_gb
-    String       docker = "quay.io/broadinstitute/viral-ngs:3.0.11-phylo"
+    String       docker = "quay.io/broadinstitute/viral-ngs:3.0.13-phylo"
   }
 
   Int disk_size = 200
@@ -348,7 +348,7 @@ task index_ref {
     File?  novocraft_license
 
     Int?   machine_mem_gb
-    String docker = "quay.io/broadinstitute/viral-ngs:3.0.11-core"
+    String docker = "quay.io/broadinstitute/viral-ngs:3.0.13-core"
   }
 
   Int disk_size = 100
@@ -470,7 +470,7 @@ task merge_vcfs_gatk {
     File        ref_fasta
 
     Int?        machine_mem_gb
-    String      docker = "quay.io/broadinstitute/viral-ngs:3.0.11-phylo"
+    String      docker = "quay.io/broadinstitute/viral-ngs:3.0.13-phylo"
 
     String      output_prefix = "merged"
   }

--- a/pipes/WDL/tasks/tasks_intrahost.wdl
+++ b/pipes/WDL/tasks/tasks_intrahost.wdl
@@ -138,7 +138,7 @@ task lofreq {
     Int       cpu = 4
 
     String    out_basename = basename(aligned_bam, '.bam')
-    String    docker = "quay.io/broadinstitute/viral-ngs:3.0.11-phylo"
+    String    docker = "quay.io/broadinstitute/viral-ngs:3.0.13-phylo"
   }
   Int disk_size = ceil(5 * size(aligned_bam, "GB") + 50)
   command <<<
@@ -215,7 +215,7 @@ task isnvs_per_sample {
     Boolean removeDoublyMappedReads = true
 
     Int?    machine_mem_gb
-    String  docker = "quay.io/broadinstitute/viral-ngs:3.0.11-phylo"
+    String  docker = "quay.io/broadinstitute/viral-ngs:3.0.13-phylo"
 
     String  sample_name = basename(basename(basename(mapped_bam, ".bam"), ".all"), ".mapped")
   }
@@ -257,7 +257,7 @@ task isnvs_vcf {
     Boolean        naiveFilter = false
 
     Int?           machine_mem_gb
-    String         docker = "quay.io/broadinstitute/viral-ngs:3.0.11-phylo"
+    String         docker = "quay.io/broadinstitute/viral-ngs:3.0.13-phylo"
   }
 
   parameter_meta {
@@ -330,7 +330,7 @@ task annotate_vcf_snpeff {
     String?        emailAddress
 
     Int?           machine_mem_gb
-    String         docker = "quay.io/broadinstitute/viral-ngs:3.0.11-phylo"
+    String         docker = "quay.io/broadinstitute/viral-ngs:3.0.13-phylo"
 
     String         output_basename = basename(basename(in_vcf, ".gz"), ".vcf")
   }

--- a/pipes/WDL/tasks/tasks_megablast.wdl
+++ b/pipes/WDL/tasks/tasks_megablast.wdl
@@ -15,7 +15,7 @@ task trim_rmdup_subsamp {
         Int cpu            = 16
         Int disk_size_gb   = 100 
 
-        String docker      = "quay.io/broadinstitute/viral-ngs:3.0.11-core"
+        String docker      = "quay.io/broadinstitute/viral-ngs:3.0.13-core"
     }
 
     parameter_meta {
@@ -75,7 +75,7 @@ task lca_megablast {
         Int     cpu            = 16
         Int     disk_size_gb   = 300
 
-        String  docker         = "quay.io/broadinstitute/viral-ngs:3.0.11-classify"
+        String  docker         = "quay.io/broadinstitute/viral-ngs:3.0.13-classify"
     }
     parameter_meta {
         trimmed_fasta: {

--- a/pipes/WDL/tasks/tasks_metagenomics.wdl
+++ b/pipes/WDL/tasks/tasks_metagenomics.wdl
@@ -216,7 +216,7 @@ task kraken2 {
     Int?   min_base_qual
 
     Int    machine_mem_gb = 90
-    String docker = "quay.io/broadinstitute/viral-ngs:3.0.11-classify"
+    String docker = "quay.io/broadinstitute/viral-ngs:3.0.13-classify"
   }
 
   parameter_meta {
@@ -348,7 +348,7 @@ task report_primary_kraken_taxa {
     File          kraken_summary_report
     String        focal_taxon = "Viruses"
 
-    String        docker = "quay.io/broadinstitute/viral-ngs:3.0.11-classify"
+    String        docker = "quay.io/broadinstitute/viral-ngs:3.0.13-classify"
   }
   String out_basename = basename(kraken_summary_report, '.txt')
   Int disk_size = 50
@@ -397,7 +397,7 @@ task filter_refs_to_found_taxa {
     File          taxdump_tgz
     Int           min_read_count = 100
 
-    String        docker = "quay.io/broadinstitute/viral-ngs:3.0.11-classify"
+    String        docker = "quay.io/broadinstitute/viral-ngs:3.0.13-classify"
   }
   String ref_basename = basename(taxid_to_ref_accessions_tsv, '.tsv')
   String hits_basename = basename(focal_report_tsv, '.tsv')
@@ -447,7 +447,7 @@ task build_kraken2_db {
     Int?          zstd_compression_level
 
     Int           machine_mem_gb = 100
-    String        docker = "quay.io/broadinstitute/viral-ngs:3.0.11-classify"
+    String        docker = "quay.io/broadinstitute/viral-ngs:3.0.13-classify"
   }
 
   Int disk_size = 750
@@ -588,7 +588,7 @@ task blastx {
     File   krona_taxonomy_db_tgz
 
     Int    machine_mem_gb = 8
-    String docker = "quay.io/broadinstitute/viral-ngs:3.0.11-classify"
+    String docker = "quay.io/broadinstitute/viral-ngs:3.0.13-classify"
   }
 
   parameter_meta {
@@ -677,7 +677,7 @@ task krona {
     Int?         magnitude_column
 
     Int          machine_mem_gb = 3
-    String       docker = "quay.io/broadinstitute/viral-ngs:3.0.11-classify"
+    String       docker = "quay.io/broadinstitute/viral-ngs:3.0.13-classify"
   }
 
   Int disk_size = 50
@@ -782,7 +782,7 @@ task filter_bam_to_taxa {
     String         out_filename_suffix = "filtered"
 
     Int            machine_mem_gb = 8
-    String         docker = "quay.io/broadinstitute/viral-ngs:3.0.11-classify"
+    String         docker = "quay.io/broadinstitute/viral-ngs:3.0.13-classify"
   }
 
   String out_basename = basename(classified_bam, ".bam") + "." + out_filename_suffix
@@ -874,7 +874,7 @@ task kaiju {
     File   krona_taxonomy_db_tgz  # taxonomy/taxonomy.tab
 
     Int    machine_mem_gb = 100
-    String docker = "quay.io/broadinstitute/viral-ngs:3.0.11-classify"
+    String docker = "quay.io/broadinstitute/viral-ngs:3.0.13-classify"
   }
 
   String   input_basename = basename(reads_unmapped_bam, ".bam")

--- a/pipes/WDL/tasks/tasks_ncbi.wdl
+++ b/pipes/WDL/tasks/tasks_ncbi.wdl
@@ -6,7 +6,7 @@ task download_fasta {
     Array[String]+ accessions
     String         emailAddress
 
-    String         docker = "quay.io/broadinstitute/viral-ngs:3.0.11-phylo"
+    String         docker = "quay.io/broadinstitute/viral-ngs:3.0.13-phylo"
   }
 
   command <<<
@@ -41,7 +41,7 @@ task download_fasta_from_accession_string {
     String out_prefix
     String emailAddress
 
-    String docker = "quay.io/broadinstitute/viral-ngs:3.0.11-phylo"
+    String docker = "quay.io/broadinstitute/viral-ngs:3.0.13-phylo"
   }
 
   command <<<
@@ -92,7 +92,7 @@ task download_annotations {
     String         emailAddress
     String         combined_out_prefix
 
-    String         docker = "quay.io/broadinstitute/viral-ngs:3.0.11-phylo"
+    String         docker = "quay.io/broadinstitute/viral-ngs:3.0.13-phylo"
   }
 
   command <<<
@@ -133,7 +133,7 @@ task download_ref_genomes_from_tsv {
     File      ref_genomes_tsv    # [tax_id, isolate_prefix, taxname, colon_delim_accession_list]
     String    emailAddress
 
-    String    docker = "quay.io/broadinstitute/viral-ngs:3.0.11-phylo"
+    String    docker = "quay.io/broadinstitute/viral-ngs:3.0.13-phylo"
   }
 
   command <<<
@@ -179,7 +179,7 @@ task sequencing_platform_from_bam {
   input {
     File    bam
 
-    String  docker = "quay.io/broadinstitute/viral-ngs:3.0.11-core"
+    String  docker = "quay.io/broadinstitute/viral-ngs:3.0.13-core"
   }
 
   command <<<
@@ -233,7 +233,7 @@ task align_and_annot_transfer_single {
 
     String       out_basename = basename(genome_fasta, '.fasta')
     Int          machine_mem_gb = 30
-    String       docker = "quay.io/broadinstitute/viral-ngs:3.0.11-phylo"
+    String       docker = "quay.io/broadinstitute/viral-ngs:3.0.13-phylo"
   }
 
   parameter_meta {
@@ -287,7 +287,7 @@ task structured_comments {
 
     File?  filter_to_ids
 
-    String docker = "quay.io/broadinstitute/viral-ngs:3.0.11-core"
+    String docker = "quay.io/broadinstitute/viral-ngs:3.0.13-core"
   }
   String out_base = basename(assembly_stats_tsv, '.txt')
   command <<<
@@ -339,7 +339,7 @@ task structured_comments_from_aligned_bam {
     String  out_basename = basename(aligned_bam, '.bam')
     Boolean is_genome_assembly = true
     Boolean sanitize_ids = true
-    String  docker = "quay.io/broadinstitute/viral-ngs:3.0.11-core"
+    String  docker = "quay.io/broadinstitute/viral-ngs:3.0.13-core"
   }
   # see https://www.ncbi.nlm.nih.gov/genbank/structuredcomment/
   command <<<
@@ -456,7 +456,7 @@ task rename_fasta_header {
 
     String out_basename = basename(genome_fasta, ".fasta")
 
-    String docker = "quay.io/broadinstitute/viral-ngs:3.0.11-core"
+    String docker = "quay.io/broadinstitute/viral-ngs:3.0.13-core"
   }
   command <<<
     set -e
@@ -618,7 +618,7 @@ task sra_meta_prep {
     Boolean     paired
 
     String      out_name = "sra_metadata.tsv"
-    String      docker="quay.io/broadinstitute/viral-ngs:3.0.11-core"
+    String      docker="quay.io/broadinstitute/viral-ngs:3.0.13-core"
   }
   Int disk_size = 100
   parameter_meta {
@@ -1079,7 +1079,7 @@ task generate_author_sbt_file {
     File?   defaults_yaml
     String  out_base = "authors"
 
-    String  docker = "quay.io/broadinstitute/py3-bio:0.1.5"
+    String  docker = "quay.io/broadinstitute/py3-bio:0.1.7"
   }
 
   parameter_meta {
@@ -1230,7 +1230,7 @@ task table2asn {
 
     String       out_basename = basename(assembly_fasta, ".fasta")
     Int          machine_mem_gb = 8
-    String       docker = "quay.io/broadinstitute/viral-ngs:3.0.11-phylo"  # this could be a simpler docker image, we don't use anything beyond table2asn itself
+    String       docker = "quay.io/broadinstitute/viral-ngs:3.0.13-phylo"  # this could be a simpler docker image, we don't use anything beyond table2asn itself
   }
   Int disk_size = 50
 
@@ -1321,7 +1321,7 @@ task package_special_genbank_ftp_submission {
     String account_name
     String wizard="BankIt_SARSCoV2_api"
 
-    String  docker = "quay.io/broadinstitute/viral-ngs:3.0.11-baseimage"
+    String  docker = "quay.io/broadinstitute/viral-ngs:3.0.13-baseimage"
   }
   command <<<
     set -e
@@ -1385,7 +1385,7 @@ task genbank_special_taxa {
     Int     taxid
     File    taxdump_tgz
     File    vadr_by_taxid_tsv # "gs://pathogen-public-dbs/viral-references/annotation/vadr/vadr-by-taxid.tsv"
-    String  docker = "quay.io/broadinstitute/viral-ngs:3.0.11-classify"
+    String  docker = "quay.io/broadinstitute/viral-ngs:3.0.13-classify"
   }
 
   command <<<

--- a/pipes/WDL/tasks/tasks_ncbi_tools.wdl
+++ b/pipes/WDL/tasks/tasks_ncbi_tools.wdl
@@ -9,7 +9,7 @@ task Fetch_SRA_to_BAM {
         String? email_address
         String? ncbi_api_key
         Int?    machine_mem_gb
-        String  docker = "quay.io/broadinstitute/ncbi-tools:2.12.0"
+        String  docker = "quay.io/broadinstitute/ncbi-tools:2.13.0"
     }
     Int disk_size = 750
     meta {
@@ -158,7 +158,7 @@ task Fetch_SRA_to_BAM {
 task fetch_genbank_metadata {
     input {
         String  genbank_accession
-        String  docker = "quay.io/broadinstitute/ncbi-tools:2.12.0"
+        String  docker = "quay.io/broadinstitute/ncbi-tools:2.13.0"
     }
     Int disk_size = 50
     command <<<
@@ -189,7 +189,7 @@ task biosample_tsv_filter_preexisting {
         File           meta_submit_tsv
 
         String         out_basename = "biosample_attributes"
-        String         docker = "quay.io/broadinstitute/ncbi-tools:2.12.0"
+        String         docker = "quay.io/broadinstitute/ncbi-tools:2.13.0"
     }
     Int disk_size = 50
     meta {
@@ -251,7 +251,7 @@ task fetch_biosamples {
         Array[String]  biosample_ids
 
         String         out_basename = "biosample_attributes"
-        String         docker = "quay.io/broadinstitute/ncbi-tools:2.12.0"
+        String         docker = "quay.io/broadinstitute/ncbi-tools:2.13.0"
     }
     Int disk_size = 50
     meta {
@@ -287,7 +287,7 @@ task ncbi_sftp_upload {
 
         String         wait_for="1"  # all, disabled, some number
 
-        String         docker = "quay.io/broadinstitute/ncbi-tools:2.12.0"
+        String         docker = "quay.io/broadinstitute/ncbi-tools:2.13.0"
     }
     Int disk_size = 100
     command <<<
@@ -333,7 +333,7 @@ task sra_tsv_to_xml {
         String   bioproject
         String   data_bucket_uri
 
-        String   docker = "quay.io/broadinstitute/ncbi-tools:2.12.0"
+        String   docker = "quay.io/broadinstitute/ncbi-tools:2.13.0"
     }
     Int disk_size = 50
     command <<<
@@ -369,7 +369,7 @@ task biosample_submit_tsv_to_xml {
         File     meta_submit_tsv
         File     config_js
 
-        String   docker = "quay.io/broadinstitute/ncbi-tools:2.12.0"
+        String   docker = "quay.io/broadinstitute/ncbi-tools:2.13.0"
     }
     Int disk_size = 50
     meta {
@@ -406,7 +406,7 @@ task biosample_submit_tsv_ftp_upload {
         File     config_js
         String   target_path
 
-        String   docker = "quay.io/broadinstitute/ncbi-tools:2.12.0"
+        String   docker = "quay.io/broadinstitute/ncbi-tools:2.13.0"
     }
     String base=basename(meta_submit_tsv, '.tsv')
     Int disk_size = 100    
@@ -446,7 +446,7 @@ task biosample_xml_response_to_tsv {
         File     meta_submit_tsv
         File     ncbi_report_xml
 
-        String   docker = "quay.io/broadinstitute/ncbi-tools:2.12.0"
+        String   docker = "quay.io/broadinstitute/ncbi-tools:2.13.0"
     }
     String out_name = "~{basename(meta_submit_tsv, '.tsv')}-attributes.tsv"
     Int disk_size = 100

--- a/pipes/WDL/tasks/tasks_nextstrain.wdl
+++ b/pipes/WDL/tasks/tasks_nextstrain.wdl
@@ -5,7 +5,7 @@ task taxid_to_nextclade_dataset_name {
         Int     taxid
         File    taxdump_tgz
         File    nextclade_by_taxid_tsv # "gs://pathogen-public-dbs/viral-references/typing/nextclade-by-taxid.tsv"
-        String  docker = "quay.io/broadinstitute/viral-ngs:3.0.11-classify"
+        String  docker = "quay.io/broadinstitute/viral-ngs:3.0.13-classify"
     }
     command <<<
         set -e
@@ -61,7 +61,7 @@ task nextclade_one_sample {
         File? gene_annotations_json
         String? dataset_name
         Int    disk_size = 50
-        String docker = "nextstrain/nextclade:3.21.0"
+        String docker = "nextstrain/nextclade:3.21.2"
     }
     String basename = basename(genome_fasta, ".fasta")
     command <<<
@@ -153,7 +153,7 @@ task nextclade_many_samples {
         String       basename
         File?        genome_ids_setdefault_blank
         Int          disk_size = 150
-        String       docker = "nextstrain/nextclade:3.21.0"
+        String       docker = "nextstrain/nextclade:3.21.2"
     }
     command <<<
         set -e
@@ -328,7 +328,7 @@ task derived_cols {
         String?       lab_highlight_loc
         Array[File]   table_map = []
 
-        String        docker = "quay.io/broadinstitute/viral-ngs:3.0.11-core"
+        String        docker = "quay.io/broadinstitute/viral-ngs:3.0.13-core"
         Int           disk_size = 50
     }
     parameter_meta {
@@ -889,7 +889,7 @@ task filter_sequences_to_list {
 
         String       out_fname = sub(sub(basename(sequences, ".zst"), ".vcf", ".filtered.vcf"), ".fasta$", ".filtered.fasta")
         # Prior docker image: "nextstrain/base:build-20240318T173028Z"
-        String       docker = "quay.io/broadinstitute/viral-ngs:3.0.11-core"
+        String       docker = "quay.io/broadinstitute/viral-ngs:3.0.13-core"
         Int          disk_size = 750
     }
     parameter_meta {
@@ -989,7 +989,7 @@ task mafft_one_chr {
         Boolean  large = false
         Boolean  memsavetree = false
 
-        String   docker = "quay.io/broadinstitute/viral-ngs:3.0.11-phylo"
+        String   docker = "quay.io/broadinstitute/viral-ngs:3.0.13-phylo"
         Int      mem_size = 500
         Int      cpus = 64
         Int      disk_size = 750
@@ -1078,7 +1078,7 @@ task mafft_one_chr_chunked {
         Int      batch_chunk_size = 2000
         Int      threads_per_job = 2
 
-        String   docker = "quay.io/broadinstitute/viral-ngs:3.0.11-phylo"
+        String   docker = "quay.io/broadinstitute/viral-ngs:3.0.13-phylo"
         Int      mem_size = 32
         Int      cpus = 64
         Int      disk_size = 750

--- a/pipes/WDL/tasks/tasks_read_utils.wdl
+++ b/pipes/WDL/tasks/tasks_read_utils.wdl
@@ -82,7 +82,7 @@ task group_bams_by_sample {
 task get_bam_samplename {
   input {
     File    bam
-    String  docker = "quay.io/broadinstitute/viral-ngs:3.0.11-core"
+    String  docker = "quay.io/broadinstitute/viral-ngs:3.0.13-core"
   }
   Int   disk_size = round(size(bam, "GB")) + 50
   command <<<
@@ -108,7 +108,7 @@ task get_sample_meta {
   input {
     Array[File] samplesheets_extended
 
-    String      docker = "quay.io/broadinstitute/viral-ngs:3.0.11-core"
+    String      docker = "quay.io/broadinstitute/viral-ngs:3.0.13-core"
   }
   Int disk_size = 50
   command <<<
@@ -168,7 +168,7 @@ task merge_and_reheader_bams {
       File?        reheader_table
       String       out_basename = basename(in_bams[0], ".bam")
 
-      String       docker = "quay.io/broadinstitute/viral-ngs:3.0.11-core"
+      String       docker = "quay.io/broadinstitute/viral-ngs:3.0.13-core"
       Int          disk_size = 750
       Int          machine_mem_gb = 8
     }
@@ -239,7 +239,7 @@ task rmdup_ubam {
 
     Int     max_reads = 100000000
     Int?    machine_mem_gb
-    String  docker = "quay.io/broadinstitute/viral-ngs:3.0.11-core"
+    String  docker = "quay.io/broadinstitute/viral-ngs:3.0.13-core"
   }
 
   # Memory autoscaling: M-Vicuna loads reads into memory for deduplication.
@@ -325,7 +325,7 @@ task bbnorm_bam {
 
     Int?    machine_mem_gb
     Int?    cpu
-    String  docker = "quay.io/broadinstitute/viral-ngs:3.0.11-core"
+    String  docker = "quay.io/broadinstitute/viral-ngs:3.0.13-core"
   }
 
   # Memory autoscaling: BBNorm uses Java and loads kmer data structures into memory.
@@ -426,7 +426,7 @@ task downsample_bams {
     Boolean      deduplicateAfter = false
 
     Int?         machine_mem_gb
-    String       docker = "quay.io/broadinstitute/viral-ngs:3.0.11-core"
+    String       docker = "quay.io/broadinstitute/viral-ngs:3.0.13-core"
   }
 
   Int disk_size = 750
@@ -493,7 +493,7 @@ task FastqToUBAM {
     Int     cpus = 2
     Int     mem_gb = 4
     Int     disk_size = 750
-    String  docker = "quay.io/broadinstitute/viral-ngs:3.0.11-core"
+    String  docker = "quay.io/broadinstitute/viral-ngs:3.0.13-core"
   }
   parameter_meta {
     fastq_1: { description: "Unaligned read1 file in fastq format", patterns: ["*.fastq", "*.fastq.gz", "*.fq", "*.fq.gz"] }
@@ -546,7 +546,7 @@ task read_depths {
     File      aligned_bam
 
     String    out_basename = basename(aligned_bam, '.bam')
-    String    docker = "quay.io/broadinstitute/viral-ngs:3.0.11-core"
+    String    docker = "quay.io/broadinstitute/viral-ngs:3.0.13-core"
   }
   Int disk_size = 200
   command <<<

--- a/pipes/WDL/tasks/tasks_reports.wdl
+++ b/pipes/WDL/tasks/tasks_reports.wdl
@@ -15,7 +15,7 @@ task alignment_metrics {
     Int    max_amplicons=500
 
     Int    machine_mem_gb=16
-    String docker = "quay.io/broadinstitute/viral-ngs:3.0.11-core"
+    String docker = "quay.io/broadinstitute/viral-ngs:3.0.13-core"
   }
 
   String out_basename = basename(aligned_bam, ".bam")
@@ -142,7 +142,7 @@ task plot_coverage {
     String? plotXLimits # of the form "min max" (ints, space between)
     String? plotYLimits # of the form "min max" (ints, space between)
 
-    String  docker = "quay.io/broadinstitute/viral-ngs:3.0.11-core"
+    String  docker = "quay.io/broadinstitute/viral-ngs:3.0.13-core"
   }
 
   Int disk_size = 375
@@ -226,7 +226,7 @@ task merge_coverage_per_position {
 
     String       out_report_name = "coverage_report.csv"
     Int          disk_size = 100
-    String       docker = "quay.io/broadinstitute/py3-bio:0.1.5"
+    String       docker = "quay.io/broadinstitute/py3-bio:0.1.7"
   }
 
   command <<<
@@ -286,7 +286,7 @@ task coverage_report {
     Array[File]  mapped_bam_idx = []  # optional.. speeds it up if you provide it, otherwise we auto-index
     String       out_report_name = "coverage_report.txt"
 
-    String       docker = "quay.io/broadinstitute/viral-ngs:3.0.11-core"
+    String       docker = "quay.io/broadinstitute/viral-ngs:3.0.13-core"
   }
 
   Int disk_size = 375
@@ -359,7 +359,7 @@ task fastqc {
   input {
     File   reads_bam
 
-    String docker = "quay.io/broadinstitute/viral-ngs:3.0.11-core"
+    String docker = "quay.io/broadinstitute/viral-ngs:3.0.13-core"
   }
   parameter_meta {
     reads_bam:{ 
@@ -402,7 +402,7 @@ task align_and_count {
 
     Int?   cpu
     Int?   machine_mem_gb
-    String docker = "quay.io/broadinstitute/viral-ngs:3.0.11-core"
+    String docker = "quay.io/broadinstitute/viral-ngs:3.0.13-core"
   }
 
   String  reads_basename=basename(reads_bam, ".bam")
@@ -517,7 +517,7 @@ task align_and_count_summary {
 
     String       output_prefix = "count_summary"
 
-    String       docker = "quay.io/broadinstitute/viral-ngs:3.0.11-core"
+    String       docker = "quay.io/broadinstitute/viral-ngs:3.0.13-core"
   }
 
   Int disk_size = 100
@@ -551,7 +551,7 @@ task aggregate_metagenomics_reports {
     String       aggregate_taxlevel_focus                 = "species"
     Int          aggregate_top_N_hits                     = 5
 
-    String       docker = "quay.io/broadinstitute/viral-ngs:3.0.11-classify"
+    String       docker = "quay.io/broadinstitute/viral-ngs:3.0.13-classify"
   }
 
   parameter_meta {
@@ -720,7 +720,7 @@ task multiqc_from_bams {
     File?          config
     String?        config_yaml
 
-    String         docker = "ghcr.io/broadinstitute/read-qc-tools:1.1.0"
+    String         docker = "ghcr.io/broadinstitute/read-qc-tools:1.1.1"
 
     Int?           cpu              # Override auto-scaled CPU (default: 2*num_bams, capped 4-32)
     Int?           machine_mem_gb   # Override auto-scaled memory (default: 2*cpu GB)
@@ -901,7 +901,7 @@ task compare_two_genomes {
     File   genome_two
     String out_basename
 
-    String docker = "quay.io/broadinstitute/viral-ngs:3.0.11-assemble"
+    String docker = "quay.io/broadinstitute/viral-ngs:3.0.13-assemble"
   }
 
   Int disk_size = 50

--- a/pipes/WDL/tasks/tasks_sarscov2.wdl
+++ b/pipes/WDL/tasks/tasks_sarscov2.wdl
@@ -254,7 +254,7 @@ task sc2_meta_final {
 
         File?         filter_to_ids
 
-        String        docker = "quay.io/broadinstitute/py3-bio:0.1.5"
+        String        docker = "quay.io/broadinstitute/py3-bio:0.1.7"
     }
     String out_basename = basename(basename(assembly_stats_tsv, '.txt'), '.tsv')
     Int disk_size = 50
@@ -404,7 +404,7 @@ task crsp_meta_etl {
         String        allowed_purposes = '["Baseline surveillance (random sampling)", "Targeted surveillance (non-random sampling)", "Screening for Variants of Concern (VOC)", "Longitudinal surveillance (repeat sampling of individuals)", "Vaccine escape surveillance", "Cluster/Outbreak investigation"]'
         String        sequencing_lab_prefix = 'CDCBI'
 
-        String        docker = "quay.io/broadinstitute/py3-bio:0.1.5"
+        String        docker = "quay.io/broadinstitute/py3-bio:0.1.7"
     }
     String out_basename = basename(basename(basename(sample_meta_crsp, '.txt'), '.tsv'), '.metadata')
     Int disk_size = 50

--- a/pipes/WDL/tasks/tasks_taxon_filter.wdl
+++ b/pipes/WDL/tasks/tasks_taxon_filter.wdl
@@ -15,7 +15,7 @@ task deplete_taxa {
 
     Int?         cpu
     Int?         machine_mem_gb
-    String       docker = "quay.io/broadinstitute/viral-ngs:3.0.11-classify"
+    String       docker = "quay.io/broadinstitute/viral-ngs:3.0.13-classify"
   }
 
   # Autoscale CPU based on input size: 8 CPUs for ~1M reads (0.15 GB), 96 CPUs for ~100M reads (15 GB)
@@ -142,7 +142,7 @@ task filter_to_taxon {
     String   neg_control_prefixes_space_separated = "neg water NTC"
 
     Int      machine_mem_gb = 15
-    String   docker = "quay.io/broadinstitute/viral-ngs:3.0.11-classify"
+    String   docker = "quay.io/broadinstitute/viral-ngs:3.0.13-classify"
   }
 
   # do this in two steps in case the input doesn't actually have "cleaned" in the name
@@ -196,7 +196,7 @@ task build_lastal_db {
     File   sequences_fasta
 
     Int    machine_mem_gb = 7
-    String docker = "quay.io/broadinstitute/viral-ngs:3.0.11-classify"
+    String docker = "quay.io/broadinstitute/viral-ngs:3.0.13-classify"
   }
 
   String db_name = basename(sequences_fasta, ".fasta")
@@ -234,7 +234,7 @@ task merge_one_per_sample {
     Boolean      rmdup = false
 
     Int          machine_mem_gb = 7
-    String       docker = "quay.io/broadinstitute/viral-ngs:3.0.11-core"
+    String       docker = "quay.io/broadinstitute/viral-ngs:3.0.13-core"
   }
 
   Int disk_size = 750

--- a/pipes/WDL/tasks/tasks_terra.wdl
+++ b/pipes/WDL/tasks/tasks_terra.wdl
@@ -24,7 +24,7 @@ task gcs_copy {
     File logs = stdout()
   }
   runtime {
-    docker: "quay.io/broadinstitute/viral-ngs:3.0.11-baseimage"
+    docker: "quay.io/broadinstitute/viral-ngs:3.0.13-baseimage"
     memory: "1 GB"
     cpu: 1
   }
@@ -32,7 +32,7 @@ task gcs_copy {
 
 task check_terra_env {
   input {
-    String docker = "quay.io/broadinstitute/viral-ngs:3.0.11-baseimage"
+    String docker = "quay.io/broadinstitute/viral-ngs:3.0.13-baseimage"
   }
   meta {
     description: "task for inspection of backend to determine whether the task is running on Terra and/or GCP"
@@ -329,7 +329,7 @@ task upload_entities_tsv {
     String        terra_project
     File          tsv_file
 
-    String        docker = "quay.io/broadinstitute/viral-ngs:3.0.11-baseimage"
+    String        docker = "quay.io/broadinstitute/viral-ngs:3.0.13-baseimage"
   }
   meta {
     volatile: true
@@ -368,7 +368,7 @@ task download_entities_tsv {
     String  outname = "~{terra_project}-~{workspace_name}-~{table_name}.tsv"
     String? nop_input_string # this does absolutely nothing, except that it allows an optional mechanism for you to block execution of this step upon the completion of another task in your workflow
 
-    String  docker = "quay.io/broadinstitute/viral-ngs:3.0.11-baseimage"
+    String  docker = "quay.io/broadinstitute/viral-ngs:3.0.13-baseimage"
   }
 
   meta {
@@ -439,7 +439,7 @@ task create_or_update_sample_tables {
     String  sample_table_name  = "sample"
     String  library_table_name = "library"
 
-    String  docker = "quay.io/broadinstitute/viral-ngs:3.0.11-core"
+    String  docker = "quay.io/broadinstitute/viral-ngs:3.0.13-core"
   }
 
   meta {
@@ -612,7 +612,7 @@ task find_illumina_files_in_directory {
     String  illumina_dir
     String? fastq_dir
     Int?    lane
-    String  docker = "quay.io/broadinstitute/viral-ngs:3.0.11-baseimage"
+    String  docker = "quay.io/broadinstitute/viral-ngs:3.0.13-baseimage"
   }
   parameter_meta {
     illumina_dir: {

--- a/pipes/WDL/tasks/tasks_utils.wdl
+++ b/pipes/WDL/tasks/tasks_utils.wdl
@@ -51,7 +51,7 @@ task unpack_archive_to_bucket_path {
         # execution and resource requirements
         Int    disk_size      = ceil(3.0 * size(input_archive_files[0], "GB")) + 50
         Int    machine_mem_gb = 8
-        String docker         = "quay.io/broadinstitute/viral-ngs:3.0.11-core"
+        String docker         = "quay.io/broadinstitute/viral-ngs:3.0.13-core"
     }
 
     parameter_meta {
@@ -293,7 +293,7 @@ task zcat {
         { if [ -f /sys/fs/cgroup/memory.peak ]; then cat /sys/fs/cgroup/memory.peak; elif [ -f /sys/fs/cgroup/memory/memory.peak ]; then cat /sys/fs/cgroup/memory/memory.peak; elif [ -f /sys/fs/cgroup/memory/memory.max_usage_in_bytes ]; then cat /sys/fs/cgroup/memory/memory.max_usage_in_bytes; else echo "0"; fi } > MEM_BYTES
     >>>
     runtime {
-        docker: "quay.io/broadinstitute/viral-ngs:3.0.11-core"
+        docker: "quay.io/broadinstitute/viral-ngs:3.0.13-core"
         memory: "1 GB"
         cpu:    cpus
         disks: "local-disk ~{disk_size} LOCAL"
@@ -350,7 +350,7 @@ task tar_extract {
         tar -xv ~{tar_opts} -f "~{tar_file}"
     >>>
     runtime {
-        docker: "quay.io/broadinstitute/viral-ngs:3.0.11-baseimage"
+        docker: "quay.io/broadinstitute/viral-ngs:3.0.13-baseimage"
         memory: "2 GB"
         cpu:    2
         disks: "local-disk ~{disk_size} HDD"
@@ -514,7 +514,7 @@ task download_from_url {
         printf "Downloaded file size (bytes): " && stat --format=%s  "~{download_subdir_local}/${downloaded_file_name}" | tee SIZE_OF_DOWNLOADED_FILE_BYTES
     >>>
     runtime {
-        docker: "quay.io/broadinstitute/viral-ngs:3.0.11-baseimage"
+        docker: "quay.io/broadinstitute/viral-ngs:3.0.13-baseimage"
         memory: "2 GB"
         cpu:    1
         disks: "local-disk ~{disk_size} LOCAL"
@@ -540,7 +540,7 @@ task sanitize_fasta_headers {
     File   in_fasta
     String out_filename = "~{basename(in_fasta, '.fasta')}-sanitized.fasta"
   }
-  String docker = "quay.io/broadinstitute/py3-bio:0.1.5"
+  String docker = "quay.io/broadinstitute/py3-bio:0.1.7"
   Int    disk_size = 375
   command <<<
     python3<<CODE
@@ -847,7 +847,7 @@ task tsv_join {
   runtime {
     memory: "~{machine_mem_gb} GB"
     cpu: 4
-    docker: "quay.io/broadinstitute/viral-ngs:3.0.11-core"
+    docker: "quay.io/broadinstitute/viral-ngs:3.0.13-core"
     disks: "local-disk ~{disk_size} HDD"
     disk: "~{disk_size} GB" # TES
     dx_instance_type: "mem1_ssd1_v2_x4"
@@ -898,7 +898,7 @@ task tsv_drop_cols {
         File          in_tsv
         Array[String] drop_cols
         String        out_filename = basename(in_tsv, '.tsv') + ".drop.tsv"
-        String        docker = "quay.io/broadinstitute/py3-bio:0.1.5"
+        String        docker = "quay.io/broadinstitute/py3-bio:0.1.7"
     }
     Int disk_size = 50
     command <<<
@@ -931,7 +931,7 @@ task tsv_stack {
   input {
     Array[File]+ input_tsvs
     String       out_basename
-    String       docker = "quay.io/broadinstitute/viral-ngs:3.0.11-core"
+    String       docker = "quay.io/broadinstitute/viral-ngs:3.0.13-core"
   }
 
   Int disk_size = 50
@@ -1114,7 +1114,7 @@ task today {
   runtime {
     memory: "1 GB"
     cpu: 1
-    docker: "quay.io/broadinstitute/viral-ngs:3.0.11-baseimage"
+    docker: "quay.io/broadinstitute/viral-ngs:3.0.13-baseimage"
     disks: "local-disk ~{disk_size} HDD"
     disk: "~{disk_size} GB" # TES
     dx_instance_type: "mem1_ssd1_v2_x2"
@@ -1149,7 +1149,7 @@ task s3_copy {
     Array[String] out_uris = read_lines("OUT_URIS")
   }
   runtime {
-    docker: "quay.io/broadinstitute/viral-ngs:3.0.11-baseimage"
+    docker: "quay.io/broadinstitute/viral-ngs:3.0.13-baseimage"
     memory: "2 GB"
     cpu: cpus
     disks: "local-disk ~{disk_gb} SSD"
@@ -1193,7 +1193,7 @@ task filter_sequences_by_length {
         File   sequences_fasta
         Int    min_non_N = 1
 
-        String docker = "quay.io/broadinstitute/viral-ngs:3.0.11-core"
+        String docker = "quay.io/broadinstitute/viral-ngs:3.0.13-core"
         Int    disk_size = 750
     }
     parameter_meta {

--- a/requirements-modules.txt
+++ b/requirements-modules.txt
@@ -1,9 +1,9 @@
-broadinstitute/viral-ngs=3.0.11
-broadinstitute/read-qc-tools=1.1.0
-broadinstitute/py3-bio=0.1.5
+broadinstitute/viral-ngs=3.0.13
+broadinstitute/read-qc-tools=1.1.1
+broadinstitute/py3-bio=0.1.7
 broadinstitute/beast-beagle-cuda=1.10.5pre
-broadinstitute/ncbi-tools=2.12.0
+broadinstitute/ncbi-tools=2.13.0
 nextstrain/base=build-20240318T173028Z
 andersenlabapps/ivar=1.3.1
 quay.io/staphb/pangolin=4.4-pdata-1.38
-nextstrain/nextclade=3.21.0
+nextstrain/nextclade=3.21.2


### PR DESCRIPTION
Update upstream docker images:
 - viral-ngs 3.0.11 -> 3.0.13
 - read-qc-tools 1.1.0 -> 1.1.1
 - py3-bio 0.1.5 -> 0.1.7
 - ncbi-tools 2.12.0 -> ncbi-tools=2.13.0
 - nextclade 3.21.0 -> 3.21.2