### PR TITLE
Quote WDL File variable expansions to handle paths with spaces

### DIFF
--- a/pipes/WDL/tasks/tasks_assembly.wdl
+++ b/pipes/WDL/tasks/tasks_assembly.wdl
@@ -71,9 +71,9 @@ task assemble {
         assembly --version | tee VERSION
 
         assembly assemble_spades \
-          ~{reads_unmapped_bam} \
-          ~{trim_clip_db} \
-          ~{sample_name}.assembly1-spades.fasta \
+          "~{reads_unmapped_bam}" \
+          "~{trim_clip_db}" \
+          "~{sample_name}.assembly1-spades.fasta" \
           ~{'--nReads=' + spades_n_reads} \
           ~{true="--alwaysSucceed" false="" always_succeed} \
           ~{'--minContigLen=' + spades_min_contig_len} \
@@ -595,12 +595,12 @@ task ivar_trim {
         ivar version | head -1 | tee VERSION
         if [ -f "~{trim_coords_bed}" ]; then
           ivar trim -e \
-            ~{'-b ' + trim_coords_bed} \
+            ~{'-b "' + trim_coords_bed + '"'} \
             ~{'-m ' + min_keep_length} \
             ~{'-s ' + sliding_window} \
             ~{'-q ' + min_quality} \
             ~{'-x ' + primer_offset} \
-            -i ~{aligned_bam} -p trim | tee IVAR_OUT
+            -i "~{aligned_bam}" -p trim | tee IVAR_OUT
           samtools sort -@ $(nproc) -m 1000M -o ~{bam_basename}.trimmed.bam trim.bam
         else
           echo "skipping ivar trim"
@@ -922,16 +922,16 @@ task refine_assembly_with_aligned_reads {
 
         if [ ~{true='true' false='false' mark_duplicates} == "true" ]; then
           read_utils mkdup_picard \
-            ~{reads_aligned_bam} \
+            "~{reads_aligned_bam}" \
             temp_markdup.bam \
             --JVMmemory "$mem_in_mb"m \
             --loglevel=DEBUG
         else
-          ln -s ~{reads_aligned_bam} temp_markdup.bam
+          ln -s "~{reads_aligned_bam}" temp_markdup.bam
         fi
         samtools index -@ $(nproc) temp_markdup.bam temp_markdup.bai
 
-        ln -s ~{reference_fasta} assembly.fasta
+        ln -s "~{reference_fasta}" assembly.fasta
         assembly refine_assembly \
           assembly.fasta \
           temp_markdup.bam \

--- a/pipes/WDL/tasks/tasks_assembly.wdl
+++ b/pipes/WDL/tasks/tasks_assembly.wdl
@@ -79,7 +79,7 @@ task assemble {
           ~{'--minContigLen=' + spades_min_contig_len} \
           ~{'--spadesOpts="' + spades_options + '"'} \
           --memLimitGb $mem_in_gb \
-          --outReads=~{sample_name}.subsamp.bam \
+          --outReads="~{sample_name}.subsamp.bam" \
           --loglevel=DEBUG
 
         samtools view -c ~{sample_name}.subsamp.bam | tee subsample_read_count >&2
@@ -601,7 +601,7 @@ task ivar_trim {
             ~{'-q ' + min_quality} \
             ~{'-x ' + primer_offset} \
             -i "~{aligned_bam}" -p trim | tee IVAR_OUT
-          samtools sort -@ $(nproc) -m 1000M -o ~{bam_basename}.trimmed.bam trim.bam
+          samtools sort -@ $(nproc) -m 1000M -o "~{bam_basename}.trimmed.bam" trim.bam
         else
           echo "skipping ivar trim"
           cp "~{aligned_bam}" "~{bam_basename}.trimmed.bam"

--- a/pipes/WDL/tasks/tasks_demux.wdl
+++ b/pipes/WDL/tasks/tasks_demux.wdl
@@ -239,22 +239,22 @@ task illumina_demux {
     fi
     
     # Parse the lane count & run ID from RunInfo.xml file
-    lane_count=$(xmllint --xpath "string(//Run/FlowcellLayout/@LaneCount)" $RUNINFO_FILE)
+    lane_count=$(xmllint --xpath "string(//Run/FlowcellLayout/@LaneCount)" "$RUNINFO_FILE")
     if [ -z "$lane_count" ]; then
         echo "Could not parse LaneCount from RunInfo.xml. Please check RunInfo.xml is properly formatted"
     fi
 
-    surface_count=$(xmllint --xpath "string(//Run/FlowcellLayout/@SurfaceCount)" $RUNINFO_FILE)
+    surface_count=$(xmllint --xpath "string(//Run/FlowcellLayout/@SurfaceCount)" "$RUNINFO_FILE")
     if [ -z "$surface_count" ]; then
         echo "Could not parse SurfaceCount from RunInfo.xml. Please check RunInfo.xml is properly formatted"
     fi
 
-    swath_count=$(xmllint --xpath "string(//Run/FlowcellLayout/@SwathCount)" $RUNINFO_FILE)
+    swath_count=$(xmllint --xpath "string(//Run/FlowcellLayout/@SwathCount)" "$RUNINFO_FILE")
     if [ -z "$swath_count" ]; then
         echo "Could not parse SwathCount from RunInfo.xml. Please check RunInfo.xml is properly formatted"
     fi
 
-    tile_count=$(xmllint --xpath "string(//Run/FlowcellLayout/@TileCount)" $RUNINFO_FILE)
+    tile_count=$(xmllint --xpath "string(//Run/FlowcellLayout/@TileCount)" "$RUNINFO_FILE")
     if [ -z "$tile_count" ]; then
         echo "Could not parse TileCount from RunInfo.xml. Please check RunInfo.xml is properly formatted"
     fi
@@ -366,8 +366,8 @@ task illumina_demux {
       $FLOWCELL_DIR \
       ~{lane} \
       . \
-      ~{'--sampleSheet=' + samplesheet} \
-      ~{'--runInfo=' + runinfo} \
+      ~{'--sampleSheet="' + samplesheet + '"'} \
+      ~{'--runInfo="' + runinfo + '"'} \
       ~{'--sequencing_center=' + sequencingCenter} \
       --outMetrics=metrics.txt \
       --commonBarcodes=barcodes.txt \
@@ -436,7 +436,7 @@ task illumina_demux {
       ~{'--predemux_trim_r1_3prime '  + inner_barcode_predemux_trim_r1_3prime} \
       ~{'--predemux_trim_r2_5prime '  + inner_barcode_predemux_trim_r2_5prime} \
       ~{'--predemux_trim_r2_3prime '  + inner_barcode_predemux_trim_r2_3prime} \
-      ~{'--sampleSheet=' + samplesheet} \
+      ~{'--sampleSheet="' + samplesheet + '"'} \
       "--runInfo=${RUNINFO_FILE}" \
       --illuminaRunDirectory=$FLOWCELL_DIR \
       $demux_threads \
@@ -843,7 +843,7 @@ task get_illumina_run_metadata {
     illumina --version | tee VERSION
 
     illumina illumina_metadata \
-      --runinfo ~{runinfo_xml} \
+      --runinfo "~{runinfo_xml}" \
       ~{'--sequencing_center ' + sequencing_center} \
       --out_runinfo runinfo.json \
       --loglevel=DEBUG
@@ -969,15 +969,15 @@ task demux_fastqs {
     illumina --version | tee VERSION
 
     illumina splitcode_demux_fastqs \
-      --fastq_r1 ~{fastq_r1} \
-      ~{'--fastq_r2 ' + fastq_r2} \
-      --samplesheet ~{samplesheet} \
-      --runinfo ~{runinfo_xml} \
-      ~{'--sequencing_center ' + sequencingCenter} \
+      --fastq_r1 "~{fastq_r1}" \
+      ~{'--fastq_r2 "' + fastq_r2 + '"'} \
+      --samplesheet "~{samplesheet}" \
+      --runinfo "~{runinfo_xml}" \
+      ~{'--sequencing_center "' + sequencingCenter + '"'} \
       --outdir . \
       --append_run_id \
-      --out_meta_by_sample ~{fastq_basename}-meta_by_sample.json \
-      --out_meta_by_filename ~{fastq_basename}-meta_by_filename.json \
+      --out_meta_by_sample "~{fastq_basename}-meta_by_sample.json" \
+      --out_meta_by_filename "~{fastq_basename}-meta_by_filename.json" \
       --loglevel=DEBUG
 
     # Workaround: create empty JSON files if Python code didn't produce them (zero-read FASTQs)

--- a/pipes/WDL/tasks/tasks_demux.wdl
+++ b/pipes/WDL/tasks/tasks_demux.wdl
@@ -368,7 +368,7 @@ task illumina_demux {
       . \
       ~{'--sampleSheet="' + samplesheet + '"'} \
       ~{'--runInfo="' + runinfo + '"'} \
-      ~{'--sequencing_center=' + sequencingCenter} \
+      ~{'--sequencing_center="' + sequencingCenter + '"'} \
       --outMetrics=metrics.txt \
       --commonBarcodes=barcodes.txt \
       ~{'--flowcell=' + flowcell} \

--- a/pipes/WDL/tasks/tasks_interhost.wdl
+++ b/pipes/WDL/tasks/tasks_interhost.wdl
@@ -311,7 +311,7 @@ task beast {
       ~{true="-beagle_double" false="-beagle_single" beagle_double_precision} \
       -beagle_scaling always \
       ~{'-beagle_order ' + beagle_order} \
-      ~{beauti_xml}
+      "~{beauti_xml}"
   >>>
 
   output {

--- a/pipes/WDL/tasks/tasks_intrahost.wdl
+++ b/pipes/WDL/tasks/tasks_intrahost.wdl
@@ -82,7 +82,7 @@ task polyphonia_detect_cross_contamination {
     fi
 
     polyphonia cross_contamination \
-      --ref ~{reference_fasta} \
+      --ref "~{reference_fasta}" \
       --vcf ~{sep=' ' lofreq_vcfs} \
       --consensus ~{sep=' ' genome_fastas} \
       --read-depths ~{sep=' ' select_first([read_depths, []])} \
@@ -94,7 +94,7 @@ task polyphonia_detect_cross_contamination {
       ~{'--min-matches-proportion ' + min_matches_proportion} \
       ~{'--min-maf ' + min_maf} \
       ~{'--masked-positions ' + masked_positions} \
-      ~{'--masked-positions-file ' + masked_positions_file} \
+      ~{'--masked-positions-file "' + masked_positions_file + '"'} \
       $PLATE_MAPS_INPUT \
       ~{'--plate-size ' + plate_size} \
       ~{'--plate-columns ' + plate_columns} \
@@ -224,8 +224,8 @@ task isnvs_per_sample {
   command <<<
     intrahost --version | tee VERSION
     intrahost vphaser_one_sample \
-        ~{mapped_bam} \
-        ~{assembly_fasta} \
+        "~{mapped_bam}" \
+        "~{assembly_fasta}" \
         vphaser2.~{sample_name}.txt.gz \
         ~{'--vphaserNumThreads=' + threads} \
         ~{true="--removeDoublyMappedReads" false="" removeDoublyMappedReads} \
@@ -286,7 +286,7 @@ task isnvs_vcf {
     echo "snpRefAccessions: $snpRefAccessions"
 
     intrahost merge_to_vcf \
-        ~{reference_fasta} \
+        "~{reference_fasta}" \
         isnvs.vcf.gz \
         $SAMPLES \
         --isnvs ~{sep=' ' vphaser2Calls} \

--- a/pipes/WDL/tasks/tasks_megablast.wdl
+++ b/pipes/WDL/tasks/tasks_megablast.wdl
@@ -98,12 +98,12 @@ task lca_megablast {
     command <<<
         #Extract BLAST DB tarball
         read_utils extract_tarball \
-          ~{blast_db_tgz} . \
+          "~{blast_db_tgz}" . \
           --loglevel=DEBUG
-        
-        # Extract taxonomy DB tarball 
+
+        # Extract taxonomy DB tarball
         read_utils extract_tarball \
-          ~{taxonomy_db_tgz} . \
+          "~{taxonomy_db_tgz}" . \
           --loglevel=DEBUG
 
         '''
@@ -189,7 +189,7 @@ task ChunkBlastHits {
     command <<<
         #Extract tarball contents
         read_utils extract_tarball \
-          ~{blast_db_tgz} . \
+          "~{blast_db_tgz}" . \
           --loglevel=DEBUG
         export LOG_DIR=~{log_dir_final}
         echo "Using $(nproc) CPU cores."
@@ -274,12 +274,12 @@ task blastoff {
     command <<<
         #Extract BLAST DB tarball
         read_utils extract_tarball \
-          ~{blast_db_tgz} . \
+          "~{blast_db_tgz}" . \
           --loglevel=DEBUG
 
         # Extract taxonomy DB tarball (includes nodes.dmp)
         read_utils extract_tarball \
-          ~{taxonomy_db_tgz} . \
+          "~{taxonomy_db_tgz}" . \
           --loglevel=DEBUG
         
         export LOG_DIR=~{log_dir_final}

--- a/pipes/WDL/tasks/tasks_megablast.wdl
+++ b/pipes/WDL/tasks/tasks_megablast.wdl
@@ -191,7 +191,7 @@ task ChunkBlastHits {
         read_utils extract_tarball \
           "~{blast_db_tgz}" . \
           --loglevel=DEBUG
-        export LOG_DIR=~{log_dir_final}
+        export LOG_DIR="~{log_dir_final}"
         echo "Using $(nproc) CPU cores."
         echo "Asked for ~{machine_mem_gb} memory GB"
         #Adding taxidlist input as optional 

--- a/pipes/WDL/tasks/tasks_utils.wdl
+++ b/pipes/WDL/tasks/tasks_utils.wdl
@@ -599,7 +599,7 @@ task md5sum {
   }
   Int disk_size = 100
   command <<<
-    md5sum ~{in_file} | cut -f 1 -d ' ' | tee MD5
+    md5sum "~{in_file}" | cut -f 1 -d ' ' | tee MD5
   >>>
   output {
     String md5 = read_string("MD5")
@@ -1138,11 +1138,11 @@ task s3_copy {
     set -e
     S3_PREFIX=$(echo "~{s3_uri_prefix}" | sed 's|/*$||')
     mkdir -p ~/.aws
-    cp ~{aws_credentials} ~/.aws/credentials
+    cp "~{aws_credentials}" ~/.aws/credentials
     touch OUT_URIS
     for f in ~{sep=' ' infiles}; do
-      aws s3 cp $f $S3_PREFIX/
-      echo "$S3_PREFIX/$(basename $f)" >> OUT_URIS
+      aws s3 cp "$f" "$S3_PREFIX/"
+      echo "$S3_PREFIX/$(basename "$f")" >> OUT_URIS
     done
   >>>
   output {

--- a/pipes/WDL/tasks/tasks_utils.wdl
+++ b/pipes/WDL/tasks/tasks_utils.wdl
@@ -1140,10 +1140,14 @@ task s3_copy {
     mkdir -p ~/.aws
     cp "~{aws_credentials}" ~/.aws/credentials
     touch OUT_URIS
-    for f in ~{sep=' ' infiles}; do
-      aws s3 cp "$f" "$S3_PREFIX/"
-      echo "$S3_PREFIX/$(basename "$f")" >> OUT_URIS
-    done
+    INFILES=~{write_lines(infiles)}
+    while IFS= read -r f || [ -n "$f" ]; do
+      # Skip empty or whitespace-only lines
+      if [ -n "$f" ] && [ -n "$(echo "$f" | tr -d '[:space:]')" ]; then
+        aws s3 cp "$f" "$S3_PREFIX/"
+        echo "$S3_PREFIX/$(basename "$f")" >> OUT_URIS
+      fi
+    done < "$INFILES"
   >>>
   output {
     Array[String] out_uris = read_lines("OUT_URIS")


### PR DESCRIPTION
Fixes shell word-splitting issues when WDL File inputs contain spaces in their filenames.

## Problem

Terra submission `9492e9ff-c210-4b9e-b5f1-7d8318ab0d58` in workspace `gcid-viral-y6/Swift-RNA-Seq` failed with all 18 shards (2 workflows × 9 shards each) reporting:

```
illumina: error: unrecognized arguments: - NC.tsv.renamed.txt
```

Root cause: The samplesheet filename `B29_Swift_Dplt_NonDplt - NC.tsv.renamed.txt` contains spaces. When passed unquoted to shell commands via `~{samplesheet}`, the shell splits it into multiple arguments.

## Root Cause Chain

1. `samplesheet_rename_ids` task receives a file with spaces: `"B29_Swift_Dplt_NonDplt - NC.tsv"`
2. Uses `basename(old_sheet, '.txt')` which preserves the spaces
3. Outputs `"B29_Swift_Dplt_NonDplt - NC.tsv.renamed.txt"`
4. `demux_fastqs` task passes this unquoted: `--samplesheet ~{samplesheet}`
5. Shell expands to: `--samplesheet /path/to/B29_Swift_Dplt_NonDplt - NC.tsv.renamed.txt`
6. Shell word-splits on spaces into 3 tokens: `/path/to/B29_Swift_Dplt_NonDplt`, `-`, `NC.tsv.renamed.txt`
7. argparse rejects the unexpected `-` and `NC.tsv.renamed.txt` arguments

## Solution

Wrap all WDL File variable expansions in double quotes to prevent shell word-splitting:

- **Direct expansions**: `~{file_var}` → `"~{file_var}"`
- **Optional with space separator**: `~{'--flag ' + file_var}` → `~{'--flag "' + file_var + '"'}`
- **Optional with = concatenation**: `~{'--flag=' + file_var}` → `~{'--flag="' + file_var + '"'}`

## Files Changed

### Initial commit (c38a12ab):
- `pipes/WDL/tasks/tasks_demux.wdl` — demux_fastqs, illumina_demux, get_illumina_run_metadata
- `pipes/WDL/tasks/tasks_assembly.wdl` — assemble_spades, ivar_trim, refine_assembly
- `pipes/WDL/tasks/tasks_intrahost.wdl` — cross_contamination, vphaser2, merge_to_vcf
- `pipes/WDL/tasks/tasks_interhost.wdl` — beast
- `pipes/WDL/tasks/tasks_utils.wdl` — md5sum, s3_copy
- `pipes/WDL/tasks/tasks_megablast.wdl` — megablast_chunk and related tasks

### Copilot review fixes (d14a1d24):
Addressed 5 additional issues identified by GitHub Copilot:

1. **s3_copy** (tasks_utils.wdl): Replaced unsafe `for f in ~{sep=' ' infiles}` loop with `write_lines` pattern that properly handles filenames with spaces and filters empty/whitespace lines for cross-WDL-engine compatibility.

2. **illumina_demux** (tasks_demux.wdl): Quoted `sequencingCenter` string input to handle values with spaces like "Broad Institute".

3. **assemble** (tasks_assembly.wdl): Quoted `--outReads` path containing `sample_name`.

4. **ivar_trim** (tasks_assembly.wdl): Quoted samtools output path containing `bam_basename` derived from input filename.

5. **ChunkBlastHits** (tasks_megablast.wdl): Quoted `LOG_DIR` export value to prevent word-splitting.

**Not changed**: Python heredoc usages (e.g., `open('~{samplesheet}', 'r')`) are already safe since the path is inside Python string literals.

## Testing

- ✅ `miniwdl check pipes/WDL/workflows/*.wdl` passes (no new syntax errors)
- WDL syntax validated successfully with existing warnings only