### PR TITLE
WDL 1.1 language modernization: keys()/as_pairs()/as_map()

### DIFF
--- a/pipes/WDL/tasks/tasks_terra.wdl
+++ b/pipes/WDL/tasks/tasks_terra.wdl
@@ -475,10 +475,10 @@ task create_or_update_sample_tables {
     read_counts_cleaned = {}
     if '~{default="" read_counts_raw_json}':
         with open('~{default="" read_counts_raw_json}','rt') as inf:
-            read_counts_raw = {pair['left']: pair['right'] for pair in json.load(inf)}
+            read_counts_raw = json.load(inf)
     if '~{default="" read_counts_cleaned_json}':
         with open('~{default="" read_counts_cleaned_json}','rt') as inf:
-            read_counts_cleaned = {pair['left']: pair['right'] for pair in json.load(inf)}
+            read_counts_cleaned = json.load(inf)
 
     # create tsv to populate library table with raw_bam and cleaned_bam columns
     raw_bams_list               = '~{sep="*" raw_reads_unaligned_bams}'.split('*')

--- a/pipes/WDL/workflows/assemble_denovo_metagenomic.wdl
+++ b/pipes/WDL/workflows/assemble_denovo_metagenomic.wdl
@@ -267,9 +267,7 @@ workflow assemble_denovo_metagenomic {
         }
 
         if(assembly_length_unambiguous > min_scaffold_unambig) {
-            scatter(h in assembly_header) {
-                String stat_by_taxon = stats_by_taxon[h]
-            }
+            Array[String] stat_by_taxon = unzip(as_pairs(stats_by_taxon)).right
         }
     }
 
@@ -277,7 +275,7 @@ workflow assemble_denovo_metagenomic {
     if (length(select_all(stat_by_taxon)) > 0) {
         call utils.concatenate as assembly_stats_non_empty {
             input:
-                infiles     = [write_tsv([assembly_header]), write_tsv(select_all(stat_by_taxon))],
+                infiles     = [write_tsv([keys(stats_by_taxon[0])]), write_tsv(select_all(stat_by_taxon))],
                 output_name = "assembly_metadata-~{sample_id}.tsv"
         }
     }

--- a/pipes/WDL/workflows/assemble_denovo_metagenomic.wdl
+++ b/pipes/WDL/workflows/assemble_denovo_metagenomic.wdl
@@ -284,7 +284,7 @@ workflow assemble_denovo_metagenomic {
     if (length(select_all(stat_by_taxon)) == 0) {
         call utils.concatenate as assembly_stats_empty {
             input:
-                infiles     = [write_tsv([assembly_header])],
+                infiles     = [write_tsv([if length(stats_by_taxon) > 0 then keys(stats_by_taxon[0]) else assembly_header])],
                 output_name = "assembly_metadata-~{sample_id}.tsv"
         }
     }

--- a/pipes/WDL/workflows/assemble_denovo_metagenomic.wdl
+++ b/pipes/WDL/workflows/assemble_denovo_metagenomic.wdl
@@ -267,7 +267,9 @@ workflow assemble_denovo_metagenomic {
         }
 
         if(assembly_length_unambiguous > min_scaffold_unambig) {
-            Array[String] stat_by_taxon = unzip(as_pairs(stats_by_taxon)).right
+            scatter(k in keys(stats_by_taxon)) {
+                String stat_by_taxon = stats_by_taxon[k]
+            }
         }
     }
 

--- a/pipes/WDL/workflows/assemble_refbased.wdl
+++ b/pipes/WDL/workflows/assemble_refbased.wdl
@@ -104,7 +104,7 @@ workflow assemble_refbased {
             'trim_percent': "~{ivar_trim.primer_trimmed_read_percent}",
             'trim_count':   "~{ivar_trim.primer_trimmed_read_count}"
         }
-        Array[String] ivar_stats_row = [ivar_stats['file'], ivar_stats['trim_percent'], ivar_stats['trim_count']]
+        Array[String] ivar_stats_row = unzip(as_pairs(ivar_stats)).right
     }
 
     if(length(reads_unmapped_bams)>1) {

--- a/pipes/WDL/workflows/assemble_refbased.wdl
+++ b/pipes/WDL/workflows/assemble_refbased.wdl
@@ -104,7 +104,7 @@ workflow assemble_refbased {
             'trim_percent': "~{ivar_trim.primer_trimmed_read_percent}",
             'trim_count':   "~{ivar_trim.primer_trimmed_read_count}"
         }
-        Array[String] ivar_stats_row = unzip(as_pairs(ivar_stats)).right
+        Array[String] ivar_stats_row = [ivar_stats['file'], ivar_stats['trim_percent'], ivar_stats['trim_count']]
     }
 
     if(length(reads_unmapped_bams)>1) {

--- a/pipes/WDL/workflows/demux_deplete.wdl
+++ b/pipes/WDL/workflows/demux_deplete.wdl
@@ -205,8 +205,8 @@ workflow demux_deplete {
                 raw_reads_unaligned_bams     = flatten(illumina_demux.raw_reads_unaligned_bams),
                 cleaned_reads_unaligned_bams = select_all(cleaned_bam_passing),
                 meta_by_filename_json        = meta_filename.merged_json,
-                read_counts_raw_json         = write_json(count_raw),
-                read_counts_cleaned_json     = write_json(count_cleaned)
+                read_counts_raw_json         = write_json(as_map(count_raw)),
+                read_counts_cleaned_json     = write_json(as_map(count_cleaned))
             }
         }
     }

