### PR TITLE
Wire inner-barcode trim knobs into demux_fastqs

### DIFF
--- a/pipes/WDL/tasks/tasks_demux.wdl
+++ b/pipes/WDL/tasks/tasks_demux.wdl
@@ -914,6 +914,14 @@ task demux_fastqs {
     File   samplesheet
     File   runinfo_xml
 
+    # --- inner-barcode trim knobs (mirror task illumina_demux's splitcode pathway) ---
+    Int     inner_barcode_trim_r1_right_of_barcode = 10
+    Int     inner_barcode_predemux_trim_r1_3prime  = 18
+    Int     inner_barcode_predemux_trim_r2_5prime  = 18
+    Int     inner_barcode_predemux_trim_r2_3prime  = 18
+    Int?    inner_barcode_predemux_trim_r1_5prime     # unset by illumina_demux; exposed for override
+    Int?    inner_barcode_trim_r2_left_of_barcode     # unset by illumina_demux; exposed for override
+
     String? sequencingCenter
 
     Int?    cpu
@@ -954,6 +962,30 @@ task demux_fastqs {
       description: "Illumina RunInfo.xml file. NOTE: run_date and flowcell_id are extracted from this file and cannot be overridden due to viral-core limitations. Feature request needed to expose these as CLI parameters.",
       category: "required"
     }
+    inner_barcode_trim_r1_right_of_barcode: {
+      description: "Additional bp to trim from R1 immediately after the inner barcode. Mirrors task illumina_demux's --trim_r1_right_of_barcode.",
+      category: "advanced"
+    }
+    inner_barcode_predemux_trim_r1_3prime: {
+      description: "Bp to trim from R1's 3' end before inner-barcode demux. Mirrors task illumina_demux's --predemux_trim_r1_3prime.",
+      category: "advanced"
+    }
+    inner_barcode_predemux_trim_r2_5prime: {
+      description: "Bp to trim from R2's 5' end before inner-barcode demux. Mirrors task illumina_demux's --predemux_trim_r2_5prime.",
+      category: "advanced"
+    }
+    inner_barcode_predemux_trim_r2_3prime: {
+      description: "Bp to trim from R2's 3' end before inner-barcode demux. Mirrors task illumina_demux's --predemux_trim_r2_3prime.",
+      category: "advanced"
+    }
+    inner_barcode_predemux_trim_r1_5prime: {
+      description: "Bp to trim from R1's 5' end before inner-barcode demux. Not set by task illumina_demux; unset here by default (no trim applied).",
+      category: "advanced"
+    }
+    inner_barcode_trim_r2_left_of_barcode: {
+      description: "Additional bp to trim from R2 immediately before the inner barcode. Not set by task illumina_demux; unset here by default (no trim applied).",
+      category: "advanced"
+    }
   }
 
   # Derive base name from fastq_r1 for output file naming
@@ -974,6 +1006,12 @@ task demux_fastqs {
       --samplesheet "~{samplesheet}" \
       --runinfo "~{runinfo_xml}" \
       ~{'--sequencing_center "' + sequencingCenter + '"'} \
+      ~{'--trim_r1_right_of_barcode ' + inner_barcode_trim_r1_right_of_barcode} \
+      ~{'--predemux_trim_r1_3prime '  + inner_barcode_predemux_trim_r1_3prime} \
+      ~{'--predemux_trim_r2_5prime '  + inner_barcode_predemux_trim_r2_5prime} \
+      ~{'--predemux_trim_r2_3prime '  + inner_barcode_predemux_trim_r2_3prime} \
+      ~{'--predemux_trim_r1_5prime '  + inner_barcode_predemux_trim_r1_5prime} \
+      ~{'--trim_r2_left_of_barcode '  + inner_barcode_trim_r2_left_of_barcode} \
       --outdir . \
       --append_run_id \
       --out_meta_by_sample "~{fastq_basename}-meta_by_sample.json" \


### PR DESCRIPTION
## Summary
- `task illumina_demux` (BAM path, `illumina splitcode_demux`) has wired 4 inner-barcode trim knobs as task-default `Int` inputs since 2025-11-11. `task demux_fastqs` (FASTQ path, `illumina splitcode_demux_fastqs`) — the task `load_illumina_fastqs`/`load_illumina_fastqs_deplete` actually call — never passed any trim flags, so FASTQ-path demux runs silently skip trimming regardless of docker image version (confirmed against production reruns: byte-identical untrimmed BAMs with fresh docker digests and zero call-cache hits).
- viral-ngs PR #1096 (already in the pinned `3.0.17` image) only added the CLI flags — they default to unset (`None`), so the WDL task must explicitly pass them. No docker version bump needed.
- This PR ports the trim wiring into `demux_fastqs`, exposing all 6 trim knobs the CLI now accepts (`illumina_demux` only wires 4). The 4 shared knobs default to `illumina_demux`'s exact values (10/18/18/18, always emitted); the 2 extra knobs (`--predemux_trim_r1_5prime`, `--trim_r2_left_of_barcode`) default to unset/not emitted, matching `illumina_demux`'s current behavior while making them overridable.
- Task-level defaults only (no new workflow-level inputs) — matches the existing repo pattern, since `illumina_demux`'s knobs are also task-level only.

## Test plan
- [x] `miniwdl check` on both caller workflows (`load_illumina_fastqs.wdl`, `load_illumina_fastqs_deplete.wdl`) — passes with only pre-existing `StringCoercion` deprecation warnings (same class already emitted by `illumina_demux`'s identical `~{'--flag ' + value}` idiom).
- [x] Ran `miniwdl run pipes/WDL/workflows/load_illumina_fastqs.wdl` against the existing `test_inputs-load_illumina_fastqs-local.json` fixture end-to-end (docker-based) — workflow completes successfully, `read_counts_raw` output matches the existing `test_outputs-load_illumina_fastqs-local.json` fixture exactly (`[200, 150, 100, 0, 160]`), so no fixture update needed.
- [x] Verified the fix functionally: inspected read lengths in the output BAMs. 3-barcode (splitcode) samples trim from 50bp raw down to 14bp, exactly matching the default trim math (R1: 50 minus 18 predemux-3' minus 8bp barcode minus 10 right-of-barcode; R2: 50 minus 18 predemux-5' minus 18 predemux-3'). The 2-barcode direct-conversion sample (no splitcode) stays untrimmed at 50bp, correctly mirroring illumina_demux's scoping of trimming to the splitcode pathway only.
- [ ] womtool validation not run locally (no local JRE) — will be covered by CI's validate_wdl_womtool job.
- [ ] Terra method config re-sync and production read-length checkpoint verification (via the gdrive swift-techdev-trim-checkpoint script) are operator-driven, post-merge steps — out of scope for this PR.
