### PR TITLE
Sanitize Terra table names to prevent upload failures

### DIFF
--- a/pipes/WDL/tasks/tasks_terra.wdl
+++ b/pipes/WDL/tasks/tasks_terra.wdl
@@ -452,16 +452,21 @@ task create_or_update_sample_tables {
     flowcell_data_id  = '~{flowcell_run_id}'
     workspace_project = '~{workspace_namespace}'
     workspace_name    = '~{workspace_name}'
-    lib_col_name      = "entity:~{library_table_name}_id"
 
     # import required packages
     import sys
     import collections
     import json
     import csv
+    import re
     import pandas as pd
     import numpy as np
     from firecloud import api as fapi
+
+    # sanitize table names to conform to Terra naming requirements (alphanumeric, underscores, dashes only)
+    sample_table_name = re.sub(r'[^a-zA-Z0-9_-]', '_', '~{sample_table_name}')
+    library_table_name = re.sub(r'[^a-zA-Z0-9_-]', '_', '~{library_table_name}')
+    lib_col_name = f"entity:{library_table_name}_id"
 
     print(workspace_project + "\n" + workspace_name)
 
@@ -547,8 +552,8 @@ task create_or_update_sample_tables {
             outrow[table_name + "_id"] = row['name']
             rows.append(outrow)
         return (headers, rows)
-    header, rows = get_entities_to_table(workspace_project, workspace_name, "~{sample_table_name}")
-    df_sample = pd.DataFrame.from_records(rows, columns=header, index="~{sample_table_name}_id")
+    header, rows = get_entities_to_table(workspace_project, workspace_name, sample_table_name)
+    df_sample = pd.DataFrame.from_records(rows, columns=header, index=sample_table_name + "_id")
     print(df_sample.index)
 
     # create tsv to populate sample table with new sample->library mappings
@@ -565,7 +570,7 @@ task create_or_update_sample_tables {
 
     sample_fname = 'sample_membership.tsv'
     with open(sample_fname, 'wt') as outf:
-        outf.write('entity:~{sample_table_name}_id\tlibraries\n')
+        outf.write(f'entity:{sample_table_name}_id\tlibraries\n')
         merged_sample_ids = set()
         for sample_id, libraries in sample_to_libraries.items():
             if sample_id in df_sample.index and "libraries" in df_sample.columns and test_non_empty_value(df_sample.libraries[sample_id]):
@@ -575,7 +580,7 @@ task create_or_update_sample_tables {
                 print (f"\tsample {sample_id} pre-exists in Terra table, merging old members {already_associated_libraries} with new members {libraries}")
                 merged_sample_ids.add(sample_id)
 
-            outf.write(f'{sample_id}\t{json.dumps([{"entityType":"~{library_table_name}","entityName":library_name} for library_name in libraries])}\n')
+            outf.write(f'{sample_id}\t{json.dumps([{"entityType":library_table_name,"entityName":library_name} for library_name in libraries])}\n')
     print(f"wrote {len(sample_to_libraries)} samples to {sample_fname} where {len(merged_sample_ids)} samples were already in the Terra table")
 
     # write everything to the Terra table! -- TO DO: move this to separate task


### PR DESCRIPTION
## Problem

Failed submissions in `gcid-viral-y6/Swift-RNA-Seq` with error:
```
Invalid input: 260508_SL-EXE_0855_A23K35TLT4.8. Input may only contain alphanumeric characters, underscores, and dashes.
```

Terra entity type names must only contain alphanumeric characters, underscores, and dashes. When flowcell run IDs contain periods (e.g., `A23K35TLT4.8`), and these are passed as `sample_table_name` or `library_table_name` via the method configuration (`this.00_flowcells_id`), the Terra API rejects the upload.

## Solution

Sanitize `sample_table_name` and `library_table_name` in the `create_or_update_sample_tables` task by replacing invalid characters with underscores using regex substitution in the Python command block.

## Changes

- Add `import re` to Python imports
- Sanitize both table names: `re.sub(r'[^a-zA-Z0-9_-]', '_', table_name)`
- Move `lib_col_name` assignment after sanitization
- Replace WDL string interpolations with sanitized Python variables in:
  - `get_entities_to_table()` call
  - DataFrame index creation
  - TSV file headers

## Testing

- ✅ `miniwdl check pipes/WDL/tasks/tasks_terra.wdl` passes
- Ready for re-submission in Terra workspace to verify fix

Fixes the specific issue in submission `c5306878-e0b3-4a36-802a-e2249daf3a46`.