--- a/pipes/WDL/workflows/load_illumina_fastqs_deplete.wdl
+++ b/pipes/WDL/workflows/load_illumina_fastqs_deplete.wdl
@@ -166,8 +166,8 @@ workflow load_illumina_fastqs_deplete {
           raw_reads_unaligned_bams     = raw_bams,
           cleaned_reads_unaligned_bams = select_all(cleaned_bam_passing),
           meta_by_filename_json        = meta_default_filename.out_json,
-          read_counts_raw_json         = write_json(count_raw),
-          read_counts_cleaned_json     = write_json(count_cleaned)
+          read_counts_raw_json         = write_json(as_map(count_raw)),
+          read_counts_cleaned_json     = write_json(as_map(count_cleaned))
       }
     }
   }

--- a/pipes/WDL/workflows/scaffold_and_refine_multitaxa.wdl
+++ b/pipes/WDL/workflows/scaffold_and_refine_multitaxa.wdl
@@ -157,7 +157,7 @@ workflow scaffold_and_refine_multitaxa {
     if (length(select_all(stat_by_taxon)) == 0) {
         call utils.concatenate as assembly_stats_empty {
             input:
-                infiles     = [write_tsv([assembly_header])],
+                infiles     = [write_tsv([if length(stats_by_taxon) > 0 then keys(stats_by_taxon[0]) else assembly_header])],
                 output_name = "assembly_metadata-~{sample_id}.tsv"
         }
     }

--- a/pipes/WDL/workflows/scaffold_and_refine_multitaxa.wdl
+++ b/pipes/WDL/workflows/scaffold_and_refine_multitaxa.wdl
@@ -140,7 +140,9 @@ workflow scaffold_and_refine_multitaxa {
         }
 
         if(assembly_length_unambiguous > min_scaffold_unambig) {
-            Array[String] stat_by_taxon = unzip(as_pairs(stats_by_taxon)).right
+            scatter(k in keys(stats_by_taxon)) {
+                String stat_by_taxon = stats_by_taxon[k]
+            }
         }
     }
 

--- a/pipes/WDL/workflows/scaffold_and_refine_multitaxa.wdl
+++ b/pipes/WDL/workflows/scaffold_and_refine_multitaxa.wdl
@@ -140,9 +140,7 @@ workflow scaffold_and_refine_multitaxa {
         }
 
         if(assembly_length_unambiguous > min_scaffold_unambig) {
-            scatter(h in assembly_header) {
-                String stat_by_taxon = stats_by_taxon[h]
-            }
+            Array[String] stat_by_taxon = unzip(as_pairs(stats_by_taxon)).right
         }
     }
 
