### PR TITLE
Speed up DNAnexus workflow compilation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -314,7 +314,7 @@ jobs:
   deploy_dnanexus:
     #if: ${{ github.event.ref == 'dnanexus' }}
     if: github.event_name == 'release' || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/dnanexus' || (github.event_name == 'pull_request' && github.base_ref == 'master')
-    timeout-minutes: 60  # Prevent runaway jobs; dxCompiler can hang
+    timeout-minutes: 90  # Per-workflow timeout in build-dx.sh handles dxCompiler hangs
     # cancel earlier actions, if a commit is added to a branch or a PR
     concurrency:
       group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -328,6 +328,8 @@ jobs:
       # stored here: https://github.com/broadinstitute/viral-pipelines/settings/secrets/actions
       DX_API_TOKEN: ${{ secrets.DX_API_TOKEN }}
       DX_PROJECT: project-F8PQ6380xf5bK0Qk0YPjB17P
+      DX_COMPILER_PARALLELISM: 4
+      DX_COMPILER_TIMEOUT: 15m
     steps:
       - name: checkout repository
         uses: actions/checkout@v6

--- a/github_actions_ci/build-dx.sh
+++ b/github_actions_ci/build-dx.sh
@@ -16,6 +16,10 @@ dx select $DX_PROJECT
 
 # compile with dxCompiler
 COMPILE_SUCCESS="dxCompiler-compile_all-success.txt"
+DX_COMPILER_PARALLELISM="${DX_COMPILER_PARALLELISM:-4}"
+DX_COMPILER_TIMEOUT="${DX_COMPILER_TIMEOUT:-15m}"
+echo "dxCompiler executable creation parallelism: $DX_COMPILER_PARALLELISM"
+echo "dxCompiler per-workflow timeout: $DX_COMPILER_TIMEOUT"
 touch $COMPILE_SUCCESS
 for workflow in pipes/WDL/workflows/*.wdl; do
   if [ -n "$(grep DX_SKIP_WORKFLOW $workflow)" ]; then
@@ -26,25 +30,32 @@ for workflow in pipes/WDL/workflows/*.wdl; do
 
     defaults_json="pipes/dnax/dx-defaults-$workflow_name.json"
     if [ -f "$defaults_json" ]; then
-      CMD_DEFAULTS="-defaults $defaults_json"
+      CMD_DEFAULTS=(-defaults "$defaults_json")
     else
-      CMD_DEFAULTS=""
+      CMD_DEFAULTS=()
     fi
 
     extras_json="pipes/dnax/dx-extras.json"
-    CMD_DEFAULTS+=" -extras $extras_json"
+    CMD_DEFAULTS+=(-extras "$extras_json")
 
-	  dx_id=$(java -jar dxCompiler.jar compile \
-      $workflow $CMD_DEFAULTS -f -verbose \
-      -leaveWorkflowsOpen \
-      -imports pipes/WDL/tasks/ \
-      -project $DX_PROJECT \
-      -destination /build/$VERSION/$workflow_name)
-    if [ $? -eq 0 ]; then
-        echo "Succeeded: $workflow_name = $dx_id"
+    compile_start=$SECONDS
+    if dx_id=$(timeout --signal=TERM --kill-after=30s "$DX_COMPILER_TIMEOUT" \
+      java -jar dxCompiler.jar compile \
+        "$workflow" "${CMD_DEFAULTS[@]}" -f \
+        -executableCreationParallelism "$DX_COMPILER_PARALLELISM" \
+        -leaveWorkflowsOpen \
+        -imports pipes/WDL/tasks/ \
+        -project "$DX_PROJECT" \
+        -destination "/build/$VERSION/$workflow_name"); then
+        echo "Succeeded in $((SECONDS - compile_start))s: $workflow_name = $dx_id"
     else
-        echo "Failed to build: $workflow_name"
-        exit $?
+        compile_status=$?
+        if [ "$compile_status" -eq 124 ]; then
+          echo "Timed out after $((SECONDS - compile_start))s building: $workflow_name"
+        else
+          echo "Failed after $((SECONDS - compile_start))s building: $workflow_name (exit $compile_status)"
+        fi
+        exit "$compile_status"
     fi
     echo -e "$workflow_name\t$dx_id" >> $COMPILE_SUCCESS
   fi


### PR DESCRIPTION
## Summary

- let dxCompiler create up to four mutually independent executables in parallel while retaining the serial outer workflow loop
- replace verbose compiler output with per-workflow elapsed times and a configurable 15-minute timeout
- increase the overall job guardrail from 60 to 90 minutes now that individual compiler hangs are bounded

## Rationale

The latest deploy run reached 64 of 71 workflows before the 60-minute job timeout, while identical workflows have shown large DNAnexus latency variation across runs. dxCompiler 2.15.0 already supports dependency-aware executable creation parallelism, so this reduces platform wait time without introducing concurrent success-manifest writes or project-wide executable reuse.

## CI benchmark

The credentialed PR build completed successfully in 14m02s. All 71 workflows compiled in 794 seconds total, with a 10-second median, 16-second p90, and 21-second maximum per workflow.

## Testing

- `bash -n github_actions_ci/build-dx.sh`
- parsed `.github/workflows/build.yml` with Ruby YAML
- `git diff --check`
- ShellCheck error-level analysis via the stable Docker image
- verified GNU `timeout` status 124 handling in Ubuntu 24.04
- credentialed `deploy_dnanexus` CI build completed successfully