@@ -150,7 +148,7 @@ workflow scaffold_and_refine_multitaxa {
     if (length(select_all(stat_by_taxon)) > 0) {
         call utils.concatenate as assembly_stats_non_empty {
             input:
-                infiles     = [write_tsv([assembly_header]), write_tsv(select_all(stat_by_taxon))],
+                infiles     = [write_tsv([keys(stats_by_taxon[0])]), write_tsv(select_all(stat_by_taxon))],
                 output_name = "assembly_metadata-~{sample_id}.tsv"
         }
     }


### PR DESCRIPTION
## Summary

PR #635 bumped every WDL file from `version 1.0` to `version 1.1` but did not adopt any of the idiomatic patterns 1.1 unlocks. This PR applies the highest-value, lowest-risk simplifications identified by a full-repo modernization review, verified against both miniwdl and Cromwell/womtool.

Reference: https://github.com/openwdl/wdl/blob/wdl-1.1/docs/Versions.md

Excluded from this review/PR: all `sarscov2_*` workflows (legacy, unsupported going forward).

## Changes

### 1. keys() to derive assembly-metadata TSV headers/rows
**Files:** `scaffold_and_refine_multitaxa.wdl`, `assemble_denovo_metagenomic.wdl`

Both workflows hand-maintained a ~40-element `assembly_header` string literal that had to be kept in lock-step with the keys of a `Map[String,String] stats_by_taxon` built inside a scatter, then re-extracted the values with `scatter(h in assembly_header) { stats_by_taxon[h] }`. Because WDL 1.1 Maps are insertion-ordered, `keys(stats_by_taxon)` derives that same key list directly from the map instead of the hardcoded literal, removing the duplication and a real drift hazard (if the literal and the map keys ever fell out of sync, TSV columns would silently misalign). Likewise, the TSV header row in the non-empty branch is now `keys(stats_by_taxon[0])` instead of the literal.

The `assembly_header` literal is kept only as the true fallback: used for the header when `stats_by_taxon` itself has zero elements (no reference clusters found at all). When clusters exist but all fell below the length threshold, the header is still derived from `keys(stats_by_taxon[0])`.

### 2. as_map() for the Terra read-count JSON round-trip
**Files:** `demux_deplete.wdl`, `load_illumina_fastqs_deplete.wdl`, `tasks_terra.wdl`

`count_raw`/`count_cleaned` (`Array[Pair[String,Int]]`) were serialized with `write_json()` as a bare array of left/right pairs, then rebuilt into a Python dict via a comprehension in the consuming task. `as_map()` converts the pairs to a real `Map` before serialization, so the JSON is already a flat name-to-count object and the Python side collapses to a plain `json.load()`.

This commit touches producer and consumer together since it changes the on-disk JSON schema. Note: `as_map()` errors on duplicate keys, whereas the old comprehension silently kept the last one; keys are `basename(raw_reads, '.bam')`, which are unique per flowcell, so this is a stricter but safe behavior change.

### assemble_refbased.wdl: no net change
An earlier revision of this PR also modernized `ivar_stats_row` (a small, fixed 3-key map) using `as_pairs()+unzip()`. That was reverted after discovering `unzip()` is unsupported by the Cromwell/womtool WDL 1.1 parser (see below); a nested scatter to decompose a 3-element map was not worth the added complexity, so this file is back to its original manual index list with no net diff.

## Investigated and intentionally not pursued

- **unzip()** - the `broadinstitute/womtool:develop` WDL 1.1 parser fails on `Unzip(AsPairs(...))` expressions with an internal error (unimplemented case for the `Unzip` expression element), even though miniwdl handles it correctly. Confirmed via local Docker testing that `keys()` and `as_map()` are unaffected; only `unzip()` is broken. Avoided entirely in this PR as a result.
- **task max** (`tasks_read_utils.wdl`) - reduces a variable-length `Array[Int]`. WDL 1.1 native `max()` is strictly two-argument (`Int max(Int, Int)`) with no array-reduce/fold in the language, so it is not a drop-in replacement. Its only caller is the excluded `sarscov2_illumina_full.wdl`. Left as-is.
- **after keyword** - a full sweep of every in-scope workflow found no nop/dummy-output sequencing hacks; all task ordering already flows from genuine data dependencies. Nothing to replace.
- **collect_by_key()** - every grouping-by-key candidate task either derives its key from file contents that must be read inside a container (`get_sample_meta`, `sra_meta_prep`), discovers its inputs at runtime via `gcloud storage ls` (`find_illumina_files_in_directory`), or is only called by the excluded `sarscov2_illumina_full.wdl` (`group_bams_by_sample`, the one otherwise-clean fit). No viable in-scope target.
- **docker: -> container:** (~184 occurrences) and **sep= placeholder -> sep() function** (~100 occurrences) - both are deprecations that still work in 1.1. Deferred to their own separate, isolated mechanical PRs so the semantic diffs here are not drowned in noise.

## Verification

- `miniwdl check` across all workflows and tasks: clean.
- Full-repo validation against a real `broadinstitute/womtool:develop` build (pulled and run locally via Docker, since this caught an incompatibility the CI run later confirmed): all 93 workflows validate successfully.
- Confirmed via standalone WDL snippets that `write_json(as_map(...))` produces the expected flat JSON object, and that `keys()` preserves Map insertion order (needed since the downstream TSV consumers read columns positionally).
- Ran the `assemble_refbased` miniwdl-local integration test end-to-end with real Docker containers/aligners: all 15 curated expected-output values matched exactly.
- Exercised `create_or_update_sample_tables` directly with a hand-built `as_map`-shaped JSON: confirmed the generated `library_metadata.tsv` carried correct `read_count_raw`/`read_count_cleaned` values before hitting the (expected, credential-gated) Firecloud API call.
- All CI checks pass, including `validate_wdl_womtool`, `test_miniwdl`, and `test_cromwell`.